### PR TITLE
fix: remove deprecated Docker compose version and pin facade image to 1.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
     VulnerableApp-base:
       image: sasanlabs/owasp-vulnerableapp:unreleased
@@ -14,7 +13,7 @@ services:
         - VulnerableApp-base
         - VulnerableApp-jsp
         - VulnerableApp-php
-      image: sasanlabs/owasp-vulnerableapp-facade
+      image: sasanlabs/owasp-vulnerableapp-facade:1.2.1
       volumes:
        - ./templates:/etc/nginx/templates
       ports:


### PR DESCRIPTION

Fixes warning + issue #486 in docker-compose.yml:
1. Removes obsolete [version: 3.9] field (Docker Compose has deprecated version in V2 so no need) 
2. Pinned VulnerableApp-facade image to specific version instead of floating ":latest" tag - issue fix of #486

## Manual test
- "docker-compose up" no longer shows "version is obsolete" warning
- Application runs successfully at localhost
- Both `:latest` and `:1.2.1` tags exist on Docker Hub (`docker pull` confirmed)
