### PR TITLE
Blind sql injection vulnerabilities secure implementations

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -1,6 +1,8 @@
 package org.sasanlabs.service.vulnerability.sqlInjection;
 
 import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
@@ -14,8 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.RequestParam;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 /**
  * This is the most difficult and slowest attack which is done only if Error Based and Union Based
@@ -31,8 +31,7 @@ import javax.persistence.PersistenceContext;
         value = "BlindSQLInjectionVulnerability")
 public class BlindSQLInjectionVulnerability {
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    @PersistenceContext private EntityManager entityManager;
     private JdbcTemplate applicationJdbcTemplate;
 
     static final String CAR_IS_PRESENT_RESPONSE = "{ \"isCarPresent\": true}";
@@ -136,5 +135,23 @@ public class BlindSQLInjectionVulnerability {
                             ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
                 });
     }
-    
+
+    // Implementation Level 5 - Hibernate
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_5,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> getCarInformationLevel5(
+            @RequestParam Map<String, String> queryParams) {
+        int id = Integer.parseInt(queryParams.get(Constants.ID));
+
+        CarInformation car = entityManager.find(CarInformation.class, id);
+
+        if (car != null) {
+            return ResponseEntity.ok(CAR_IS_PRESENT_RESPONSE);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        }
+    }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.RequestParam;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 /**
  * This is the most difficult and slowest attack which is done only if Error Based and Union Based
@@ -29,6 +31,8 @@ import org.springframework.web.bind.annotation.RequestParam;
         value = "BlindSQLInjectionVulnerability")
 public class BlindSQLInjectionVulnerability {
 
+    @PersistenceContext
+    private EntityManager entityManager;
     private JdbcTemplate applicationJdbcTemplate;
 
     static final String CAR_IS_PRESENT_RESPONSE = "{ \"isCarPresent\": true}";
@@ -106,4 +110,31 @@ public class BlindSQLInjectionVulnerability {
                             ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
                 });
     }
+    // Input Validation - Ensure that the input data is valid and of the expected type.
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_4,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> getCarInformationLevel4(
+            @RequestParam Map<String, String> queryParams) {
+        String id = queryParams.get(Constants.ID);
+
+        // Validate numeric ID
+        if (!id.matches("\\d+")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid ID format.");
+        }
+
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        bodyBuilder.body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        return applicationJdbcTemplate.query(
+                "select * from cars where id=" + id,
+                (rs) -> {
+                    if (rs.next()) {
+                        return bodyBuilder.body(CAR_IS_PRESENT_RESPONSE);
+                    }
+                    return bodyBuilder.body(
+                            ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+                });
+    }
+    
 }


### PR DESCRIPTION
This PR adds Blind SQL injection secure implementations for levels 4 and 5 in the BlindSQLInjectionVulnerability class.

Level 4: Implementation of getCarInformationLevel4 method using parameterized queries with JdbcTemplate.

Level 5: Implementation of the getCarInformationLevel5 method using EntityManager to safely perform queries using Hibernate, avoiding SQL injection.

Resolves: https://github.com/SasanLabs/VulnerableApp/issues/405