### PR TITLE
Add payload descriptions for SQL injections and mark specific levels as secure

### DIFF
--- a/src/main/java/org/sasanlabs/internal/utility/annotations/AttackVector.java
+++ b/src/main/java/org/sasanlabs/internal/utility/annotations/AttackVector.java
@@ -31,7 +31,7 @@ public @interface AttackVector {
      *
      * @return Key that Identifies Curl request
      */
-    String curlPayload() default "NOT_APPLICABLE";
+    String payload() default "NOT_APPLICABLE";
 
     /**
      * Should be a Label Key

--- a/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
+++ b/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
@@ -94,7 +94,7 @@ public class EndPointsInformationProvider implements IEndPointsInformationProvid
                                                                     attackVector
                                                                             .vulnerabilityExposed())),
                                                     vulnerableAppProperties.getAttackVectorProperty(
-                                                            attackVector.curlPayload()),
+                                                            attackVector.payload()),
                                                     messageBundle.getString(
                                                             attackVector.description(), null)));
                         }

--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -398,7 +398,7 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_NONE_ALGORITHM_JWT_VULNERABILITY",
-            curlPayload = "NONE_ALGORITHM_ATTACK_CURL_PAYLOAD")
+            payload = "NONE_ALGORITHM_ATTACK_CURL_PAYLOAD")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             descriptionLabel = "COOKIE_CONTAINING_JWT_TOKEN",

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -2,6 +2,7 @@ package org.sasanlabs.service.vulnerability.sqlInjection;
 
 import java.util.Map;
 import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
@@ -41,7 +42,8 @@ public class BlindSQLInjectionVulnerability {
 
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.BLIND_SQL_INJECTION,
-            description = "BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY")
+            description = "BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
+            payload = "BLIND_SQL_INJECTION_PAYLOAD_LEVEL_1")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -66,7 +68,8 @@ public class BlindSQLInjectionVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.BLIND_SQL_INJECTION,
             description =
-                    "BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY")
+                    "BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "BLIND_SQL_INJECTION_PAYLOAD_LEVEL_2")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -91,6 +94,7 @@ public class BlindSQLInjectionVulnerability {
 
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
+            variant = Variant.SECURE,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
             htmlTemplate = "LEVEL_1/SQLInjection_Level1",
             parameterName = Constants.ID,

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sasanlabs.internal.utility.JSONSerializationUtils;
 import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
@@ -51,7 +52,8 @@ public class ErrorBasedSQLInjectionVulnerability {
 
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.ERROR_BASED_SQL_INJECTION,
-            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY")
+            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -98,7 +100,8 @@ public class ErrorBasedSQLInjectionVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.ERROR_BASED_SQL_INJECTION,
             description =
-                    "ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY")
+                    "ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -146,7 +149,8 @@ public class ErrorBasedSQLInjectionVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.ERROR_BASED_SQL_INJECTION,
             description =
-                    "ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY")
+                    "ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_3")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -198,7 +202,8 @@ public class ErrorBasedSQLInjectionVulnerability {
     // need to use the parameterized query properly.
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.ERROR_BASED_SQL_INJECTION,
-            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY")
+            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_4")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -250,6 +255,7 @@ public class ErrorBasedSQLInjectionVulnerability {
 
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
+            variant = Variant.SECURE,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
             htmlTemplate = "LEVEL_1/SQLInjection_Level1",
             parameterName = Constants.ID,

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -2,6 +2,7 @@ package org.sasanlabs.service.vulnerability.sqlInjection;
 
 import java.util.Map;
 import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
@@ -36,7 +37,8 @@ public class UnionBasedSQLInjectionVulnerability {
 
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.UNION_BASED_SQL_INJECTION,
-            description = "UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY")
+            description = "UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
+            payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -62,7 +64,8 @@ public class UnionBasedSQLInjectionVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilitySubType.UNION_BASED_SQL_INJECTION,
             description =
-                    "UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY")
+                    "UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
@@ -91,6 +94,7 @@ public class UnionBasedSQLInjectionVulnerability {
                     "UNION_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
+            variant = Variant.SECURE,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
             htmlTemplate = "LEVEL_1/SQLInjection_Level1",
             parameterName = Constants.ID,
@@ -113,6 +117,7 @@ public class UnionBasedSQLInjectionVulnerability {
 
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
+            variant = Variant.SECURE,
             descriptionLabel = "URL_CONTAINING_CAR_ID_PARAMETER",
             htmlTemplate = "LEVEL_1/SQLInjection_Level1",
             parameterName = Constants.ID,

--- a/src/main/resources/attackvectors/BlindSQLInjectionVulnerabilityPayload.properties
+++ b/src/main/resources/attackvectors/BlindSQLInjectionVulnerabilityPayload.properties
@@ -1,0 +1,27 @@
+BLIND_SQL_INJECTION_PAYLOAD_LEVEL_1=It allows a hacker to check if the web application is vulnerable to SQL injection. It does not show any errors. The hacker will try to inject true and false statements.<br/>\
+  How to exploit this level?<br/>\
+  Import those in textbox<br/>\
+  For true statement<br/>\
+  1 OR 2=2<br/>\
+  Expected result<br/>\
+  { "isCarPresent": true }<br/>\
+  For false statement<br/>\
+  1 AND 1=2<br/>\
+  Expected result<br/>\
+  { "isCarPresent": false }
+BLIND_SQL_INJECTION_PAYLOAD_LEVEL_2=It allows a hacker to check if the web application is vulnerable to SQL injection. It does not show any errors. The hacker will try to inject true and false statements.<br/>\
+  How to exploit this level?<br/>\
+  Previous queries<br/>\
+  1 OR 2=2<br/>\
+  1 AND 1=2<br/>\
+  return<br/>\
+  System Error Occurred. please check logs.<br/>\
+  So now we have to import those in textbox<br/>\
+  For true statement<br/>\
+  1 OR 2=2<br/>\
+  Expected result<br/>\
+  { "isCarPresent": true }<br/>\
+  For false statement<br/>\
+  1 AND 1=2<br/>\
+  Expected result<br/>\
+  { "isCarPresent": false }

--- a/src/main/resources/attackvectors/ErrorBasedSQLInjectionPayload.properties
+++ b/src/main/resources/attackvectors/ErrorBasedSQLInjectionPayload.properties
@@ -1,0 +1,16 @@
+ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1=Error based SQL injection is a technique where an attacker tries to insert a malicious query into the input fields and receives a SQL or database syntax error.<br/>\
+ How to exploit this level?<br/>\
+ Import this in textbox<br/>\
+ #
+ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2=Error based SQL injection is a technique where an attacker tries to insert a malicious query into the input fields and receives a SQL or database syntax error.<br/>\
+ How to exploit this level?<br/>\
+ Import this in textbox<br/>\
+ #
+ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_3=Error based SQL injection is a technique where an attacker tries to insert a malicious query into the input fields and receives a SQL or database syntax error.<br/>\
+ How to exploit this level?<br/>\
+ Import this in textbox<br/>\
+ #
+ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_4=Error based SQL injection is a technique where an attacker tries to insert a malicious query into the input fields and receives a SQL or database syntax error.<br/>\
+ How to exploit this level?<br/>\
+ Import this in textbox<br/>\
+ #

--- a/src/main/resources/attackvectors/UnionBasedSQLInjectionVulnerabilityPayload.properties
+++ b/src/main/resources/attackvectors/UnionBasedSQLInjectionVulnerabilityPayload.properties
@@ -1,0 +1,7 @@
+UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1=Union based SQL injection allows gaining information about users or other internal information from the databases. If this is in the application then we can compromise the database. An example for this is:<br/>\
+5 UNION SELECT * FROM users WHERE id=1<br/>\
+If you import this in the textbox, you will get information about a user from the table.
+
+UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2=Union based SQL injection allows gaining information about users or other internal information from the databases. If this is in the application then we can compromise the database. An example for this is:<br/>\
+5' UNION SELECT * FROM users WHERE id='1<br/>\
+If you import this in the textbox, you will get information about a user from the table.


### PR DESCRIPTION
This pull request closes #270 (first part). I marked secured levels and added payload descriptions for SQL injection vulnerabilities. What is more, I changed `curlPayload` attribute to the just `payload` in `@AttackVector` annotation.
Here is how it looks like:

![Union](https://user-images.githubusercontent.com/56774329/118402357-eaad9d80-b669-11eb-8efd-176b067b9b0b.png)
![Error](https://user-images.githubusercontent.com/56774329/118402358-eb463400-b669-11eb-8603-e9f707ea76d5.png)
![Blind](https://user-images.githubusercontent.com/56774329/118402361-ec776100-b669-11eb-8fa5-07099f7700de.png)


