### PR TITLE
Fix: Use consistent latest Docker tag across services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
         - VulnerableApp-base
         - VulnerableApp-jsp
         - VulnerableApp-php
-      image: sasanlabs/owasp-vulnerableapp-facade:1.2.1
+      # All services use :latest tag for consistency and easier deployment
+      image: sasanlabs/owasp-vulnerableapp-facade:latest
       volumes:
        - ./templates:/etc/nginx/templates
       ports:


### PR DESCRIPTION
This PR fixes Docker tag inconsistency in docker-compose.yml.

Previously VulnerableApp-facade was using version 1.2.1 while other services used :latest.
Updated facade service to use :latest tag for consistency and easier deployment.

Fixes #434
