### PR TITLE
Feature/382 fix

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,48 @@
+# This workflow automates release creation and builds and deploys to DockerHub
+name: Automates release gets latest tag, creates release, builds and push to DockerHub with latest tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: 'Optional notes for the release'
+        required: false
+        type: string
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout new changes 
+        uses: actions/checkout@v2
+        with: 
+          java-version: 1.8
+          fetch-depth: 0
+      -
+        name: Get the latest tag in repository
+        id: TAG
+        run: |
+          echo "::set-output name=LATEST_VERSION::$(git tag | sort -Vr | head -n 1)"
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with: 
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      -
+        name: Publish release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          name: 'VulnerableApp-${{ steps.TAG.outputs.LATEST_VERSION }}'
+          tag_name: '${{ steps.TAG.outputs.LATEST_VERSION }}'
+          body: '${{ inputs.release_notes }}'
+      -
+        name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      -
+        name: Build and push image to Docker using JIB
+        run: |
+            ./gradlew jib \
+            -Djib.to.image=sasanlabs/owasp-vulnerableapp:latest \
+            -Djib.to.tags=${{ steps.TAG.outputs.LATEST_VERSION }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,5 @@
 # This workflow automates release creation and builds and deploys to DockerHub
-name: Automates release gets latest tag, creates release, builds and push to DockerHub with latest tag
+name: Release project
 
 on:
   workflow_dispatch:
@@ -44,5 +44,4 @@ jobs:
         name: Build and push image to Docker using JIB
         run: |
             ./gradlew jib \
-            -Djib.to.image=sasanlabs/owasp-vulnerableapp:latest \
             -Djib.to.tags=${{ steps.TAG.outputs.LATEST_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Gradle, create repository tag, and push a new docker image to docker hub
-name: Create Tag, Build and Push Unreleased Image to DockerHub
+name: Create Tag and Push Image to DockerHub
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
       -
-        name: Create tag for repo
+        name: Create tag for GitHub
         uses: tvdias/github-tagger@v0.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -43,4 +43,4 @@ jobs:
         name: Build with Gradle and Push
         run: |
           ./gradlew jib \
-          -Djib.to.tags='latest',$GITVERSION_SEMVER
+          -Djib.to.tags='unreleased',$GITVERSION_SEMVER

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
         name: Publish release on GitHub
         uses: softprops/action-gh-release@v1
         with:
+          name: 'VulnerableApp-${{ steps.gitversion.outputs.semver }}'
           tag_name: '${{ steps.gitversion.outputs.semver }}'
       -
         name: Grant execute permission for gradlew

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 1.8
           fetch-depth: 0
       -
-        name: Setup Gitveresion action
+        name: Setup GitVersion action
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
           versionSpec: '5.x'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,11 +31,11 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
       -
-        name: Publish release on GitHub
-        uses: softprops/action-gh-release@v1
+        name: Create tag for repo
+        uses: tvdias/github-tagger@v0.0.1
         with:
-          name: 'VulnerableApp-${{ steps.gitversion.outputs.semver }}'
-          tag_name: '${{ steps.gitversion.outputs.semver }}'
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: '${{ steps.gitversion.outputs.semver }}'
       -
         name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,26 @@ jobs:
         uses: actions/checkout@v2
         with:
           java-version: 1.8
+          fetch-depth: 0
+      -
+        name: Setup Gitveresion action
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+      -
+        name: Execute GitVersion action
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.7
+      -
+        name: Publish release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: '${{ steps.gitversion.outputs.semver }}'
       -
         name: Grant execute permission for gradlew
         run: chmod +x gradlew
       -
         name: Build with Gradle and Push
-        run: ./gradlew jib
+        run: |
+          ./gradlew jib \
+          -Djib.to.tags='latest',$GITVERSION_SEMVER

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
-# This workflow will build a Java project with Gradle and push a new docker image to docker hub
-name: Build and Push Image to DockerHub
+# This workflow will build a Java project with Gradle, create repository tag, and push a new docker image to docker hub
+name: Create Tag, Build and Push Unreleased Image to DockerHub
 
 on:
   push:
@@ -43,4 +43,5 @@ jobs:
         name: Build with Gradle and Push
         run: |
           ./gradlew jib \
-          -Djib.to.tags='unreleased',$GITVERSION_SEMVER
+          -Djib.to.image=sasanlabs/owasp-vulnerableapp:unreleased \
+          -Djib.to.tags=$GITVERSION_SEMVER

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git commit -m "+semver:patch some text"
 ```
 By default, if the version is not provided in the commit message, then patch is incremented.
 
-The updated version is used to create a tag for the latest published release on GitHub and DockerHub.
+The updated version is used to create a tag on GitHub and the most recent build on DockerHub.
 
 <em>Which version should be incremented?</em>
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,33 @@ There are multiple ways in which you can contribute to the project:
 1. If you are a developer and trying to start on to the project, then the suggestion is to go through the list of [issues](https://github.com/SasanLabs/VulnerableApp/issues) which contains `good first issue` which can be a good starter.
 2. If you are a developer or a security professional looking to add new Vulnerability type then you can Generate the Sample Vulnerability by running `./gradlew GenerateSampleVulnerability`. It will generate the Sample Vulnerability template which has placeholders and comments. Modified files can be seen in the logs of the command or in the github history. You can navigate to those files, fill in the placeholders and then build the project to see the effect of the changes.
 3. In case you are looking to contribute to the project by publicising it or working on the growth of the project, please feel free to add your thoughts to discussions section or issues and we can discuss over them.
+### Semantic Versioning ###
+Leveraging GitHub workflow and actions, semantic versioning is automated.
+When committing your feature, you have the option to increment the version's major, minor, or patch value
+by including <code>+semver:[major|minor|patch]</code> in your commit message. Major, minor, patch values are the
+strings 'major', 'minor', and 'patch'.
+
+Examples:
+```properties
+git commit -m "some text +semver:major"
+git commit -m "+semver:minor some text"
+git commit -m "+semver:patch some text"
+```
+By default, if the version is not provided in the commit message, then patch is incremented.
+
+The updated version is used to create a tag for the latest published release on GitHub and DockerHub.
+
+<em>Which version should be incremented?</em>
+
+<table>
+<thead><td>Version</td><td>Description</td></thead>
+<tr><td>Major</td><td>Changes that break backwards compatibility</td></tr>
+<tr><td>Minor</td><td>New features that are backwards compatible</td></tr>
+<tr><td>Patch</td><td>Bug fixes that are backwards compatible</td></tr>
+</table>
+More information can be found at <a href="https://semver.org/" alt="semantic versioning specification">Semantic 
+Versioning 
+Specifiction</a>.
 
 ## Building the project
 There are 2 ways in which this project can be built and used:

--- a/README.md
+++ b/README.md
@@ -40,33 +40,6 @@ There are multiple ways in which you can contribute to the project:
 1. If you are a developer and trying to start on to the project, then the suggestion is to go through the list of [issues](https://github.com/SasanLabs/VulnerableApp/issues) which contains `good first issue` which can be a good starter.
 2. If you are a developer or a security professional looking to add new Vulnerability type then you can Generate the Sample Vulnerability by running `./gradlew GenerateSampleVulnerability`. It will generate the Sample Vulnerability template which has placeholders and comments. Modified files can be seen in the logs of the command or in the github history. You can navigate to those files, fill in the placeholders and then build the project to see the effect of the changes.
 3. In case you are looking to contribute to the project by publicising it or working on the growth of the project, please feel free to add your thoughts to discussions section or issues and we can discuss over them.
-### Semantic Versioning ###
-Leveraging GitHub workflow and actions, semantic versioning is automated.
-When committing your feature, you have the option to increment the version's major, minor, or patch value
-by including <code>+semver:[major|minor|patch]</code> in your commit message. Major, minor, patch values are the
-strings 'major', 'minor', and 'patch'.
-
-Examples:
-```properties
-git commit -m "some text +semver:major"
-git commit -m "+semver:minor some text"
-git commit -m "+semver:patch some text"
-```
-By default, if the version is not provided in the commit message, then patch is incremented.
-
-The updated version is used to create a tag on GitHub and the most recent build on DockerHub.
-
-<em>Which version should be incremented?</em>
-
-<table>
-<thead><td>Version</td><td>Description</td></thead>
-<tr><td>Major</td><td>Changes that break backwards compatibility</td></tr>
-<tr><td>Minor</td><td>New features that are backwards compatible</td></tr>
-<tr><td>Patch</td><td>Bug fixes that are backwards compatible</td></tr>
-</table>
-More information can be found at <a href="https://semver.org/" alt="semantic versioning specification">Semantic 
-Versioning 
-Specifiction</a>.
 
 ## Running the project
 There are 2 ways to run the project:

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,6 @@ jib {
 	from {
     	  image = 'openjdk:8-jre-alpine'
   	}
-  	to {
-    	  image = 'sasanlabs/owasp-vulnerableapp'
-  	}
 }
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ jib {
     	  image = 'openjdk:8-jre-alpine'
   	}
   	to {
-    	  image = 'sasanlabs/owasp-vulnerableapp:unreleased'
+    	  image = 'sasanlabs/owasp-vulnerableapp'
   	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ jib {
 	from {
     	  image = 'openjdk:8-jre-alpine'
   	}
+    to {
+        image = 'sasanlabs/owasp-vulnerableapp'
+    }
 }
 
 jacoco {

--- a/docs/ReleaseVulnerableApp.md
+++ b/docs/ReleaseVulnerableApp.md
@@ -29,8 +29,7 @@ there is an option to provide release notes.
 
 To initialize the workflow, from the repository:
 1. Select the 'Actions' tab.
-2. Under 'Workflows' select 'Automates release gets latest tag, creates release, builds and push to DockerHub with 
-latest tag'.
+2. Under 'Workflows' select 'Release project' workflow.
 3. Select 'Run Workflow' where it says 'This workflow has a workflow_dispatch event trigger'.
 4. Then select 'run workflow' again (can include optional release notes).
 

--- a/docs/ReleaseVulnerableApp.md
+++ b/docs/ReleaseVulnerableApp.md
@@ -1,7 +1,9 @@
 # Releasing VulnerableApp #
 
-VulnerableApp is Leveraging GitHub workflow and actions for creating new releases automatically.
-When committing the feature, we have the option to increment the version's to major, minor, or patch value
+VulnerableApp is leveraging multiple GitHub workflows and actions for creating new releases automatically.
+The first workflow automates semantic versioning, repository tag creation, building and deploying as unreleased to 
+DockerHub.
+When committing a feature, we have the option to increment the version's major, minor, or patch value
 by including <code>+semver:[major|minor|patch]</code> in the commit message. Major, minor, patch values are the
 strings 'major', 'minor', and 'patch'.
 
@@ -17,8 +19,18 @@ Examples of version change considering the current version is 1.10.0:
 2. For minor release, the newer version will be 1.11.0
 3. for major release, the newer version will be 2.0.0
 
-The github action will create a tag for the latest published release on GitHub and DockerHub.
+More information can be found at [Semantic
+   Versioning
+   Specifiction](https://semver.org/)
 
-More information can be found at [Semantic 
-Versioning 
-Specifiction](https://semver.org/)
+The second workflow automates release creation. Using <code>workflow_dispatch</code>, this will get the latest 
+repository tag, create a GitHub release, build and deploy as latest to DockerHub. When initializing this workflow, 
+there is an option to provide release notes. 
+
+To initialize the workflow, from the repository:
+1. Select the 'Actions' tab.
+2. Under 'Workflows' select 'Automates release gets latest tag, creates release, builds and push to DockerHub with 
+latest tag'.
+3. Select 'Run Workflow' where it says 'This workflow has a workflow_dispatch event trigger'.
+4. Then select 'run workflow' again (can include optional release notes).
+


### PR DESCRIPTION
Workflow does not auto-create a new release, it only creates a new tag.
Changed 'latest' to 'unreleased' in workflow for Docker tag for most recent build/deploy to better align with manual release creation on GitHub.