### PR TITLE
Mocked network calls made in SSRFVulnerabilityTest.

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -68,17 +68,21 @@ public class SSRFVulnerability {
                                 MetaDataServiceMock.getResponse(u), true),
                         HttpStatus.OK);
             } else {
-                URLConnection urlConnection = u.openConnection();
-                try (BufferedReader reader =
-                        new BufferedReader(new InputStreamReader(urlConnection.getInputStream()))) {
-                    return new ResponseEntity<>(
-                            new GenericVulnerabilityResponseBean<>(
-                                    reader.lines().collect(Collectors.joining()), true),
-                            HttpStatus.OK);
-                }
+                return new ResponseEntity<>(
+                    new GenericVulnerabilityResponseBean<>(
+                            getResponseForURLConnection(u), true),
+                    HttpStatus.OK);
             }
         } else {
             return invalidUrlResponse();
+        }
+    }
+
+    String getResponseForURLConnection(URL u) throws IOException {
+        URLConnection urlConnection = u.openConnection();
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(urlConnection.getInputStream()))) {
+            return reader.lines().collect(Collectors.joining());
         }
     }
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -69,9 +69,9 @@ public class SSRFVulnerability {
                         HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(
-                    new GenericVulnerabilityResponseBean<>(
-                            getResponseForURLConnection(u), true),
-                    HttpStatus.OK);
+                        new GenericVulnerabilityResponseBean<>(
+                                getResponseForURLConnection(u), true),
+                        HttpStatus.OK);
             }
         } else {
             return invalidUrlResponse();

--- a/src/test/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerabilityTest.java
@@ -48,7 +48,9 @@ class SSRFVulnerabilityTest {
         SSRFVulnerability ssrfSpy = spy(new SSRFVulnerability(GIST_ID));
         // mocks network calls
         doReturn(GIST_URL_CONTENT).when(ssrfSpy).getResponseForURLConnection(eq(new URL(GIST_URL)));
-        doReturn(OTHER_URL_CONTENT).when(ssrfSpy).getResponseForURLConnection(eq(new URL(OTHER_URL)));
+        doReturn(OTHER_URL_CONTENT)
+                .when(ssrfSpy)
+                .getResponseForURLConnection(eq(new URL(OTHER_URL)));
         ssrfVulnerability = ssrfSpy;
     }
 

--- a/src/test/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerabilityTest.java
@@ -3,13 +3,18 @@ package org.sasanlabs.service.vulnerability.ssrf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -36,7 +41,16 @@ class SSRFVulnerabilityTest {
 
     private static String tempFileUrl;
 
-    private final SSRFVulnerability ssrfVulnerability = new SSRFVulnerability(GIST_ID);
+    private SSRFVulnerability ssrfVulnerability;
+
+    @BeforeEach
+    void each() throws IOException {
+        SSRFVulnerability ssrfSpy = spy(new SSRFVulnerability(GIST_ID));
+        // mocks network calls
+        doReturn(GIST_URL_CONTENT).when(ssrfSpy).getResponseForURLConnection(eq(new URL(GIST_URL)));
+        doReturn(OTHER_URL_CONTENT).when(ssrfSpy).getResponseForURLConnection(eq(new URL(OTHER_URL)));
+        ssrfVulnerability = ssrfSpy;
+    }
 
     @BeforeAll
     static void setUp() throws IOException {


### PR DESCRIPTION
Re issue #445.

The fix simply mocks the two network requests that happen from the SSRFVulnerabilityTest test. I tried to keep the changes to a minimum, especially to the SSRFVulnerability class. Here I simply moved the network call out to a new getResponseForURLConnection() call, mostly unchanged. This is the method that is mocked from the test.

I ran into some strange Mockito spy behavior which forced the creation of the interim ssrfSpy variable.

Thanks!