### PR TITLE
Add payload description for unrestricted file upload vulnerability and mark secure levels

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sasanlabs.internal.utility.FrameworkConstants;
 import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
@@ -158,7 +159,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.REFLECTED_XSS,
                 VulnerabilitySubType.PATH_TRAVERSAL
             },
-            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME")
+            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_1")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -180,7 +182,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.PERSISTENT_XSS,
                 VulnerabilitySubType.REFLECTED_XSS
             },
-            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME")
+            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_2")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -202,7 +205,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.PERSISTENT_XSS,
                 VulnerabilitySubType.REFLECTED_XSS
             },
-            description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_FILE_EXTENSION")
+            description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_FILE_EXTENSION",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_3")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -230,7 +234,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.PERSISTENT_XSS,
                 VulnerabilitySubType.REFLECTED_XSS
             },
-            description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION")
+            description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_4")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -259,7 +264,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.REFLECTED_XSS
             },
             description =
-                    "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION_CASE_INSENSITIVE")
+                    "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION_CASE_INSENSITIVE",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_5")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -292,7 +298,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.REFLECTED_XSS
             },
             description =
-                    "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIVE")
+                    "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIVE",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_6")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -324,7 +331,8 @@ public class UnrestrictedFileUpload {
                 VulnerabilitySubType.REFLECTED_XSS
             },
             description =
-                    "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE")
+                    "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_7")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_7,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -354,7 +362,8 @@ public class UnrestrictedFileUpload {
 
     @AttackVector(
             vulnerabilityExposed = {VulnerabilitySubType.PATH_TRAVERSAL},
-            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME")
+            description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
+            payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_8")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
@@ -380,6 +389,7 @@ public class UnrestrictedFileUpload {
                     "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,
+            variant = Variant.SECURE,
             descriptionLabel = "UNRESTRICTED_FILE_UPLOADED_POST_CALL",
             htmlTemplate = "LEVEL_1/FileUpload",
             parameterName = REQUEST_PARAMETER,

--- a/src/main/resources/attackvectors/BlindSQLInjectionVulnerabilityPayload.properties
+++ b/src/main/resources/attackvectors/BlindSQLInjectionVulnerabilityPayload.properties
@@ -7,7 +7,7 @@ BLIND_SQL_INJECTION_PAYLOAD_LEVEL_1=As Blind SQL Injection doesn't show any inte
  Similarly if you check for <code>carid</code> as <code>1</code>, you will find that it is present in the database but, what if we insert <code>carid </code> as <code>1 AND 1=2</code>, it will be evaluated to <code>false</code>. Let's check by inserting following statement in the textbox:<br/>\
   <code>1 AND 1=2</code><br/>\
   Expected result:<br/>\
-  <code>{ "isCarPresent": false }</code><br/>\
+  <code>{ "isCarPresent": false }</code><br/>
 BLIND_SQL_INJECTION_PAYLOAD_LEVEL_2=As Blind SQL Injection doesn't show any internal details like errors or table data. However, it does allow asking a set of questions to the database which results in <b>true</b> or <b>false</b> based on the data present in the database. Similarly, hackers use the same technique to retrieve entire data from the database.<br/>\
  <b>How to exploit this level?</b><br/>\
  Following inputs <code>1 OR 2=2</code> and <code>1 AND 1=2</code> returns <code>System Error Occurred. please check logs</code>. It doesn't evaluate to <code>true</code> or <code>false</code><br/>\

--- a/src/main/resources/attackvectors/UnrestrictedFileUploadPayload.properties
+++ b/src/main/resources/attackvectors/UnrestrictedFileUploadPayload.properties
@@ -1,0 +1,38 @@
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_1=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Create a file with extension .html, and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+Now if we upload this file and access it, the file should get executed in the browser. This level is also vulnerable to Path Traversal Vulnerability, if we choose a filename similar to <code>../index.html</code> then the file gets uploaded in another directory than the expected one.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_2=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Create a file with extension .html, and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+  Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_3=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Filename validation is added, so now to exploit this level you have to create a file with extension .htm, and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+  Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_4=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Filename validation is improved, so now to exploit this level you have to a create a file with extension .HTML, and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+  Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_5=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Filename validation is improved in this level where case insensitive validation checks are added, so now to exploit this level you have to create a file with extension .xhtml, and paste the following code: <br/>\
+  <code>&lt;a:script xmlns:a="http://www.w3.org/1999/xhtml"&gt;alert(navigator.userAgent)&lt;/a:script&gt;</code><br/>\
+  Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_6=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Filename validation is improved in this level where only files containing .jpeg and .png extension are accepted, so now to exploit this level you have to a create a file with extension .jpeg.html,and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+  Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_7=Hackers can execute code in a user's machine by uploading a file in the proper format to the server and trick the user into accessing it. Generally, users run personal machines with administrator privileges and disabled browser security policies which make attack execution easier. A persistent XSS attack is a similar type of attack that causes cookie and sensitive data thefts.<br/>\
+<b>How to exploit this level?</b><br/>\
+  Filename validation is improved in this level where only files with .jpeg and .png extension are accepted, so now to exploit this level we have to create a file with extension like .html.jpeg, and insert a null byte character like '\0' or '%00' before .jpeg or .png and paste the following code: <br/>\
+  <code>&lt;html&gt;&lt;script&gt;alert(navigator.userAgent);&lt;/script&gt;&lt;/html&gt;</code><br/>\
+  The extension after the null byte is ignored and the file will be treated as .html. Now if we upload this file and access it, the file should get executed in the browser.
+UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_8=A path traversal attack aims to overwrite files and directories that are stored outside the web root folder. By manipulating variables that reference files with "dot-dot-slash (../)" sequences and its variations or by using absolute file paths, it may be possible to change arbitrary files and directories stored on file system including application source code or configuration and critical system files.<br/>\
+<b>How to exploit this level?</b><br/>\
+  This level is vulnerable for path traversal, so if you choose a filename like <code>../index.html</code> then the file will be stored in another directory than provided.


### PR DESCRIPTION
This pull request closes #270. I added payload descriptions for unrestricted file upload vulnerability. Due to the upcoming deadline, I am adding the first five levels at the moment. I will add the rest as soon as possible later.
Here is how it looks like:
![UFU](https://user-images.githubusercontent.com/56774329/119232078-204bfe00-bb24-11eb-99a6-5b8c7dc0c81a.png)
