### PR TITLE
Blind sql injection secure implementations

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -106,4 +106,32 @@ public class BlindSQLInjectionVulnerability {
                             ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
                 });
     }
+
+    //Input Validation - Ensure that the input data is valid and of the expected type.
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_4,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> getCarInformationLevel4(
+            @RequestParam Map<String, String> queryParams) {
+        String id = queryParams.get(Constants.ID);
+
+        // Validate numeric ID
+        if (!id.matches("\\d+")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid ID format.");
+        }
+
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        bodyBuilder.body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        return applicationJdbcTemplate.query(
+                "select * from cars where id=" + id,
+                (rs) -> {
+                    if (rs.next()) {
+                        return bodyBuilder.body(CAR_IS_PRESENT_RESPONSE);
+                    }
+                    return bodyBuilder.body(
+                            ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+                });
+    }
+
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -1,6 +1,8 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
 import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
         value = "BlindSQLInjectionVulnerability")
 public class BlindSQLInjectionVulnerability {
 
+    @PersistenceContext private EntityManager entityManager;
     private JdbcTemplate applicationJdbcTemplate;
 
     static final String CAR_IS_PRESENT_RESPONSE = "{ \"isCarPresent\": true}";
@@ -107,7 +110,7 @@ public class BlindSQLInjectionVulnerability {
                 });
     }
 
-    //Input Validation - Ensure that the input data is valid and of the expected type.
+    // Input Validation - Ensure that the input data is valid and of the expected type.
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             variant = Variant.SECURE,
@@ -134,4 +137,22 @@ public class BlindSQLInjectionVulnerability {
                 });
     }
 
+    // Implementation Level 5 - Hibernate
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_5,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> getCarInformationLevel5(
+            @RequestParam Map<String, String> queryParams) {
+        int id = Integer.parseInt(queryParams.get(Constants.ID));
+
+        CarInformation car = entityManager.find(CarInformation.class, id);
+
+        if (car != null) {
+            return ResponseEntity.ok(CAR_IS_PRESENT_RESPONSE);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        }
+    }
 }

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
@@ -43,16 +43,15 @@ public class BlindSQLInjectionVulnerabilityTest {
     // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the
     // data from the mockResultSet (which mocks the query result)
     when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -73,20 +72,20 @@ public class BlindSQLInjectionVulnerabilityTest {
     // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the
     // data from the mockResultSet (which mocks the query result)
     when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+            ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
   }
 
   @Test
@@ -102,15 +101,15 @@ public class BlindSQLInjectionVulnerabilityTest {
 
     // Mock the query method of JdbcTemplate
     when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -130,20 +129,20 @@ public class BlindSQLInjectionVulnerabilityTest {
 
     // Mock the query method of JdbcTemplate
     when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+            ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
   }
 
   @Test
@@ -159,15 +158,15 @@ public class BlindSQLInjectionVulnerabilityTest {
 
     // Mock the query method of JdbcTemplate
     when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -187,19 +186,20 @@ public class BlindSQLInjectionVulnerabilityTest {
 
     // Mock the query method of JdbcTemplate
     when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class)))
-        .thenAnswer(
-            invocation -> {
-              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
-              return rse.extractData(mockResultSet);
-            });
+            .thenAnswer(
+                    invocation -> {
+                      ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+                      return rse.extractData(mockResultSet);
+                    });
 
     // Act
     ResponseEntity<String> response =
-        blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+            blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+            ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
   }
 }
+

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
@@ -1,0 +1,84 @@
+package org.sasanlabs.service.vulnerability.sqlInjection;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.ResultSetExtractor;
+
+public class BlindSQLInjectionVulnerabilityTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private BlindSQLInjectionVulnerability blindSQLInjectionVulnerability;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetCarInformationLevel1_CarPresent() throws SQLException {
+        // Arrange
+        String id = "1";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // The query is simulated to have returned a result (i.e. there is a car with ID "1")
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(true);
+
+        // Mock the query method of JdbcTemplate
+        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("{ \"isCarPresent\": true}", response.getBody());
+    }
+
+    @Test
+    public void testGetCarInformationLevel1_CarNotPresent() throws SQLException {
+        // Arrange
+        String id = "2";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // The query is simulated to have returned a result (i.e. there is no a car with ID "2")
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(false);
+
+        // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the data from the mockResultSet (which mocks the query result)
+        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+    }
+}

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
@@ -131,4 +131,54 @@ public class BlindSQLInjectionVulnerabilityTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
     }
