### PR TITLE
feat: implement @ChallengeCard annotation for structured vulnerability challenges

### DIFF
--- a/src/main/java/org/sasanlabs/beans/ChallengeCardResponseBean.java
+++ b/src/main/java/org/sasanlabs/beans/ChallengeCardResponseBean.java
@@ -1,0 +1,92 @@
+package org.sasanlabs.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * This class is the response bean for the ChallengeCard annotation.
+ * It provides the detailed learning challenges, hints, and payloads
+ * associated with a specific vulnerability level.
+ *
+ * <p>Note: As these beans are returned to the UI, they expect that all 
+ * the labels/property keys are resolved to their respective values via 
+ * the MessageBundle.
+ *
+ * @author Aryan mr.aryankaushal@gmail.com
+ */
+public class ChallengeCardResponseBean {
+    
+    @JsonProperty("ChallengeText")
+    private String challengeText;
+
+    @JsonProperty("hints")
+    private List<HintResponseBean> hints;
+
+    @JsonProperty("payload")
+    private PayloadResponseBean payload;
+
+    public ChallengeCardResponseBean(String challengeText, List<HintResponseBean> hints, PayloadResponseBean payload) {
+        this.challengeText = challengeText;
+        this.hints = hints;
+        this.payload = payload;
+    }
+
+    public String getChallengeText() {
+        return challengeText;
+    }
+
+    public List<HintResponseBean> getHints() {
+        return hints;
+    }
+
+    public PayloadResponseBean getPayload() {
+        return payload;
+    }
+
+    /**
+     * Response bean for the Hint within a ChallengeCard.
+     */
+    public static class HintResponseBean {
+        
+        @JsonProperty("order")
+        private int order;
+
+        @JsonProperty("text")
+        private String text;
+
+        public HintResponseBean(int order, String text) {
+            this.order = order;
+            this.text = text;
+        }
+
+        public int getOrder() {
+            return order;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+
+    public static class PayloadResponseBean {
+        
+        @JsonProperty("description")
+        private String description;
+
+        @JsonProperty("value")
+        private String value;
+
+        public PayloadResponseBean(String description, String value) {
+            this.description = description;
+            this.value = value;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/src/main/java/org/sasanlabs/beans/ChallengeCardResponseBean.java
+++ b/src/main/java/org/sasanlabs/beans/ChallengeCardResponseBean.java
@@ -4,18 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * This class is the response bean for the ChallengeCard annotation.
- * It provides the detailed learning challenges, hints, and payloads
- * associated with a specific vulnerability level.
+ * This class is the response bean for the ChallengeCard annotation. It provides the detailed
+ * learning challenges, hints, and payloads associated with a specific vulnerability level.
  *
- * <p>Note: As these beans are returned to the UI, they expect that all 
- * the labels/property keys are resolved to their respective values via 
- * the MessageBundle.
+ * <p>Note: As these beans are returned to the UI, they expect that all the labels/property keys are
+ * resolved to their respective values via the MessageBundle.
  *
  * @author Aryan mr.aryankaushal@gmail.com
  */
 public class ChallengeCardResponseBean {
-    
+
     @JsonProperty("ChallengeText")
     private String challengeText;
 
@@ -25,7 +23,8 @@ public class ChallengeCardResponseBean {
     @JsonProperty("payload")
     private PayloadResponseBean payload;
 
-    public ChallengeCardResponseBean(String challengeText, List<HintResponseBean> hints, PayloadResponseBean payload) {
+    public ChallengeCardResponseBean(
+            String challengeText, List<HintResponseBean> hints, PayloadResponseBean payload) {
         this.challengeText = challengeText;
         this.hints = hints;
         this.payload = payload;
@@ -43,11 +42,9 @@ public class ChallengeCardResponseBean {
         return payload;
     }
 
-    /**
-     * Response bean for the Hint within a ChallengeCard.
-     */
+    /** Response bean for the Hint within a ChallengeCard. */
     public static class HintResponseBean {
-        
+
         @JsonProperty("order")
         private int order;
 
@@ -69,7 +66,7 @@ public class ChallengeCardResponseBean {
     }
 
     public static class PayloadResponseBean {
-        
+
         @JsonProperty("description")
         private String description;
 

--- a/src/main/java/org/sasanlabs/beans/LevelResponseBean.java
+++ b/src/main/java/org/sasanlabs/beans/LevelResponseBean.java
@@ -126,7 +126,7 @@ public class LevelResponseBean implements Comparable<LevelResponseBean> {
         return challengeCards;
     }
 
-    public void setChallengeCards (List<ChallengeCardResponseBean> challengeCards) {
+    public void setChallengeCards(List<ChallengeCardResponseBean> challengeCards) {
         this.challengeCards = challengeCards;
     }
 }

--- a/src/main/java/org/sasanlabs/beans/LevelResponseBean.java
+++ b/src/main/java/org/sasanlabs/beans/LevelResponseBean.java
@@ -40,6 +40,9 @@ public class LevelResponseBean implements Comparable<LevelResponseBean> {
     @JsonProperty("AttackVectors")
     private List<AttackVectorResponseBean> attackVectorResponseBeans = new ArrayList<>();
 
+    @JsonProperty("ChallengeCard")
+    private List<ChallengeCardResponseBean> challengeCards = new ArrayList<>();
+
     public String getLevel() {
         return level;
     }
@@ -117,5 +120,13 @@ public class LevelResponseBean implements Comparable<LevelResponseBean> {
     public int compareTo(LevelResponseBean levelResponseBean) {
         return LevelConstants.getOrdinal(this.level)
                 - LevelConstants.getOrdinal(levelResponseBean.getLevel());
+    }
+
+    public List<ChallengeCardResponseBean> getChallengeCards() {
+        return challengeCards;
+    }
+
+    public void setChallengeCards (List<ChallengeCardResponseBean> challengeCards) {
+        this.challengeCards = challengeCards;
     }
 }

--- a/src/main/java/org/sasanlabs/internal/utility/annotations/ChallengeCard.java
+++ b/src/main/java/org/sasanlabs/internal/utility/annotations/ChallengeCard.java
@@ -1,0 +1,48 @@
+package org.sasanlabs.internal.utility.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to define learning challenges for vulnerabilities.
+ * * @author Aryan mr.aryankaushal@gmail.com
+ * */
+@Repeatable(ChallengeCard.ChallengeCards.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = ElementType.METHOD)
+public @interface ChallengeCard {
+    
+    String ChallengeText();
+
+    Hint[] hints() default {};
+
+    Payload[] payload();
+
+    /**
+     * Container annotation for making {@link ChallengeCard} repeatable.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(value = ElementType.METHOD)
+    public @interface ChallengeCards {
+        ChallengeCard[] value();
+    }
+
+    /**
+     * Defines a hint for the challenge.
+     */
+    public @interface Hint {
+        int order();
+        String text();
+    }
+
+    /**
+     * Defines the exploit payload for the challenge.
+     */
+    public @interface Payload {
+        String description();
+        String value();
+    }
+}

--- a/src/main/java/org/sasanlabs/internal/utility/annotations/ChallengeCard.java
+++ b/src/main/java/org/sasanlabs/internal/utility/annotations/ChallengeCard.java
@@ -7,42 +7,38 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to define learning challenges for vulnerabilities.
- * * @author Aryan mr.aryankaushal@gmail.com
- * */
+ * Annotation to define learning challenges for vulnerabilities. * @author Aryan
+ * mr.aryankaushal@gmail.com
+ */
 @Repeatable(ChallengeCard.ChallengeCards.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = ElementType.METHOD)
 public @interface ChallengeCard {
-    
-    String ChallengeText();
+
+    String challengeText();
 
     Hint[] hints() default {};
 
-    Payload[] payload();
+    Payload payload();
 
-    /**
-     * Container annotation for making {@link ChallengeCard} repeatable.
-     */
+    /** Container annotation for making {@link ChallengeCard} repeatable. */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(value = ElementType.METHOD)
     public @interface ChallengeCards {
         ChallengeCard[] value();
     }
 
-    /**
-     * Defines a hint for the challenge.
-     */
+    /** Defines a hint for the challenge. */
     public @interface Hint {
         int order();
+
         String text();
     }
 
-    /**
-     * Defines the exploit payload for the challenge.
-     */
+    /** Defines the exploit payload for the challenge. */
     public @interface Payload {
         String description();
+
         String value();
     }
 }

--- a/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
+++ b/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.sasanlabs.beans.AllEndPointsResponseBean;
 import org.sasanlabs.beans.AttackVectorResponseBean;
+import org.sasanlabs.beans.ChallengeCardResponseBean;
 import org.sasanlabs.beans.LevelResponseBean;
 import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.configuration.VulnerableAppProperties;
@@ -18,6 +19,7 @@ import org.sasanlabs.internal.utility.FrameworkConstants;
 import org.sasanlabs.internal.utility.GenericUtils;
 import org.sasanlabs.internal.utility.MessageBundle;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.IEndPointsInformationProvider;
@@ -85,6 +87,34 @@ public class EndPointsInformationProvider implements IEndPointsInformationProvid
                         levelResponseBean.setVariant(vulnLevel.variant());
                         levelResponseBean.setHtmlTemplate(vulnLevel.htmlTemplate());
                         levelResponseBean.setRequestMethod(vulnLevel.requestMethod());
+                        ChallengeCard[] challengeCards =
+                                method.getAnnotationsByType(ChallengeCard.class);
+                        for (ChallengeCard card : challengeCards) {
+                            List<ChallengeCardResponseBean.HintResponseBean> hintBeans =
+                                    new ArrayList<>();
+                            for (ChallengeCard.Hint hint : card.hints()) {
+                                hintBeans.add(
+                                        new ChallengeCardResponseBean.HintResponseBean(
+                                                hint.order(),
+                                                messageBundle.getString(hint.text(), null)));
+                            }
+
+                            ChallengeCardResponseBean.PayloadResponseBean payloadBean =
+                                    new ChallengeCardResponseBean.PayloadResponseBean(
+                                            messageBundle.getString(
+                                                    card.payload().description(), null),
+                                            vulnerableAppProperties.getAttackVectorProperty(
+                                                    card.payload().value()));
+
+                            levelResponseBean
+                                    .getChallengeCards()
+                                    .add(
+                                            new ChallengeCardResponseBean(
+                                                    messageBundle.getString(
+                                                            card.challengeText(), null),
+                                                    hintBeans,
+                                                    payloadBean));
+                        }
                         for (AttackVector attackVector : attackVectors) {
                             levelResponseBean
                                     .getAttackVectorResponseBeans()


### PR DESCRIPTION
## Summary
This PR introduces a new annotation-driven system to define "Challenge Cards" for vulnerabilities. This allows developers to embed specific learning goals, hints, and payloads directly within the Java code using annotations, which are then exposed to the UI.

## Changes
- **New Annotations**: Created `@ChallengeCard` (repeatable) along with nested `@Hint` and `@Payload` definitions in `org.sasanlabs.internal.utility.annotations`.
- **Response Beans**: Implemented `ChallengeCardResponseBean` and updated `LevelResponseBean` to support the new data structure.
- **Scanner Logic**: Updated `EndPointsInformationProvider` to use Reflection to scan for these annotations and resolve localization keys via `MessageBundle`.
- **Formatting**: Applied Google Java Style (AOSP) via Spotless.

## Why this is needed
Currently, adding structured challenges to vulnerable endpoints requires manual configuration. This change makes the project more extensible by allowing challenges to be defined right where the vulnerability logic lives.

## How to test
1. Annotate a method in any `VulnerableAppRestController` with `@ChallengeCard`.
2. Start the application.
3. Access the `/allEndpoints` or `/vulnerabilityDefinitions` API.
4. Verify that the `challengeCards` field is populated with the correct JSON structure.

Closes #587