### PR TITLE
Spring boot upgrade to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.0.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.6.4")
     }
 }
 


### PR DESCRIPTION
The spring version `2.2.0.RELEASE` has `6 vulnerabilities` (including log4j2). So, updating to latest version would resolve it.

https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-log4j2/2.2.0.RELEASE

**Latest version:-**

https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-log4j2/2.6.4