### PR TITLE
Fixed file upload directory creation when system root directory is not writable by application. #449

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -92,10 +92,10 @@ public class UnrestrictedFileUpload {
                     "If you are running vulnerableApp as a Jar then UnrestrictedFileUpload will not work. "
                             + "For more information: https://github.com/SasanLabs/VulnerableApp/issues/255",
                     e);
-            if (root != null) {
+            if (root == null || !root.toFile().exists()) {
                 root = Files.createTempDirectory(null);
             }
-            if (contentDispositionRoot != null) {
+            if (contentDispositionRoot == null || !contentDispositionRoot.toFile().exists()) {
                 contentDispositionRoot = Files.createTempDirectory(null);
             }
         }


### PR DESCRIPTION
Updated code will set `root` and `contentDispositionRoot` to a temporary folder if they weren't created for any reason. If they were created successfully, they won't be changed.