### PR TITLE
#406 secured implementations for Union SQL Injection

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
@@ -15,7 +15,7 @@ public class CarInformation {
 
     private String name;
 
-    @Column(name = "IMAGE")
+    @Column(name = "image")
     private String imagePath;
 
     public CarInformation() {}
@@ -48,6 +48,10 @@ public class CarInformation {
     }
 
     public void setImagePath(String imagePath) {
+        this.imagePath = imagePath;
+    }
+
+    public void setImage(String imagePath) {
         this.imagePath = imagePath;
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
@@ -2,17 +2,17 @@ package org.sasanlabs.service.vulnerability.sqlInjection;
 
 import javax.persistence.*;
 
-
 /** @author preetkaran20@gmail.com KSASAN */
 @Access(AccessType.FIELD)
 @Entity
 @Table(name = "cars")
-@NamedQuery( name="findById", query = "select c from CarInformation c where c.id=:id")
+@NamedQuery(name = "findById", query = "select c from CarInformation c where c.id=:id")
 public class CarInformation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
+
     private String name;
 
     @Column(name = "IMAGE")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformation.java
@@ -1,9 +1,21 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
+import javax.persistence.*;
+
+
 /** @author preetkaran20@gmail.com KSASAN */
+@Access(AccessType.FIELD)
+@Entity
+@Table(name = "cars")
+@NamedQuery( name="findById", query = "select c from CarInformation c where c.id=:id")
 public class CarInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String name;
+
+    @Column(name = "IMAGE")
     private String imagePath;
 
     public CarInformation() {}

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformationRepository.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformationRepository.java
@@ -1,8 +1,7 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CarInformationRepository extends JpaRepository<CarInformation, Integer> {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformationRepository.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/CarInformationRepository.java
@@ -1,0 +1,10 @@
+package org.sasanlabs.service.vulnerability.sqlInjection;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CarInformationRepository extends JpaRepository<CarInformation, Integer> {
+
+    Optional<CarInformation> findById(Integer id);
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -18,6 +18,7 @@ import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -120,7 +121,9 @@ public class UnionBasedSQLInjectionVulnerability {
         SqlParameterSource namedParameters = new MapSqlParameterSource().addValue("id", id);
         CarInformation s =
                 namedParameterJdbcTemplate.queryForObject(
-                        "select * from cars where id=:id", namedParameters, CarInformation.class);
+                        "select * from cars where id=:id",
+                        namedParameters,
+                        new BeanPropertyRowMapper<>(CarInformation.class));
         return new ResponseEntity<>(s, HttpStatus.OK);
     }
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -41,14 +41,14 @@ public class UnionBasedSQLInjectionVulnerability {
     private final JdbcTemplate applicationJdbcTemplate;
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final CarInformationRepository carInformationRepository;
-    private final EntityManager em;
+    private final EntityManager entityManager;
 
     public UnionBasedSQLInjectionVulnerability(
-            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate, NamedParameterJdbcTemplate namedParameterJdbcTemplate, CarInformationRepository carInformationRepository, EntityManager em) {
+            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate, NamedParameterJdbcTemplate namedParameterJdbcTemplate, CarInformationRepository carInformationRepository, EntityManager entityManager) {
         this.applicationJdbcTemplate = applicationJdbcTemplate;
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
         this.carInformationRepository = carInformationRepository;
-        this.em = em;
+        this.entityManager = entityManager;
     }
 
     @AttackVector(
@@ -131,7 +131,7 @@ public class UnionBasedSQLInjectionVulnerability {
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
         String jql = "from CarInformation where id = :id";
-        TypedQuery<CarInformation> q = em.createQuery(jql, CarInformation.class)
+        TypedQuery<CarInformation> q = entityManager.createQuery(jql, CarInformation.class)
                 .setParameter("id", Integer.valueOf(id));
         return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
     }
@@ -144,13 +144,13 @@ public class UnionBasedSQLInjectionVulnerability {
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
 
-        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<CarInformation> cq = cb.createQuery(CarInformation.class);
         Root<CarInformation> root = cq.from(CarInformation.class);
 
         cq.select(root).where(cb.equal(root.get("id"), id));
 
-        TypedQuery<CarInformation> q = em.createQuery(cq);
+        TypedQuery<CarInformation> q = entityManager.createQuery(cq);
         return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
     }
 
@@ -161,7 +161,7 @@ public class UnionBasedSQLInjectionVulnerability {
     public ResponseEntity<CarInformation> getCarInformationLevel8(
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
-        TypedQuery<CarInformation> q = em.createNamedQuery("findById", CarInformation.class)
+        TypedQuery<CarInformation> q = entityManager.createNamedQuery("findById", CarInformation.class)
                 .setParameter("id", Integer.valueOf(id));
         return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
     }

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -4,7 +4,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
-
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
@@ -19,12 +23,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 
 /**
  * Union Based SQL Injection is another dangerous way to extract data from the database by combining
@@ -44,7 +42,10 @@ public class UnionBasedSQLInjectionVulnerability {
     private final EntityManager entityManager;
 
     public UnionBasedSQLInjectionVulnerability(
-            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate, NamedParameterJdbcTemplate namedParameterJdbcTemplate, CarInformationRepository carInformationRepository, EntityManager entityManager) {
+            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate,
+            NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+            CarInformationRepository carInformationRepository,
+            EntityManager entityManager) {
         this.applicationJdbcTemplate = applicationJdbcTemplate;
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
         this.carInformationRepository = carInformationRepository;
@@ -117,11 +118,11 @@ public class UnionBasedSQLInjectionVulnerability {
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
         SqlParameterSource namedParameters = new MapSqlParameterSource().addValue("id", id);
-        CarInformation s = namedParameterJdbcTemplate.queryForObject(
-                "select * from cars where id=:id", namedParameters, CarInformation.class);
+        CarInformation s =
+                namedParameterJdbcTemplate.queryForObject(
+                        "select * from cars where id=:id", namedParameters, CarInformation.class);
         return new ResponseEntity<>(s, HttpStatus.OK);
     }
-
 
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
@@ -131,8 +132,10 @@ public class UnionBasedSQLInjectionVulnerability {
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
         String jql = "from CarInformation where id = :id";
-        TypedQuery<CarInformation> q = entityManager.createQuery(jql, CarInformation.class)
-                .setParameter("id", Integer.valueOf(id));
+        TypedQuery<CarInformation> q =
+                entityManager
+                        .createQuery(jql, CarInformation.class)
+                        .setParameter("id", Integer.valueOf(id));
         return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
     }
 
@@ -161,8 +164,10 @@ public class UnionBasedSQLInjectionVulnerability {
     public ResponseEntity<CarInformation> getCarInformationLevel8(
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
-        TypedQuery<CarInformation> q = entityManager.createNamedQuery("findById", CarInformation.class)
-                .setParameter("id", Integer.valueOf(id));
+        TypedQuery<CarInformation> q =
+                entityManager
+                        .createNamedQuery("findById", CarInformation.class)
+                        .setParameter("id", Integer.valueOf(id));
         return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
     }
 
@@ -173,8 +178,11 @@ public class UnionBasedSQLInjectionVulnerability {
     public ResponseEntity<CarInformation> getCarInformationLevel9(
             @RequestParam final Map<String, String> queryParams) {
         final String id = queryParams.get("id");
-        Optional<CarInformation> carInformation = carInformationRepository.findById(Integer.valueOf(id));
-        return carInformation.map(information -> new ResponseEntity<>(information, HttpStatus.OK)).orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+        Optional<CarInformation> carInformation =
+                carInformationRepository.findById(Integer.valueOf(id));
+        return carInformation
+                .map(information -> new ResponseEntity<>(information, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
     private ResponseEntity<CarInformation> resultSetToResponse(final ResultSet rs)

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -3,6 +3,8 @@ package org.sasanlabs.service.vulnerability.sqlInjection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Optional;
+
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
@@ -13,7 +15,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 /**
  * Union Based SQL Injection is another dangerous way to extract data from the database by combining
@@ -28,10 +39,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class UnionBasedSQLInjectionVulnerability {
 
     private final JdbcTemplate applicationJdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final CarInformationRepository carInformationRepository;
+    private final EntityManager em;
 
     public UnionBasedSQLInjectionVulnerability(
-            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate) {
+            @Qualifier("applicationJdbcTemplate") final JdbcTemplate applicationJdbcTemplate, NamedParameterJdbcTemplate namedParameterJdbcTemplate, CarInformationRepository carInformationRepository, EntityManager em) {
         this.applicationJdbcTemplate = applicationJdbcTemplate;
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+        this.carInformationRepository = carInformationRepository;
+        this.em = em;
     }
 
     @AttackVector(
@@ -90,6 +107,74 @@ public class UnionBasedSQLInjectionVulnerability {
                 "select * from cars where id=?",
                 prepareStatement -> prepareStatement.setString(1, id),
                 this::resultSetToResponse);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_5,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<CarInformation> getCarInformationLevel5(
+            @RequestParam final Map<String, String> queryParams) {
+        final String id = queryParams.get("id");
+        SqlParameterSource namedParameters = new MapSqlParameterSource().addValue("id", id);
+        CarInformation s = namedParameterJdbcTemplate.queryForObject(
+                "select * from cars where id=:id", namedParameters, CarInformation.class);
+        return new ResponseEntity<>(s, HttpStatus.OK);
+    }
+
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_6,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<CarInformation> getCarInformationLevel6(
+            @RequestParam final Map<String, String> queryParams) {
+        final String id = queryParams.get("id");
+        String jql = "from CarInformation where id = :id";
+        TypedQuery<CarInformation> q = em.createQuery(jql, CarInformation.class)
+                .setParameter("id", Integer.valueOf(id));
+        return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_7,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<CarInformation> getCarInformationLevel7(
+            @RequestParam final Map<String, String> queryParams) {
+        final String id = queryParams.get("id");
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<CarInformation> cq = cb.createQuery(CarInformation.class);
+        Root<CarInformation> root = cq.from(CarInformation.class);
+
+        cq.select(root).where(cb.equal(root.get("id"), id));
+
+        TypedQuery<CarInformation> q = em.createQuery(cq);
+        return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_8,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<CarInformation> getCarInformationLevel8(
+            @RequestParam final Map<String, String> queryParams) {
+        final String id = queryParams.get("id");
+        TypedQuery<CarInformation> q = em.createNamedQuery("findById", CarInformation.class)
+                .setParameter("id", Integer.valueOf(id));
+        return new ResponseEntity<>(q.getSingleResult(), HttpStatus.OK);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_9,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<CarInformation> getCarInformationLevel9(
+            @RequestParam final Map<String, String> queryParams) {
+        final String id = queryParams.get("id");
+        Optional<CarInformation> carInformation = carInformationRepository.findById(Integer.valueOf(id));
+        return carInformation.map(information -> new ResponseEntity<>(information, HttpStatus.OK)).orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
     private ResponseEntity<CarInformation> resultSetToResponse(final ResultSet rs)

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
@@ -124,6 +126,11 @@ class UnionBasedSQLInjectionVulnerabilityTest {
                 .queryForObject(
                         eq("select * from cars where id=:id"),
                         argThat(argumentMatcher),
-                        eq(CarInformation.class));
+                        (RowMapper<Object>)
+                                argThat(
+                                        val ->
+                                                ((BeanPropertyRowMapper) val)
+                                                        .getMappedClass()
+                                                        .equals(CarInformation.class)));
     }
 }

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
@@ -36,7 +36,7 @@ class UnionBasedSQLInjectionVulnerabilityTest {
                         (PreparedStatementSetter) any(),
                         (ResultSetExtractor<? extends Object>) any());
 
-        unionBasedSQLInjectionVulnerability = new UnionBasedSQLInjectionVulnerability(template);
+        unionBasedSQLInjectionVulnerability = new UnionBasedSQLInjectionVulnerability(template, namedParameterJdbcTemplate);
     }
 
     @Test

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
@@ -17,8 +17,6 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import javax.persistence.EntityManager;
 
 class UnionBasedSQLInjectionVulnerabilityTest {
 
@@ -46,7 +44,12 @@ class UnionBasedSQLInjectionVulnerabilityTest {
                         (PreparedStatementSetter) any(),
                         (ResultSetExtractor<? extends Object>) any());
 
-        unionBasedSQLInjectionVulnerability = new UnionBasedSQLInjectionVulnerability(template, namedParameterJdbcTemplate, carInformationRepository, entityManager);
+        unionBasedSQLInjectionVulnerability =
+                new UnionBasedSQLInjectionVulnerability(
+                        template,
+                        namedParameterJdbcTemplate,
+                        carInformationRepository,
+                        entityManager);
     }
 
     @Test
@@ -114,7 +117,9 @@ class UnionBasedSQLInjectionVulnerabilityTest {
         final String id = "1' UNION SELECT * FROM cars; --";
         unionBasedSQLInjectionVulnerability.getCarInformationLevel5(params);
         // Assert
-        ArgumentMatcher<MapSqlParameterSource> argumentMatcher = sqlParameterSource -> Objects.requireNonNull(sqlParameterSource.getValue("id").equals(id));
+        ArgumentMatcher<MapSqlParameterSource> argumentMatcher =
+                sqlParameterSource ->
+                        Objects.requireNonNull(sqlParameterSource.getValue("id").equals(id));
         verify(namedParameterJdbcTemplate)
                 .queryForObject(
                         eq("select * from cars where id=:id"),

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerabilityTest.java
@@ -1,29 +1,39 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.persistence.EntityManager;
 
 class UnionBasedSQLInjectionVulnerabilityTest {
 
     private UnionBasedSQLInjectionVulnerability unionBasedSQLInjectionVulnerability;
     private JdbcTemplate template;
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private CarInformationRepository carInformationRepository;
+    private EntityManager entityManager;
 
     @BeforeEach
-    void setUp() throws IOException {
+    void setUp() {
         template = Mockito.mock(JdbcTemplate.class);
+        namedParameterJdbcTemplate = Mockito.mock(NamedParameterJdbcTemplate.class);
+        carInformationRepository = Mockito.mock(CarInformationRepository.class);
+        entityManager = Mockito.mock(EntityManager.class);
 
         // mock database
         doReturn(null)
@@ -36,11 +46,11 @@ class UnionBasedSQLInjectionVulnerabilityTest {
                         (PreparedStatementSetter) any(),
                         (ResultSetExtractor<? extends Object>) any());
 
-        unionBasedSQLInjectionVulnerability = new UnionBasedSQLInjectionVulnerability(template, namedParameterJdbcTemplate);
+        unionBasedSQLInjectionVulnerability = new UnionBasedSQLInjectionVulnerability(template, namedParameterJdbcTemplate, carInformationRepository, entityManager);
     }
 
     @Test
-    void getCarInformationLevel1_ExpectParamInjected() throws IOException {
+    void getCarInformationLevel1_ExpectParamInjected() {
         // Act
         final Map<String, String> params =
                 Collections.singletonMap("id", "1 UNION SELECT * FROM cars;");
@@ -54,7 +64,7 @@ class UnionBasedSQLInjectionVulnerabilityTest {
     }
 
     @Test
-    void getCarInformationLevel2_ExpectParamInjected() throws IOException {
+    void getCarInformationLevel2_ExpectParamInjected() {
         // Act
         final Map<String, String> params =
                 Collections.singletonMap("id", "1' UNION SELECT * FROM cars; --");
@@ -68,7 +78,7 @@ class UnionBasedSQLInjectionVulnerabilityTest {
     }
 
     @Test
-    void getCarInformationLevel3_ExpectParamEscaped() throws IOException {
+    void getCarInformationLevel3_ExpectParamEscaped() {
         // Act
         final Map<String, String> params =
                 Collections.singletonMap("id", "1' UNION SELECT * FROM cars; --");
@@ -82,7 +92,7 @@ class UnionBasedSQLInjectionVulnerabilityTest {
     }
 
     @Test
-    void getCarInformationLevel4_ExpecParamEscaped() throws IOException {
+    void getCarInformationLevel4_ExpectParamEscaped() {
         // Act
         final Map<String, String> params =
                 Collections.singletonMap("id", "1' UNION SELECT * FROM cars; --");
@@ -94,5 +104,21 @@ class UnionBasedSQLInjectionVulnerabilityTest {
                         eq("select * from cars where id=?"),
                         (PreparedStatementSetter) any(),
                         (ResultSetExtractor<? extends Object>) any());
+    }
+
+    @Test
+    void getCarInformationLevel5_ExpectParamEscaped() {
+        // Act
+        final Map<String, String> params =
+                Collections.singletonMap("id", "1' UNION SELECT * FROM cars; --");
+        final String id = "1' UNION SELECT * FROM cars; --";
+        unionBasedSQLInjectionVulnerability.getCarInformationLevel5(params);
+        // Assert
+        ArgumentMatcher<MapSqlParameterSource> argumentMatcher = sqlParameterSource -> Objects.requireNonNull(sqlParameterSource.getValue("id").equals(id));
+        verify(namedParameterJdbcTemplate)
+                .queryForObject(
+                        eq("select * from cars where id=:id"),
+                        argThat(argumentMatcher),
+                        eq(CarInformation.class));
     }
 }


### PR DESCRIPTION
When using JPA with CarInformation-Entity id must always be parsed to an integer. This leads to an NumberFormatException  querying the entity-id field with an injection string. To ensure the implementations are safe the sql injection id should be replaced by an string field e.g. name. 