### PR TITLE
Api documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 
+    // Swagger - https://springfox.github.io/springfox/docs/current/
     implementation "io.springfox:springfox-boot-starter:3.0.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,5 +79,7 @@ dependencies {
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
+
+    implementation "io.springfox:springfox-boot-starter:3.0.0"
 }
 


### PR DESCRIPTION
In modern REST API web services it is paramount to have up-to-date and detailed specification for all the endpoints available in the application.

This commit introduces a new dependency in build.gradle, to the Springfox Boot Starter 3.0.0. The implementation of the OpenAPI v3.0 specifications by Springfox, documents all the endpoint automatically using Java Reflection. The classes annotated with @RestController are scanned and every endpoint is introspected to create documentation about argument passed to this endpoint, expected result, exceptions, HTTP verb, json (or xml) input/output structure and it's possible to test each endpoint from the UI provided, so no need to use Postman.

The documentation is available at the address http://server_address:port/swagger-ui/index.html

Future work and improvements on this issue could be:
- API versioning at the control level
- Create a SwaggerConf class to separate the documentation for each version
- Optional: annotations for required fields or more information about model classes

close #184 