### PR TITLE
Nimbus jose jwt library upgrade due to vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20190722'
 
 	//https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.3'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.12'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'


### PR DESCRIPTION
- Nimbus jose jwt library upgrade due to vulnerabilities

https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt/8.3

https://github.com/advisories/GHSA-g5vf-v6wf-7w2r
https://github.com/advisories/GHSA-269g-pwp5-87pp