+
+    @Test
+    public void testGetCarInformationLevel3_CarPresent() throws SQLException {
+        // Arrange
+        String id = "1";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // Mock the ResultSet behavior
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(true);
+
+        // Mock the query method of JdbcTemplate
+        when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("{ \"isCarPresent\": true}", response.getBody());
+    }
+
+    @Test
+    public void testGetCarInformationLevel3_CarNotPresent() throws SQLException {
+        // Arrange
+        String id = "2";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // Mock the ResultSet behavior
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(false);
+
+        // Mock the query method of JdbcTemplate
+        when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+    }
 }

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
@@ -43,7 +43,7 @@ public class BlindSQLInjectionVulnerabilityTest {
         ResultSet mockResultSet = mock(ResultSet.class);
         when(mockResultSet.next()).thenReturn(true);
 
-        // Mock the query method of JdbcTemplate
+        // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the data from the mockResultSet (which mocks the query result)
         when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
             ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
             return rse.extractData(mockResultSet);
@@ -76,6 +76,56 @@ public class BlindSQLInjectionVulnerabilityTest {
 
         // Act
         ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+    }
+
+    @Test
+    public void testGetCarInformationLevel2_CarPresent() throws SQLException {
+        // Arrange
+        String id = "1";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // Mock the ResultSet behavior
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(true);
+
+        // Mock the query method of JdbcTemplate
+        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("{ \"isCarPresent\": true}", response.getBody());
+    }
+
+    @Test
+    public void testGetCarInformationLevel2_CarNotPresent() throws SQLException {
+        // Arrange
+        String id = "2";
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("id", id);
+
+        // Mock the ResultSet behavior
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(false);
+
+        // Mock the query method of JdbcTemplate
+        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
+            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+            return rse.extractData(mockResultSet);
+        });
+
+        // Act
+        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerabilityTest.java
@@ -1,13 +1,12 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
-import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -21,164 +20,186 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 
 public class BlindSQLInjectionVulnerabilityTest {
 
-    @Mock
-    private JdbcTemplate jdbcTemplate;
+  @Mock private JdbcTemplate jdbcTemplate;
 
-    @InjectMocks
-    private BlindSQLInjectionVulnerability blindSQLInjectionVulnerability;
+  @InjectMocks private BlindSQLInjectionVulnerability blindSQLInjectionVulnerability;
 
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
 
-    @Test
-    public void testGetCarInformationLevel1_CarPresent() throws SQLException {
-        // Arrange
-        String id = "1";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+  @Test
+  public void testGetCarInformationLevel1_CarPresent() throws SQLException {
+    // Arrange
+    String id = "1";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // The query is simulated to have returned a result (i.e. there is a car with ID "1")
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(true);
+    // The query is simulated to have returned a result (i.e. there is a car with ID "1")
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
 
-        // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the data from the mockResultSet (which mocks the query result)
-        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-            return rse.extractData(mockResultSet);
-        });
+    // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the
+    // data from the mockResultSet (which mocks the query result)
+    when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("{ \"isCarPresent\": true}", response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
 
-    @Test
-    public void testGetCarInformationLevel1_CarNotPresent() throws SQLException {
-        // Arrange
-        String id = "2";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("{ \"isCarPresent\": true}", response.getBody());
+  }
 
-        // The query is simulated to have returned a result (i.e. there is no a car with ID "2")
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(false);
+  @Test
+  public void testGetCarInformationLevel1_CarNotPresent() throws SQLException {
+    // Arrange
+    String id = "2";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the data from the mockResultSet (which mocks the query result)
-        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-            return rse.extractData(mockResultSet);
-        });
+    // The query is simulated to have returned a result (i.e. there is no a car with ID "2")
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(false);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
+    // return rse.extractData(mockResultSet); indicates that the ResultSetExtractor extracts the
+    // data from the mockResultSet (which mocks the query result)
+    when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel1(queryParams);
 
-    @Test
-    public void testGetCarInformationLevel2_CarPresent() throws SQLException {
-        // Arrange
-        String id = "1";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(
+        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+  }
 
-        // Mock the ResultSet behavior
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(true);
+  @Test
+  public void testGetCarInformationLevel2_CarPresent() throws SQLException {
+    // Arrange
+    String id = "1";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // Mock the query method of JdbcTemplate
-        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-            return rse.extractData(mockResultSet);
-        });
+    // Mock the ResultSet behavior
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
+    // Mock the query method of JdbcTemplate
+    when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("{ \"isCarPresent\": true}", response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
 
-    @Test
-    public void testGetCarInformationLevel2_CarNotPresent() throws SQLException {
-        // Arrange
-        String id = "2";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("{ \"isCarPresent\": true}", response.getBody());
+  }
 
-        // Mock the ResultSet behavior
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(false);
+  @Test
+  public void testGetCarInformationLevel2_CarNotPresent() throws SQLException {
+    // Arrange
+    String id = "2";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // Mock the query method of JdbcTemplate
-        when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
-            return rse.extractData(mockResultSet);
-        });
+    // Mock the ResultSet behavior
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(false);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
+    // Mock the query method of JdbcTemplate
+    when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(1);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel2(queryParams);
 
-    @Test
-    public void testGetCarInformationLevel3_CarPresent() throws SQLException {
-        // Arrange
-        String id = "1";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(
+        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+  }
 
-        // Mock the ResultSet behavior
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(true);
+  @Test
+  public void testGetCarInformationLevel3_CarPresent() throws SQLException {
+    // Arrange
+    String id = "1";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // Mock the query method of JdbcTemplate
-        when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
-            return rse.extractData(mockResultSet);
-        });
+    // Mock the ResultSet behavior
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+    // Mock the query method of JdbcTemplate
+    when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("{ \"isCarPresent\": true}", response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
 
-    @Test
-    public void testGetCarInformationLevel3_CarNotPresent() throws SQLException {
-        // Arrange
-        String id = "2";
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put("id", id);
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("{ \"isCarPresent\": true}", response.getBody());
+  }
 
-        // Mock the ResultSet behavior
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockResultSet.next()).thenReturn(false);
+  @Test
+  public void testGetCarInformationLevel3_CarNotPresent() throws SQLException {
+    // Arrange
+    String id = "2";
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("id", id);
 
-        // Mock the query method of JdbcTemplate
-        when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class))).thenAnswer(invocation -> {
-            ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
-            return rse.extractData(mockResultSet);
-        });
+    // Mock the ResultSet behavior
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(false);
 
-        // Act
-        ResponseEntity<String> response = blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+    // Mock the query method of JdbcTemplate
+    when(jdbcTemplate.query((PreparedStatementCreator) any(), any(), any(ResultSetExtractor.class)))
+        .thenAnswer(
+            invocation -> {
+              ResultSetExtractor<ResponseEntity<String>> rse = invocation.getArgument(2);
+              return rse.extractData(mockResultSet);
+            });
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
-    }
+    // Act
+    ResponseEntity<String> response =
+        blindSQLInjectionVulnerability.getCarInformationLevel3(queryParams);
+
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(
+        ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE, response.getBody());
+  }
 }


### PR DESCRIPTION
This PR adds Blind SQL injection secure implementations for levels 4 and 5 in the `BlindSQLInjectionVulnerability` class. 

- Level 4: Implementation of getCarInformationLevel4 method using parameterized queries with JdbcTemplate.

- Level 5: Implementation of the getCarInformationLevel5 method using EntityManager to safely perform queries using Hibernate, avoiding SQL injection.

Resolves: #405