### PR TITLE
Add scanner benchmark framework for DAST and SAST coverage (#553)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 .settings/
 .vscode/
 .DS_Store
+
+# Runtime output of /scanner/benchmark — sample inputs and README are tracked
+/benchmarks/*-results.json

--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ Password: hacker
 13. [LDAP Injection](https://github.com/SasanLabs/VulnerableApp/tree/master/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection)
 14. [Authentication Vulnerability](https://github.com/SasanLabs/VulnerableApp/tree/master/src/main/java/org/sasanlabs/service/vulnerability/authentication)    
 
+## Benchmarking your scanner
+
+VulnerableApp ships a comparator that grades a scanner's findings against the
+project's built-in ground truth and writes a coverage / missed / unmatched
+report. Both DAST and SAST scanners are supported via the same endpoint:
+
+- Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
+- Request body — pick the shape that matches your scanner:
+  - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` is optional and defaults to `DAST`; `type`/`cwe`/`wascId` are individually optional — any one axis matching is enough)
+  - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
+- Response body and `benchmarks/<tool>-results.json` on disk: coverage report
+
+Running the scanner itself is out of scope — you supply the JSON. See
+[`benchmarks/README.md`](benchmarks/README.md) for the full input/output
+schemas, matching rules, canonical vulnerability-type vocabulary, and `curl`
+examples.
+
 ## Contact
 In case you are stuck with any of the steps or understanding anything related to project and its goals, feel free to shoot a mail at karan.sasan@owasp.org or raise an [issue](https://github.com/SasanLabs/VulnerableApp/issues) and we will try our best to help you.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,113 @@
+# Scanner Benchmark Framework
+
+This framework lets you grade a DAST scanner (ZAP, Burp, anything else) against the
+ground truth that VulnerableApp already exposes via `/scanner`. You feed it the
+scanner's findings as JSON; it returns coverage, missed issues, and false
+positives, and writes a JSON report to `benchmarks/<tool>-results.json`.
+
+> Running the scanner is **out of scope**. You are responsible for running ZAP /
+> Burp / your tool against a live VulnerableApp instance and converting its output
+> into the input format below.
+
+## Input format
+
+```json
+{
+  "tool": "ZAP",
+  "findings": [
+    { "url": "/BlindSQLInjectionVulnerability/LEVEL_1", "type": "BLIND_SQL_INJECTION" },
+    { "url": "/XSSInImgTagAttribute/LEVEL_1",          "type": "REFLECTED_XSS" }
+  ]
+}
+```
+
+To discover the real URL/type pairs to send, hit
+`GET http://<baseurl>/VulnerableApp/scanner` — that's the ground truth you're being
+graded against. The full sample at `benchmarks/samples/zap-findings-sample.json`
+includes one deliberately invalid entry so a successful run produces a non-empty
+`falsePositiveItems` list for demonstration.
+
+- `tool` — required, non-empty. Used as the report filename.
+- `findings` — required (use `[]` if the scanner found nothing).
+- `findings[].url` — relative path (`/SQLInjection/LEVEL_1`) or absolute URL
+  (`http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1`); the comparator
+  normalises both. Query strings, the `/VulnerableApp` context path, and trailing
+  slashes are stripped.
+- `findings[].type` — case-insensitive match against
+  [`VulnerabilityType`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java)
+  enum names. See the canonical values below.
+
+## Canonical vulnerability type values (v1)
+
+The benchmark matches `findings[].type` against the `VulnerabilityType` enum by
+name. A scanner reporting `"SQL_INJECTION"` will not match — use a specific
+sub-type. The full set lives in
+[`VulnerabilityType.java`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java);
+common values:
+
+```
+BLIND_SQL_INJECTION, ERROR_BASED_SQL_INJECTION, UNION_BASED_SQL_INJECTION,
+REFLECTED_XSS, PERSISTENT_XSS, DOM_BASED_XSS,
+COMMAND_INJECTION, PATH_TRAVERSAL, HEADER_INJECTION, XXE,
+OPEN_REDIRECT_3XX_STATUS_CODE, SIMPLE_SSRF, BLIND_SSRF,
+LDAP_INJECTION, INSECURE_DIRECT_OBJECT_REFERENCE,
+UNRESTRICTED_FILE_UPLOAD, UNCONTROLLED_RESOURCE_CONSUMPTION,
+WEAK_CRYPTOGRAPHIC_HASH, INSECURE_CRYPTOGRAPHIC_STORAGE,
+USE_OF_BROKEN_CRYPTOGRAPHIC_ALGORITHM, CLICKJACKING,
+PLAINTEXT_PASSWORD_STORAGE, WEAK_PASSWORD_HASHING, USERNAME_ENUMERATION,
+WEB_CACHE_POISONING
+```
+
+## Calling the endpoint
+
+Start VulnerableApp, then:
+
+```bash
+curl -X POST http://localhost:9090/VulnerableApp/scanner/benchmark \
+  -H "Content-Type: application/json" \
+  -d @benchmarks/samples/zap-findings-sample.json
+```
+
+The HTTP response contains the same JSON that gets persisted to disk.
+
+## Output format
+
+```json
+{
+  "tool": "ZAP",
+  "coverage": 78.0,
+  "totalExpected": 50,
+  "detected": 39,
+  "missed": 11,
+  "falsePositives": 12,
+  "missedItems":         [ { "url": "/...", "type": "..." } ],
+  "falsePositiveItems":  [ { "url": "/...", "type": "..." } ]
+}
+```
+
+- `coverage` — `detected / totalExpected * 100`. Reported as `0.0` when ground
+  truth is empty.
+- `totalExpected` — number of `(URL, vulnerabilityType)` pairs across all
+  `UNSECURE` ground-truth entries. `SECURE` entries are intentionally clean and
+  do not count toward expected.
+- `missedItems` — expected pairs the scanner did not report.
+- `falsePositiveItems` — pairs the scanner reported that are not in the
+  expected set. Includes findings against `SECURE` URLs (those endpoints are
+  intentionally clean, so flagging them is over-eager).
+
+## Where the report is written
+
+By default, `benchmarks/<sanitised-tool>-results.json` relative to the working
+directory of the running VulnerableApp process. The directory is configurable
+via the `benchmark.output.dir` property in `application.properties`. Filenames
+are lowercased and stripped of anything outside `[a-z0-9_-]`. Re-running the
+endpoint for the same tool overwrites the previous report.
+
+## Limitations (v1)
+
+- DAST only; SAST benchmarking against `scanner/sast/expectedIssues.csv` is not
+  implemented.
+- Type matching is by enum name. CWE-based matching is a likely follow-up.
+- HTTP method is shown in the ground truth but is not part of the match key —
+  if the scanner reports the right URL + type with a different method, it still
+  counts as detected.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,19 +1,36 @@
 # Scanner Benchmark Framework
 
-This framework lets you grade a DAST scanner (ZAP, Burp, anything else) against the
-ground truth that VulnerableApp already exposes via `/scanner`. You feed it the
-scanner's findings as JSON; it returns coverage, missed issues, and false
-positives, and writes a JSON report to `benchmarks/<tool>-results.json`.
+This framework grades a security scanner against the ground truth that
+VulnerableApp already ships. It supports two scan modes today:
 
-> Running the scanner is **out of scope**. You are responsible for running ZAP /
-> Burp / your tool against a live VulnerableApp instance and converting its output
-> into the input format below.
+- **DAST** — graded against the live `/scanner` endpoint (URL + vulnerability type).
+- **SAST** — graded against `scanner/sast/expectedIssues.csv` (file path + line +
+  CWE / vulnerability type).
 
-## Input format
+You POST the scanner's findings as JSON to `/scanner/benchmark`; the framework
+returns coverage, missed issues, and false positives, and writes a JSON report
+to `benchmarks/<tool>-results.json`.
+
+> Running the scanner itself is **out of scope**. You are responsible for
+> running ZAP / Burp / Semgrep / your tool against VulnerableApp (or its source
+> tree) and converting its output into the input format below.
+
+## Choosing a scan type
+
+The optional `scanType` field on the request body selects the strategy. When
+omitted, it defaults to `DAST` so existing payloads keep working.
+
+| `scanType`        | Ground truth                                | Per-finding fields                        |
+|-------------------|---------------------------------------------|-------------------------------------------|
+| `DAST` (default)  | live `/scanner` endpoint                    | `url`, `type`                             |
+| `SAST`            | `scanner/sast/expectedIssues.csv`           | `filePath`, `line`, plus `cwe` and/or `type` |
+
+## DAST input format
 
 ```json
 {
   "tool": "ZAP",
+  "scanType": "DAST",
   "findings": [
     { "url": "/BlindSQLInjectionVulnerability/LEVEL_1", "type": "BLIND_SQL_INJECTION" },
     { "url": "/XSSInImgTagAttribute/LEVEL_1",          "type": "REFLECTED_XSS" }
@@ -21,27 +38,24 @@ positives, and writes a JSON report to `benchmarks/<tool>-results.json`.
 }
 ```
 
-To discover the real URL/type pairs to send, hit
-`GET http://<baseurl>/VulnerableApp/scanner` — that's the ground truth you're being
-graded against. The full sample at `benchmarks/samples/zap-findings-sample.json`
+To discover the real (URL, type) pairs to send, hit
+`GET http://<baseurl>/VulnerableApp/scanner` — that's the ground truth you're
+being graded against. The full sample at `benchmarks/samples/zap-findings-sample.json`
 includes one deliberately invalid entry so a successful run produces a non-empty
 `falsePositiveItems` list for demonstration.
 
-- `tool` — required, non-empty. Used as the report filename.
-- `findings` — required (use `[]` if the scanner found nothing).
 - `findings[].url` — relative path (`/SQLInjection/LEVEL_1`) or absolute URL
   (`http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1`); the comparator
-  normalises both. Query strings, the `/VulnerableApp` context path, and trailing
-  slashes are stripped.
+  normalises both. Query strings, the `/VulnerableApp` context path, and
+  trailing slashes are stripped.
 - `findings[].type` — case-insensitive match against
   [`VulnerabilityType`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java)
   enum names. See the canonical values below.
 
-## Canonical vulnerability type values (v1)
+### Canonical DAST vulnerability type values
 
-The benchmark matches `findings[].type` against the `VulnerabilityType` enum by
-name. A scanner reporting `"SQL_INJECTION"` will not match — use a specific
-sub-type. The full set lives in
+A scanner reporting `"SQL_INJECTION"` will not match — use a specific sub-type.
+The full set lives in
 [`VulnerabilityType.java`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java);
 common values:
 
@@ -58,19 +72,78 @@ PLAINTEXT_PASSWORD_STORAGE, WEAK_PASSWORD_HASHING, USERNAME_ENUMERATION,
 WEB_CACHE_POISONING
 ```
 
+## SAST input format
+
+```json
+{
+  "tool": "Semgrep",
+  "scanType": "SAST",
+  "findings": [
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java",
+      "line": 56,
+      "cwe": "CWE-89",
+      "type": "SQL Injection"
+    }
+  ]
+}
+```
+
+The full sample at `benchmarks/samples/semgrep-sast-sample.json` includes one
+deliberately invalid entry so a successful run produces a non-empty
+`falsePositiveItems` list.
+
+Ground truth is loaded from `scanner/sast/expectedIssues.csv`. The path is
+configurable via the `benchmark.sast.ground-truth.path` property (default:
+`scanner/sast/expectedIssues.csv` relative to the working directory).
+
+### SAST matching rules
+
+A finding matches an expected issue when:
+
+1. The normalised **`filePath`** matches, AND
+2. The **`line`** matches exactly, AND
+3. Either **`cwe`** matches the CSV's `CWE` column **or** **`type`** matches
+   the `Vulnerability Type` column (case-insensitively).
+
+A scanner can emit either CWE, type, or both — whichever pair
+(`file + line + CWE` *or* `file + line + type`) hits the ground truth wins.
+
+- **Path normalisation:** backslashes → forward slashes; leading `./` stripped;
+  whitespace trimmed. Scanner authors should emit project-relative paths;
+  absolute paths or unexpected prefixes will not match.
+- **CWE comparison:** upper-cased + trimmed (e.g. `cwe-89` and `CWE-89` both
+  match).
+- **Type comparison:** lower-cased + trimmed (e.g. `"SQL Injection"` and
+  `"sql injection"` both match).
+- **Duplicates:** a scanner that emits the same `(filePath, line, CWE)` twice
+  gets credit once.
+- **`Number of Sources` column:** present in the CSV for human reference; **not
+  used for scoring** — full credit on first match.
+
 ## Calling the endpoint
 
-Start VulnerableApp, then:
+Start VulnerableApp, then for either mode:
 
 ```bash
+# DAST
 curl -X POST http://localhost:9090/VulnerableApp/scanner/benchmark \
   -H "Content-Type: application/json" \
   -d @benchmarks/samples/zap-findings-sample.json
+
+# SAST
+curl -X POST http://localhost:9090/VulnerableApp/scanner/benchmark \
+  -H "Content-Type: application/json" \
+  -d @benchmarks/samples/semgrep-sast-sample.json
 ```
 
 The HTTP response contains the same JSON that gets persisted to disk.
 
 ## Output format
+
+The output schema is the same for DAST and SAST. The fields inside each
+`missedItems` / `falsePositiveItems` entry vary by scan type (unused fields are
+omitted from the JSON).
 
 ```json
 {
@@ -85,29 +158,37 @@ The HTTP response contains the same JSON that gets persisted to disk.
 }
 ```
 
+For SAST runs, items look like:
+
+```json
+{ "filePath": "src/main/java/.../Foo.java", "line": 56, "type": "SQL Injection", "cwe": "CWE-89" }
+```
+
 - `coverage` — `detected / totalExpected * 100`. Reported as `0.0` when ground
   truth is empty.
-- `totalExpected` — number of `(URL, vulnerabilityType)` pairs across all
-  `UNSECURE` ground-truth entries. `SECURE` entries are intentionally clean and
-  do not count toward expected.
-- `missedItems` — expected pairs the scanner did not report.
-- `falsePositiveItems` — pairs the scanner reported that are not in the
-  expected set. Includes findings against `SECURE` URLs (those endpoints are
-  intentionally clean, so flagging them is over-eager).
+- `totalExpected` — number of unique ground-truth items. For DAST, count of
+  `(URL, vulnerabilityType)` pairs across all `UNSECURE` ground-truth entries
+  (SECURE entries are intentionally clean and don't count). For SAST, count of
+  rows in the CSV.
+- `missedItems` — expected items the scanner did not report.
+- `falsePositiveItems` — items the scanner reported that are not in the
+  expected set. For DAST this includes findings against `SECURE` URLs.
 
 ## Where the report is written
 
 By default, `benchmarks/<sanitised-tool>-results.json` relative to the working
 directory of the running VulnerableApp process. The directory is configurable
-via the `benchmark.output.dir` property in `application.properties`. Filenames
-are lowercased and stripped of anything outside `[a-z0-9_-]`. Re-running the
-endpoint for the same tool overwrites the previous report.
+via `benchmark.output.dir`. Filenames are lowercased and stripped of anything
+outside `[a-z0-9_-]`. Re-running the endpoint for the same tool (regardless of
+scan type) overwrites the previous report.
 
 ## Limitations (v1)
 
-- DAST only; SAST benchmarking against `scanner/sast/expectedIssues.csv` is not
-  implemented.
-- Type matching is by enum name. CWE-based matching is a likely follow-up.
-- HTTP method is shown in the ground truth but is not part of the match key —
-  if the scanner reports the right URL + type with a different method, it still
-  counts as detected.
+- **LLM-based scanners are not yet supported.** There is no equivalent
+  ground-truth source for LLM scanners; we'd rather see real LLM scanner output
+  formats before committing to a matcher. Tracked as a follow-up.
+- DAST type matching is by enum name. CWE-based matching for DAST is a likely
+  follow-up.
+- HTTP method (DAST) is shown in the ground truth but is not part of the match
+  key — same URL + type with a different method still counts as detected.
+- SAST `Number of Sources` is not used for scoring; full credit on first match.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,7 +59,7 @@ The full set lives in
 [`VulnerabilityType.java`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java);
 common values:
 
-```
+```text
 BLIND_SQL_INJECTION, ERROR_BASED_SQL_INJECTION, UNION_BASED_SQL_INJECTION,
 REFLECTED_XSS, PERSISTENT_XSS, DOM_BASED_XSS,
 COMMAND_INJECTION, PATH_TRAVERSAL, HEADER_INJECTION, XXE,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -64,12 +64,15 @@ deliberately invalid entry so a successful run produces a non-empty
 
 ### DAST matching rules
 
-A scanner finding matches a ground-truth row when the URL **and** HTTP method
-agree AND **any one of** these axes agrees:
+A scanner finding matches a ground-truth row when **all three** of these hold:
 
-1. `type` matches the `VulnerabilityType` enum name (case-insensitive), OR
-2. `cwe` matches the type's `cweID`, OR
-3. `wascId` matches the type's `wascID`.
+1. The URL agrees, AND
+2. The HTTP method check passes (opt-in — see below for the omitted-method
+   semantics), AND
+3. **Any one of** these axes agrees:
+   - `type` matches the `VulnerabilityType` enum name (case-insensitive), OR
+   - `cwe` matches the type's `cweID`, OR
+   - `wascId` matches the type's `wascID`.
 
 The method check is opt-in: if your scanner emits a `method` field, it is
 matched strictly (`POST` vs ground-truth `GET` becomes unmatched). If
@@ -209,6 +212,8 @@ For SAST runs, items look like:
 |---|---|---|
 | `benchmark.output.dir` | `benchmarks` | Directory the JSON report is written to. |
 | `benchmark.dast.ground-truth.url` | `http://localhost:${server.port:9090}${server.servlet.context-path:/VulnerableApp}/scanner` | URL the DAST comparator fetches ground truth from. Override when running behind VulnerableApp-facade so coverage spans every backing app. |
+| `benchmark.dast.ground-truth.connect-timeout-ms` | `5000` | Connect timeout (ms) for the ground-truth fetch. Fail-fast bound so a stalled endpoint can't tie up Tomcat request threads. |
+| `benchmark.dast.ground-truth.read-timeout-ms` | `10000` | Read timeout (ms) for the ground-truth fetch. |
 | `benchmark.sast.ground-truth.path` | `scanner/sast/expectedIssues.csv` | CSV file the SAST comparator loads expected issues from. |
 
 The default DAST URL is a self-call against the running app, which means

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,8 +8,9 @@ VulnerableApp already ships. It supports two scan modes today:
   CWE / vulnerability type).
 
 You POST the scanner's findings as JSON to `/scanner/benchmark`; the framework
-returns coverage, missed issues, and false positives, and writes a JSON report
-to `benchmarks/<tool>-results.json`.
+returns coverage, missed issues, and unmatched items (findings the scanner
+reported that don't line up with any ground-truth row), and writes a JSON report to
+`benchmarks/<tool>-results.json`.
 
 > Running the scanner itself is **out of scope**. You are responsible for
 > running ZAP / Burp / Semgrep / your tool against VulnerableApp (or its source
@@ -33,16 +34,18 @@ omitted, it defaults to `DAST` so existing payloads keep working.
   "scanType": "DAST",
   "findings": [
     { "url": "/BlindSQLInjectionVulnerability/LEVEL_1", "type": "BLIND_SQL_INJECTION" },
-    { "url": "/XSSInImgTagAttribute/LEVEL_1",          "type": "REFLECTED_XSS" }
+    { "url": "/ErrorBasedSQLInjectionVulnerability/LEVEL_1", "cwe": "CWE-89" },
+    { "url": "/PathTraversal/LEVEL_1", "wascId": "33" }
   ]
 }
 ```
 
-To discover the real (URL, type) pairs to send, hit
-`GET http://<baseurl>/VulnerableApp/scanner` — that's the ground truth you're
-being graded against. The full sample at `benchmarks/samples/zap-findings-sample.json`
-includes one deliberately invalid entry so a successful run produces a non-empty
-`falsePositiveItems` list for demonstration.
+To discover the real ground-truth entries, hit
+`GET http://<baseurl>/VulnerableApp/scanner` — every `UNSECURE` entry there
+contributes one expected finding for each `vulnerabilityType` it carries. The
+full sample at `benchmarks/samples/zap-findings-sample.json` includes one
+deliberately invalid entry so a successful run produces a non-empty
+`unmatchedItems` list for demonstration.
 
 - `findings[].url` — relative path (`/SQLInjection/LEVEL_1`) or absolute URL
   (`http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1`); the comparator
@@ -51,11 +54,37 @@ includes one deliberately invalid entry so a successful run produces a non-empty
 - `findings[].type` — case-insensitive match against
   [`VulnerabilityType`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java)
   enum names. See the canonical values below.
+- `findings[].cwe` — optional. Numeric (`89`) or `CWE-`-prefixed (`CWE-89`);
+  matches against `VulnerabilityType.getCweID()`.
+- `findings[].wascId` — optional. Numeric; matches against
+  `VulnerabilityType.getWascID()`.
+- `findings[].method` — optional. HTTP method (`GET`, `POST`, …); matches
+  against the ground-truth row's request method. See "DAST matching rules"
+  below for the omitted-method semantics.
+
+### DAST matching rules
+
+A scanner finding matches a ground-truth row when the URL **and** HTTP method
+agree AND **any one of** these axes agrees:
+
+1. `type` matches the `VulnerabilityType` enum name (case-insensitive), OR
+2. `cwe` matches the type's `cweID`, OR
+3. `wascId` matches the type's `wascID`.
+
+The method check is opt-in: if your scanner emits a `method` field, it is
+matched strictly (`POST` vs ground-truth `GET` becomes unmatched). If
+the field is omitted, the finding matches the URL's ground-truth row regardless
+of method — leniency for scanners whose output format does not include the
+method. This means existing payloads continue to work; emit `method` to enable
+the stricter check.
+
+A scanner that emits multiple axes (type + cwe, etc.) for the same alert is
+counted once. A finding that matches no axis on any expected URL ends up in
+`unmatchedItems`.
 
 ### Canonical DAST vulnerability type values
 
-A scanner reporting `"SQL_INJECTION"` will not match — use a specific sub-type.
-The full set lives in
+If you choose to match by `type`, the full set lives in
 [`VulnerabilityType.java`](../src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java);
 common values:
 
@@ -91,7 +120,7 @@ WEB_CACHE_POISONING
 
 The full sample at `benchmarks/samples/semgrep-sast-sample.json` includes one
 deliberately invalid entry so a successful run produces a non-empty
-`falsePositiveItems` list.
+`unmatchedItems` list.
 
 Ground truth is loaded from `scanner/sast/expectedIssues.csv`. The path is
 configurable via the `benchmark.sast.ground-truth.path` property (default:
@@ -142,7 +171,7 @@ The HTTP response contains the same JSON that gets persisted to disk.
 ## Output format
 
 The output schema is the same for DAST and SAST. The fields inside each
-`missedItems` / `falsePositiveItems` entry vary by scan type (unused fields are
+`missedItems` / `unmatchedItems` entry vary by scan type (unused fields are
 omitted from the JSON).
 
 ```json
@@ -152,9 +181,9 @@ omitted from the JSON).
   "totalExpected": 50,
   "detected": 39,
   "missed": 11,
-  "falsePositives": 12,
+  "unmatched": 12,
   "missedItems":         [ { "url": "/...", "type": "..." } ],
-  "falsePositiveItems":  [ { "url": "/...", "type": "..." } ]
+  "unmatchedItems":  [ { "url": "/...", "type": "..." } ]
 }
 ```
 
@@ -171,8 +200,22 @@ For SAST runs, items look like:
   (SECURE entries are intentionally clean and don't count). For SAST, count of
   rows in the CSV.
 - `missedItems` — expected items the scanner did not report.
-- `falsePositiveItems` — items the scanner reported that are not in the
-  expected set. For DAST this includes findings against `SECURE` URLs.
+- `unmatchedItems` — items the scanner reported that don't line up with any
+  expected ground-truth row.
+
+## Configuration
+
+| Property | Default | Purpose |
+|---|---|---|
+| `benchmark.output.dir` | `benchmarks` | Directory the JSON report is written to. |
+| `benchmark.dast.ground-truth.url` | `http://localhost:${server.port:9090}${server.servlet.context-path:/VulnerableApp}/scanner` | URL the DAST comparator fetches ground truth from. Override when running behind VulnerableApp-facade so coverage spans every backing app. |
+| `benchmark.sast.ground-truth.path` | `scanner/sast/expectedIssues.csv` | CSV file the SAST comparator loads expected issues from. |
+
+The default DAST URL is a self-call against the running app, which means
+benchmarking works out of the box in standalone mode. In a facade-composed
+deployment, point this at the facade's aggregated `/scanner/dast` endpoint so
+scanner findings are graded against the union of every backing app's ground
+truth.
 
 ## Where the report is written
 
@@ -182,13 +225,12 @@ via `benchmark.output.dir`. Filenames are lowercased and stripped of anything
 outside `[a-z0-9_-]`. Re-running the endpoint for the same tool (regardless of
 scan type) overwrites the previous report.
 
+If the file write fails (disk full, permissions, etc.), the endpoint returns
+**HTTP 500** with the same response body as a successful run, plus an extra
+`persistenceError` string describing the failure. Callers still get the
+computed metrics; the non-2xx status is the signal that the on-disk artifact
+was *not* created.
+
 ## Limitations (v1)
 
-- **LLM-based scanners are not yet supported.** There is no equivalent
-  ground-truth source for LLM scanners; we'd rather see real LLM scanner output
-  formats before committing to a matcher. Tracked as a follow-up.
-- DAST type matching is by enum name. CWE-based matching for DAST is a likely
-  follow-up.
-- HTTP method (DAST) is shown in the ground truth but is not part of the match
-  key — same URL + type with a different method still counts as detected.
 - SAST `Number of Sources` is not used for scoring; full credit on first match.

--- a/benchmarks/samples/semgrep-sast-sample.json
+++ b/benchmarks/samples/semgrep-sast-sample.json
@@ -1,0 +1,36 @@
+{
+  "tool": "Semgrep",
+  "scanType": "SAST",
+  "findings": [
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java",
+      "line": 56,
+      "cwe": "CWE-89",
+      "type": "SQL Injection"
+    },
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java",
+      "line": 68,
+      "cwe": "CWE-89",
+      "type": "SQL Injection"
+    },
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java",
+      "line": 45,
+      "cwe": "CWE-79",
+      "type": "Reflected XSS"
+    },
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/commandInjection/CommandInjection.java",
+      "line": 46,
+      "cwe": "CWE-77",
+      "type": "Command Injection"
+    },
+    {
+      "filePath": "src/main/java/org/sasanlabs/service/vulnerability/imaginary/Imaginary.java",
+      "line": 100,
+      "cwe": "CWE-9999",
+      "type": "Made Up Vulnerability"
+    }
+  ]
+}

--- a/benchmarks/samples/zap-findings-sample.json
+++ b/benchmarks/samples/zap-findings-sample.json
@@ -1,0 +1,11 @@
+{
+  "tool": "ZAP",
+  "findings": [
+    { "url": "/BlindSQLInjectionVulnerability/LEVEL_1",  "type": "BLIND_SQL_INJECTION" },
+    { "url": "/ErrorBasedSQLInjectionVulnerability/LEVEL_1", "type": "ERROR_BASED_SQL_INJECTION" },
+    { "url": "/XSSInImgTagAttribute/LEVEL_1",           "type": "REFLECTED_XSS" },
+    { "url": "/CommandInjection/LEVEL_1",               "type": "COMMAND_INJECTION" },
+    { "url": "/PathTraversal/LEVEL_1",                  "type": "PATH_TRAVERSAL" },
+    { "url": "/MadeUpVulnerability/LEVEL_1",            "type": "BLIND_SQL_INJECTION" }
+  ]
+}

--- a/benchmarks/samples/zap-findings-sample.json
+++ b/benchmarks/samples/zap-findings-sample.json
@@ -1,11 +1,11 @@
 {
   "tool": "ZAP",
   "findings": [
-    { "url": "/BlindSQLInjectionVulnerability/LEVEL_1",  "type": "BLIND_SQL_INJECTION" },
-    { "url": "/ErrorBasedSQLInjectionVulnerability/LEVEL_1", "type": "ERROR_BASED_SQL_INJECTION" },
-    { "url": "/XSSInImgTagAttribute/LEVEL_1",           "type": "REFLECTED_XSS" },
+    { "url": "/BlindSQLInjectionVulnerability/LEVEL_1",  "type": "BLIND_SQL_INJECTION", "method": "GET" },
+    { "url": "/ErrorBasedSQLInjectionVulnerability/LEVEL_1", "cwe": "CWE-89" },
+    { "url": "/XSSInImgTagAttribute/LEVEL_1",           "type": "Cross Site Scripting (Reflected)", "cwe": "79" },
     { "url": "/CommandInjection/LEVEL_1",               "type": "COMMAND_INJECTION" },
-    { "url": "/PathTraversal/LEVEL_1",                  "type": "PATH_TRAVERSAL" },
+    { "url": "/PathTraversal/LEVEL_1",                  "wascId": "33" },
     { "url": "/MadeUpVulnerability/LEVEL_1",            "type": "BLIND_SQL_INJECTION" }
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,9 @@ dependencies {
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
+
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-csv
+    implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.10.0'
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 

--- a/docs/HOW-TO-USE-VulnerableApp.md
+++ b/docs/HOW-TO-USE-VulnerableApp.md
@@ -54,6 +54,15 @@ method: Type of HTTP method for the endpoint like GET or POST
 vulnerabilityTypes: List of vulnerability types present in the endpoint to validate if scanner is fully finding all the vulnerabilities in an endpoint.
 ```
 Note: [VulnerabilityTypes](https://github.com/SasanLabs/VulnerableApp/blob/master/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java) are custom values as no single standard represent all the Vulnerabilities. However we are working on creating a mapping between VulnerabilityType and CWE/WASC.
+
+## Benchmarking your scanner
+VulnerableApp ships a comparator that grades a scanner's findings against the `/scanner` ground truth and writes a coverage / missed / false-positive report.
+- Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
+- Request body: tool-agnostic JSON of `{ tool, findings: [ { url, type } ] }`
+- Response body and `benchmarks/<tool>-results.json` on disk: coverage report
+
+Running the scanner itself is out of scope — you supply the JSON. See [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) for the full input/output schema, canonical vulnerability type vocabulary, and a `curl` example.
+
 ## Details about ExpectedIssues.csv
 [ExpectedIssues.csv](https://github.com/SasanLabs/VulnerableApp/blob/master/scanner/sast/expectedIssues.csv) contains following information which SAST tools can leverage:
 ```

--- a/docs/HOW-TO-USE-VulnerableApp.md
+++ b/docs/HOW-TO-USE-VulnerableApp.md
@@ -56,12 +56,14 @@ vulnerabilityTypes: List of vulnerability types present in the endpoint to valid
 Note: [VulnerabilityTypes](https://github.com/SasanLabs/VulnerableApp/blob/master/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java) are custom values as no single standard represent all the Vulnerabilities. However we are working on creating a mapping between VulnerabilityType and CWE/WASC.
 
 ## Benchmarking your scanner
-VulnerableApp ships a comparator that grades a scanner's findings against the `/scanner` ground truth and writes a coverage / missed / false-positive report.
+VulnerableApp ships a comparator that grades a scanner's findings against either ground-truth source above and writes a coverage / missed / false-positive report. Both DAST and SAST scanners are supported via the same endpoint:
 - Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
-- Request body: tool-agnostic JSON of `{ tool, findings: [ { url, type } ] }`
+- Request body — pick the shape that matches your scanner:
+   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type } ] }` (the `scanType` field is optional and defaults to `DAST`)
+   - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - Response body and `benchmarks/<tool>-results.json` on disk: coverage report
 
-Running the scanner itself is out of scope — you supply the JSON. See [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) for the full input/output schema, canonical vulnerability type vocabulary, and a `curl` example.
+Running the scanner itself is out of scope — you supply the JSON. See [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) for the full input/output schemas, matching rules, canonical vulnerability type vocabulary, and `curl` examples.
 
 ## Details about ExpectedIssues.csv
 [ExpectedIssues.csv](https://github.com/SasanLabs/VulnerableApp/blob/master/scanner/sast/expectedIssues.csv) contains following information which SAST tools can leverage:

--- a/docs/HOW-TO-USE-VulnerableApp.md
+++ b/docs/HOW-TO-USE-VulnerableApp.md
@@ -56,10 +56,10 @@ vulnerabilityTypes: List of vulnerability types present in the endpoint to valid
 Note: [VulnerabilityTypes](https://github.com/SasanLabs/VulnerableApp/blob/master/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java) are custom values as no single standard represent all the Vulnerabilities. However we are working on creating a mapping between VulnerabilityType and CWE/WASC.
 
 ## Benchmarking your scanner
-VulnerableApp ships a comparator that grades a scanner's findings against either ground-truth source above and writes a coverage / missed / false-positive report. Both DAST and SAST scanners are supported via the same endpoint:
+VulnerableApp ships a comparator that grades a scanner's findings against either ground-truth source above and writes a coverage / missed / unmatched report. Both DAST and SAST scanners are supported via the same endpoint:
 - Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - Request body — pick the shape that matches your scanner:
-   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type } ] }` (the `scanType` field is optional and defaults to `DAST`)
+   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (the `scanType` field is optional and defaults to `DAST`; `type` / `cwe` / `wascId` are individually optional — any one axis matching is enough)
    - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - Response body and `benchmarks/<tool>-results.json` on disk: coverage report
 

--- a/src/main/java/org/sasanlabs/beans/ScannerResponseBean.java
+++ b/src/main/java/org/sasanlabs/beans/ScannerResponseBean.java
@@ -45,6 +45,10 @@ public class ScannerResponseBean {
         return url;
     }
 
+    public String getVariant() {
+        return variant;
+    }
+
     public RequestMethod getRequestMethod() {
         return requestMethod;
     }

--- a/src/main/java/org/sasanlabs/benchmark/BenchmarkConfiguration.java
+++ b/src/main/java/org/sasanlabs/benchmark/BenchmarkConfiguration.java
@@ -1,5 +1,7 @@
 package org.sasanlabs.benchmark;
 
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +11,12 @@ import org.springframework.web.client.RestTemplate;
 public class BenchmarkConfiguration {
 
     @Bean
-    public RestTemplate benchmarkRestTemplate(RestTemplateBuilder builder) {
-        return builder.build();
+    public RestTemplate benchmarkRestTemplate(
+            RestTemplateBuilder builder,
+            @Value("${benchmark.dast.ground-truth.connect-timeout-ms:5000}") long connectMs,
+            @Value("${benchmark.dast.ground-truth.read-timeout-ms:10000}") long readMs) {
+        return builder.setConnectTimeout(Duration.ofMillis(connectMs))
+                .setReadTimeout(Duration.ofMillis(readMs))
+                .build();
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/BenchmarkConfiguration.java
+++ b/src/main/java/org/sasanlabs/benchmark/BenchmarkConfiguration.java
@@ -1,0 +1,15 @@
+package org.sasanlabs.benchmark;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BenchmarkConfiguration {
+
+    @Bean
+    public RestTemplate benchmarkRestTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
+++ b/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
@@ -1,0 +1,67 @@
+package org.sasanlabs.benchmark.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.benchmark.service.BenchmarkResultWriter;
+import org.sasanlabs.benchmark.service.BenchmarkService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST entry point for benchmarking a scanner's findings against VulnerableApp's DAST ground truth.
+ * Mounted alongside the existing {@code /scanner} and {@code /scanner/metadata} endpoints.
+ */
+@RestController
+public class BenchmarkController {
+
+    private static final Logger LOGGER = LogManager.getLogger(BenchmarkController.class);
+
+    private final BenchmarkService benchmarkService;
+    private final BenchmarkResultWriter benchmarkResultWriter;
+
+    public BenchmarkController(
+            BenchmarkService benchmarkService, BenchmarkResultWriter benchmarkResultWriter) {
+        this.benchmarkService = benchmarkService;
+        this.benchmarkResultWriter = benchmarkResultWriter;
+    }
+
+    @PostMapping("/scanner/benchmark")
+    public ResponseEntity<?> benchmark(@RequestBody ScannerFindings input)
+            throws JsonProcessingException, UnknownHostException {
+        if (input == null || input.getTool() == null || input.getTool().trim().isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Field 'tool' is required and must be non-empty"));
+        }
+        if (input.getFindings() == null) {
+            return ResponseEntity.badRequest()
+                    .body(
+                            Map.of(
+                                    "error",
+                                    "Field 'findings' is required (use [] for an empty list)"));
+        }
+
+        BenchmarkResult result = benchmarkService.compare(input);
+
+        try {
+            Path written = benchmarkResultWriter.write(result);
+            LOGGER.info("Wrote benchmark result for tool '{}' to {}", input.getTool(), written);
+        } catch (IOException ioe) {
+            LOGGER.error(
+                    "Failed to persist benchmark result for tool '{}'; returning result in"
+                            + " response body only",
+                    input.getTool(),
+                    ioe);
+        }
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
+++ b/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
@@ -1,8 +1,6 @@
 package org.sasanlabs.benchmark.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -35,8 +33,7 @@ public class BenchmarkController {
     }
 
     @PostMapping("/scanner/benchmark")
-    public ResponseEntity<?> benchmark(@RequestBody ScannerFindings input)
-            throws JsonProcessingException, UnknownHostException {
+    public ResponseEntity<?> benchmark(@RequestBody ScannerFindings input) throws IOException {
         if (input == null || input.getTool() == null || input.getTool().trim().isEmpty()) {
             return ResponseEntity.badRequest()
                     .body(Map.of("error", "Field 'tool' is required and must be non-empty"));

--- a/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
+++ b/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
@@ -9,6 +9,7 @@ import org.sasanlabs.benchmark.model.BenchmarkResult;
 import org.sasanlabs.benchmark.model.ScannerFindings;
 import org.sasanlabs.benchmark.service.BenchmarkResultWriter;
 import org.sasanlabs.benchmark.service.BenchmarkService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,10 +54,12 @@ public class BenchmarkController {
             LOGGER.info("Wrote benchmark result for tool '{}' to {}", input.getTool(), written);
         } catch (IOException ioe) {
             LOGGER.error(
-                    "Failed to persist benchmark result for tool '{}'; returning result in"
-                            + " response body only",
+                    "Failed to persist benchmark result for tool '{}'; returning 500 with result"
+                            + " in body",
                     input.getTool(),
                     ioe);
+            result.setPersistenceError("Failed to persist benchmark result: " + ioe.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
         }
 
         return ResponseEntity.ok(result);

--- a/src/main/java/org/sasanlabs/benchmark/model/BenchmarkResult.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/BenchmarkResult.java
@@ -1,0 +1,88 @@
+package org.sasanlabs.benchmark.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Result of comparing a scanner's findings against VulnerableApp's DAST ground truth.
+ *
+ * <p>{@code coverage} is detected / totalExpected as a percentage, or 0.0 when the ground truth is
+ * empty.
+ */
+public class BenchmarkResult {
+
+    @JsonProperty("tool")
+    private String tool;
+
+    @JsonProperty("coverage")
+    private double coverage;
+
+    @JsonProperty("totalExpected")
+    private int totalExpected;
+
+    @JsonProperty("detected")
+    private int detected;
+
+    @JsonProperty("missed")
+    private int missed;
+
+    @JsonProperty("falsePositives")
+    private int falsePositives;
+
+    @JsonProperty("missedItems")
+    private List<Finding> missedItems;
+
+    @JsonProperty("falsePositiveItems")
+    private List<Finding> falsePositiveItems;
+
+    public BenchmarkResult(
+            @JsonProperty("tool") String tool,
+            @JsonProperty("coverage") double coverage,
+            @JsonProperty("totalExpected") int totalExpected,
+            @JsonProperty("detected") int detected,
+            @JsonProperty("missed") int missed,
+            @JsonProperty("falsePositives") int falsePositives,
+            @JsonProperty("missedItems") List<Finding> missedItems,
+            @JsonProperty("falsePositiveItems") List<Finding> falsePositiveItems) {
+        this.tool = tool;
+        this.coverage = coverage;
+        this.totalExpected = totalExpected;
+        this.detected = detected;
+        this.missed = missed;
+        this.falsePositives = falsePositives;
+        this.missedItems = missedItems;
+        this.falsePositiveItems = falsePositiveItems;
+    }
+
+    public String getTool() {
+        return tool;
+    }
+
+    public double getCoverage() {
+        return coverage;
+    }
+
+    public int getTotalExpected() {
+        return totalExpected;
+    }
+
+    public int getDetected() {
+        return detected;
+    }
+
+    public int getMissed() {
+        return missed;
+    }
+
+    public int getFalsePositives() {
+        return falsePositives;
+    }
+
+    public List<Finding> getMissedItems() {
+        return missedItems;
+    }
+
+    public List<Finding> getFalsePositiveItems() {
+        return falsePositiveItems;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/model/BenchmarkResult.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/BenchmarkResult.java
@@ -1,5 +1,6 @@
 package org.sasanlabs.benchmark.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
@@ -26,14 +27,18 @@ public class BenchmarkResult {
     @JsonProperty("missed")
     private int missed;
 
-    @JsonProperty("falsePositives")
-    private int falsePositives;
+    @JsonProperty("unmatched")
+    private int unmatched;
 
     @JsonProperty("missedItems")
     private List<Finding> missedItems;
 
-    @JsonProperty("falsePositiveItems")
-    private List<Finding> falsePositiveItems;
+    @JsonProperty("unmatchedItems")
+    private List<Finding> unmatchedItems;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("persistenceError")
+    private String persistenceError;
 
     public BenchmarkResult(
             @JsonProperty("tool") String tool,
@@ -41,17 +46,17 @@ public class BenchmarkResult {
             @JsonProperty("totalExpected") int totalExpected,
             @JsonProperty("detected") int detected,
             @JsonProperty("missed") int missed,
-            @JsonProperty("falsePositives") int falsePositives,
+            @JsonProperty("unmatched") int unmatched,
             @JsonProperty("missedItems") List<Finding> missedItems,
-            @JsonProperty("falsePositiveItems") List<Finding> falsePositiveItems) {
+            @JsonProperty("unmatchedItems") List<Finding> unmatchedItems) {
         this.tool = tool;
         this.coverage = coverage;
         this.totalExpected = totalExpected;
         this.detected = detected;
         this.missed = missed;
-        this.falsePositives = falsePositives;
+        this.unmatched = unmatched;
         this.missedItems = missedItems;
-        this.falsePositiveItems = falsePositiveItems;
+        this.unmatchedItems = unmatchedItems;
     }
 
     public String getTool() {
@@ -74,15 +79,23 @@ public class BenchmarkResult {
         return missed;
     }
 
-    public int getFalsePositives() {
-        return falsePositives;
+    public int getUnmatched() {
+        return unmatched;
     }
 
     public List<Finding> getMissedItems() {
         return missedItems;
     }
 
-    public List<Finding> getFalsePositiveItems() {
-        return falsePositiveItems;
+    public List<Finding> getUnmatchedItems() {
+        return unmatchedItems;
+    }
+
+    public String getPersistenceError() {
+        return persistenceError;
+    }
+
+    public void setPersistenceError(String persistenceError) {
+        this.persistenceError = persistenceError;
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/model/ExpectedIssue.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/ExpectedIssue.java
@@ -1,0 +1,44 @@
+package org.sasanlabs.benchmark.model;
+
+/**
+ * One row of SAST ground truth — a known vulnerability site in VulnerableApp's source tree, as
+ * declared by {@code scanner/sast/expectedIssues.csv}. Used by the SAST benchmark strategy to
+ * compare scanner findings against expected issues.
+ */
+public class ExpectedIssue {
+
+    private final String cwe;
+    private final String vulnerabilityType;
+    private final String filePath;
+    private final int line;
+    private final int numberOfSources;
+
+    public ExpectedIssue(
+            String cwe, String vulnerabilityType, String filePath, int line, int numberOfSources) {
+        this.cwe = cwe;
+        this.vulnerabilityType = vulnerabilityType;
+        this.filePath = filePath;
+        this.line = line;
+        this.numberOfSources = numberOfSources;
+    }
+
+    public String getCwe() {
+        return cwe;
+    }
+
+    public String getVulnerabilityType() {
+        return vulnerabilityType;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public int getNumberOfSources() {
+        return numberOfSources;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/model/Finding.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/Finding.java
@@ -1,0 +1,30 @@
+package org.sasanlabs.benchmark.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A single scanner finding — a URL that the scanner believes carries a vulnerability of a given
+ * type. URLs may be relative (path-only) or absolute; the comparator normalises both sides before
+ * matching.
+ */
+public class Finding {
+
+    @JsonProperty("url")
+    private String url;
+
+    @JsonProperty("type")
+    private String type;
+
+    public Finding(@JsonProperty("url") String url, @JsonProperty("type") String type) {
+        this.url = url;
+        this.type = type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/model/Finding.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/Finding.java
@@ -1,12 +1,15 @@
 package org.sasanlabs.benchmark.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A single scanner finding — a URL that the scanner believes carries a vulnerability of a given
- * type. URLs may be relative (path-only) or absolute; the comparator normalises both sides before
- * matching.
+ * A single scanner finding. DAST findings populate {@code url} + {@code type}; SAST findings
+ * populate {@code filePath} + {@code line} + {@code type} (and optionally {@code cwe}). Unused
+ * fields are omitted from the serialised output.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Finding {
 
     @JsonProperty("url")
@@ -15,9 +18,31 @@ public class Finding {
     @JsonProperty("type")
     private String type;
 
-    public Finding(@JsonProperty("url") String url, @JsonProperty("type") String type) {
+    @JsonProperty("filePath")
+    private String filePath;
+
+    @JsonProperty("line")
+    private Integer line;
+
+    @JsonProperty("cwe")
+    private String cwe;
+
+    @JsonCreator
+    public Finding(
+            @JsonProperty("url") String url,
+            @JsonProperty("type") String type,
+            @JsonProperty("filePath") String filePath,
+            @JsonProperty("line") Integer line,
+            @JsonProperty("cwe") String cwe) {
         this.url = url;
         this.type = type;
+        this.filePath = filePath;
+        this.line = line;
+        this.cwe = cwe;
+    }
+
+    public Finding(String url, String type) {
+        this(url, type, null, null, null);
     }
 
     public String getUrl() {
@@ -26,5 +51,17 @@ public class Finding {
 
     public String getType() {
         return type;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public Integer getLine() {
+        return line;
+    }
+
+    public String getCwe() {
+        return cwe;
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/model/Finding.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/Finding.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A single scanner finding. DAST findings populate {@code url} + {@code type}; SAST findings
+ * A single scanner finding. DAST findings populate {@code url} + {@code type} (and optionally
+ * {@code method} / {@code cwe} / {@code wascId} for taxonomy-tolerant matching); SAST findings
  * populate {@code filePath} + {@code line} + {@code type} (and optionally {@code cwe}). Unused
  * fields are omitted from the serialised output.
  */
@@ -27,22 +28,41 @@ public class Finding {
     @JsonProperty("cwe")
     private String cwe;
 
+    @JsonProperty("wascId")
+    private String wascId;
+
+    @JsonProperty("method")
+    private String method;
+
     @JsonCreator
     public Finding(
             @JsonProperty("url") String url,
             @JsonProperty("type") String type,
             @JsonProperty("filePath") String filePath,
             @JsonProperty("line") Integer line,
-            @JsonProperty("cwe") String cwe) {
+            @JsonProperty("cwe") String cwe,
+            @JsonProperty("wascId") String wascId,
+            @JsonProperty("method") String method) {
         this.url = url;
         this.type = type;
         this.filePath = filePath;
         this.line = line;
         this.cwe = cwe;
+        this.wascId = wascId;
+        this.method = method;
+    }
+
+    public Finding(
+            String url, String type, String filePath, Integer line, String cwe, String wascId) {
+        this(url, type, filePath, line, cwe, wascId, null);
+    }
+
+    public Finding(String url, String type, String filePath, Integer line, String cwe) {
+        this(url, type, filePath, line, cwe, null, null);
     }
 
     public Finding(String url, String type) {
-        this(url, type, null, null, null);
+        this(url, type, null, null, null, null, null);
     }
 
     public String getUrl() {
@@ -63,5 +83,13 @@ public class Finding {
 
     public String getCwe() {
         return cwe;
+    }
+
+    public String getWascId() {
+        return wascId;
+    }
+
+    public String getMethod() {
+        return method;
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/model/ScanType.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/ScanType.java
@@ -1,0 +1,21 @@
+package org.sasanlabs.benchmark.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Locale;
+
+/**
+ * The kind of scanner whose findings are being benchmarked. Each value selects a different
+ * ground-truth source and matching strategy in the benchmark service.
+ */
+public enum ScanType {
+    DAST,
+    SAST;
+
+    @JsonCreator
+    public static ScanType fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+        return ScanType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/model/ScannerFindings.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/ScannerFindings.java
@@ -1,25 +1,45 @@
 package org.sasanlabs.benchmark.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-/** Tool-agnostic input payload for the benchmark endpoint. */
+/**
+ * Tool-agnostic input payload for the benchmark endpoint. {@code scanType} selects which benchmark
+ * strategy runs — defaults to {@link ScanType#DAST} when omitted, preserving the original DAST-only
+ * request shape.
+ */
 public class ScannerFindings {
 
     @JsonProperty("tool")
     private String tool;
 
+    @JsonProperty("scanType")
+    private ScanType scanType;
+
     @JsonProperty("findings")
     private List<Finding> findings;
 
+    @JsonCreator
     public ScannerFindings(
-            @JsonProperty("tool") String tool, @JsonProperty("findings") List<Finding> findings) {
+            @JsonProperty("tool") String tool,
+            @JsonProperty("scanType") ScanType scanType,
+            @JsonProperty("findings") List<Finding> findings) {
         this.tool = tool;
+        this.scanType = (scanType != null) ? scanType : ScanType.DAST;
         this.findings = findings;
+    }
+
+    public ScannerFindings(String tool, List<Finding> findings) {
+        this(tool, null, findings);
     }
 
     public String getTool() {
         return tool;
+    }
+
+    public ScanType getScanType() {
+        return scanType;
     }
 
     public List<Finding> getFindings() {

--- a/src/main/java/org/sasanlabs/benchmark/model/ScannerFindings.java
+++ b/src/main/java/org/sasanlabs/benchmark/model/ScannerFindings.java
@@ -1,0 +1,28 @@
+package org.sasanlabs.benchmark.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Tool-agnostic input payload for the benchmark endpoint. */
+public class ScannerFindings {
+
+    @JsonProperty("tool")
+    private String tool;
+
+    @JsonProperty("findings")
+    private List<Finding> findings;
+
+    public ScannerFindings(
+            @JsonProperty("tool") String tool, @JsonProperty("findings") List<Finding> findings) {
+        this.tool = tool;
+        this.findings = findings;
+    }
+
+    public String getTool() {
+        return tool;
+    }
+
+    public List<Finding> getFindings() {
+        return findings;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
@@ -3,9 +3,11 @@ package org.sasanlabs.benchmark.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 import org.sasanlabs.benchmark.model.BenchmarkResult;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,8 +40,27 @@ public class BenchmarkResultWriter {
         Files.createDirectories(dir);
         String fileName = sanitizeToolName(result.getTool()) + "-results.json";
         Path target = dir.resolve(fileName);
-        OBJECT_MAPPER.writeValue(target.toFile(), result);
+        Path temp = Files.createTempFile(dir, fileName + ".", ".tmp");
+        try {
+            OBJECT_MAPPER.writeValue(temp.toFile(), result);
+            moveAtomicallyOrReplace(temp, target);
+        } catch (IOException ioe) {
+            Files.deleteIfExists(temp);
+            throw ioe;
+        }
         return target;
+    }
+
+    private static void moveAtomicallyOrReplace(Path source, Path target) throws IOException {
+        try {
+            Files.move(
+                    source,
+                    target,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException notSupported) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 
     static String sanitizeToolName(String tool) {

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
@@ -1,0 +1,53 @@
+package org.sasanlabs.benchmark.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Persists a {@link BenchmarkResult} to a JSON file under the configured benchmarks directory.
+ * Filename is derived from the (sanitised) tool name; existing files are overwritten so callers
+ * always see the latest run for a given tool.
+ */
+@Component
+public class BenchmarkResultWriter {
+
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    private final String defaultBenchmarksDir;
+
+    public BenchmarkResultWriter(
+            @Value("${benchmark.output.dir:benchmarks}") String defaultBenchmarksDir) {
+        this.defaultBenchmarksDir = defaultBenchmarksDir;
+    }
+
+    public Path write(BenchmarkResult result) throws IOException {
+        return write(result, defaultBenchmarksDir);
+    }
+
+    public Path write(BenchmarkResult result, String benchmarksDir) throws IOException {
+        Path dir = Paths.get(benchmarksDir);
+        Files.createDirectories(dir);
+        String fileName = sanitizeToolName(result.getTool()) + "-results.json";
+        Path target = dir.resolve(fileName);
+        OBJECT_MAPPER.writeValue(target.toFile(), result);
+        return target;
+    }
+
+    static String sanitizeToolName(String tool) {
+        if (tool == null) {
+            return "unknown";
+        }
+        String lowered = tool.trim().toLowerCase(Locale.ROOT);
+        String cleaned = lowered.replaceAll("[^a-z0-9_-]", "");
+        return cleaned.isEmpty() ? "unknown" : cleaned;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
@@ -62,12 +62,20 @@ public class BenchmarkResultWriter {
         }
     }
 
+    private static final int MAX_TOOL_LENGTH = 64;
+
     static String sanitizeToolName(String tool) {
         if (tool == null) {
             return "unknown";
         }
         String lowered = tool.trim().toLowerCase(Locale.ROOT);
         String cleaned = lowered.replaceAll("[^a-z0-9_-]", "");
-        return cleaned.isEmpty() ? "unknown" : cleaned;
+        if (cleaned.isEmpty()) {
+            return "unknown";
+        }
+        if (cleaned.length() > MAX_TOOL_LENGTH) {
+            cleaned = cleaned.substring(0, MAX_TOOL_LENGTH);
+        }
+        return cleaned;
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkResultWriter.java
@@ -1,7 +1,6 @@
 package org.sasanlabs.benchmark.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
@@ -21,13 +20,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class BenchmarkResultWriter {
 
-    private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
-
+    private final ObjectMapper objectMapper;
     private final String defaultBenchmarksDir;
 
     public BenchmarkResultWriter(
+            ObjectMapper objectMapper,
             @Value("${benchmark.output.dir:benchmarks}") String defaultBenchmarksDir) {
+        this.objectMapper = objectMapper;
         this.defaultBenchmarksDir = defaultBenchmarksDir;
     }
 
@@ -42,7 +41,7 @@ public class BenchmarkResultWriter {
         Path target = dir.resolve(fileName);
         Path temp = Files.createTempFile(dir, fileName + ".", ".tmp");
         try {
-            OBJECT_MAPPER.writeValue(temp.toFile(), result);
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(temp.toFile(), result);
             moveAtomicallyOrReplace(temp, target);
         } catch (IOException ioe) {
             Files.deleteIfExists(temp);

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkService.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkService.java
@@ -1,167 +1,36 @@
 package org.sasanlabs.benchmark.service;
 
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.sasanlabs.beans.ScannerResponseBean;
+import java.io.IOException;
 import org.sasanlabs.benchmark.model.BenchmarkResult;
-import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScanType;
 import org.sasanlabs.benchmark.model.ScannerFindings;
-import org.sasanlabs.service.IEndPointsInformationProvider;
-import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.stereotype.Service;
 
 /**
- * Compares a scanner's findings against VulnerableApp's DAST ground truth (the {@code /scanner}
- * endpoint's data) and produces coverage / missed / false-positive metrics.
- *
- * <p>Matching is set-based on a key of {@code normalizedUrl + "::" + uppercaseType}. URLs are
- * normalised to a context-path-stripped path; types are matched case-insensitively against {@link
- * VulnerabilityType} names. Only {@code UNSECURE} ground-truth entries count toward expected — a
- * scanner finding against a {@code SECURE} URL is treated as a false positive.
+ * Entry point for the scanner-benchmark API. Dispatches to a {@link BenchmarkStrategy}
+ * implementation based on the {@link ScanType} of the incoming request.
  */
 @Service
 public class BenchmarkService {
 
-    private static final Logger LOGGER = LogManager.getLogger(BenchmarkService.class);
+    private final DastBenchmarkStrategy dastStrategy;
+    private final SastBenchmarkStrategy sastStrategy;
 
-    private static final String CONTEXT_PATH = "/VulnerableApp";
-    private static final String UNSECURE_VARIANT = "UNSECURE";
-    private static final String KEY_SEPARATOR = "::";
-
-    private final IEndPointsInformationProvider endPointsInformationProvider;
-
-    public BenchmarkService(IEndPointsInformationProvider endPointsInformationProvider) {
-        this.endPointsInformationProvider = endPointsInformationProvider;
+    public BenchmarkService(
+            DastBenchmarkStrategy dastStrategy, SastBenchmarkStrategy sastStrategy) {
+        this.dastStrategy = dastStrategy;
+        this.sastStrategy = sastStrategy;
     }
 
-    public BenchmarkResult compare(ScannerFindings input)
-            throws com.fasterxml.jackson.core.JsonProcessingException, UnknownHostException {
-        List<ScannerResponseBean> groundTruth =
-                endPointsInformationProvider.getScannerRelatedEndPointInformation();
-
-        Map<String, Finding> expectedByKey = buildExpectedIndex(groundTruth);
-        Map<String, Finding> foundByKey = buildFoundIndex(input.getFindings());
-
-        Set<String> detectedKeys = new LinkedHashSet<>(expectedByKey.keySet());
-        detectedKeys.retainAll(foundByKey.keySet());
-
-        List<Finding> missedItems = new ArrayList<>();
-        for (Map.Entry<String, Finding> entry : expectedByKey.entrySet()) {
-            if (!foundByKey.containsKey(entry.getKey())) {
-                missedItems.add(entry.getValue());
-            }
+    public BenchmarkResult compare(ScannerFindings input) throws IOException {
+        ScanType scanType = input.getScanType() != null ? input.getScanType() : ScanType.DAST;
+        switch (scanType) {
+            case DAST:
+                return dastStrategy.compare(input);
+            case SAST:
+                return sastStrategy.compare(input);
+            default:
+                throw new IllegalArgumentException("Unsupported scan type: " + scanType);
         }
-
-        List<Finding> falsePositiveItems = new ArrayList<>();
-        for (Map.Entry<String, Finding> entry : foundByKey.entrySet()) {
-            if (!expectedByKey.containsKey(entry.getKey())) {
-                falsePositiveItems.add(entry.getValue());
-            }
-        }
-
-        int totalExpected = expectedByKey.size();
-        int detected = detectedKeys.size();
-        double coverage;
-        if (totalExpected == 0) {
-            LOGGER.warn(
-                    "Ground truth is empty; coverage cannot be computed and will be reported as"
-                            + " 0.0");
-            coverage = 0.0;
-        } else {
-            coverage = detected * 100.0 / totalExpected;
-        }
-
-        return new BenchmarkResult(
-                input.getTool(),
-                coverage,
-                totalExpected,
-                detected,
-                missedItems.size(),
-                falsePositiveItems.size(),
-                missedItems,
-                falsePositiveItems);
-    }
-
-    private Map<String, Finding> buildExpectedIndex(List<ScannerResponseBean> groundTruth) {
-        Map<String, Finding> index = new LinkedHashMap<>();
-        for (ScannerResponseBean entry : groundTruth) {
-            if (!UNSECURE_VARIANT.equalsIgnoreCase(entry.getVariant())) {
-                continue;
-            }
-            String normalizedUrl = normalizeUrl(entry.getUrl());
-            List<VulnerabilityType> types = entry.getVulnerabilityTypes();
-            if (types == null) {
-                continue;
-            }
-            for (VulnerabilityType type : types) {
-                String key = normalizedUrl + KEY_SEPARATOR + type.name();
-                index.putIfAbsent(key, new Finding(normalizedUrl, type.name()));
-            }
-        }
-        return index;
-    }
-
-    private Map<String, Finding> buildFoundIndex(List<Finding> findings) {
-        if (findings == null || findings.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        Map<String, Finding> index = new LinkedHashMap<>();
-        for (Finding finding : findings) {
-            if (finding == null || finding.getUrl() == null || finding.getType() == null) {
-                continue;
-            }
-            String normalizedUrl = normalizeUrl(finding.getUrl());
-            String normalizedType = finding.getType().trim().toUpperCase(Locale.ROOT);
-            String key = normalizedUrl + KEY_SEPARATOR + normalizedType;
-            index.putIfAbsent(key, new Finding(normalizedUrl, normalizedType));
-        }
-        return index;
-    }
-
-    /**
-     * Normalises a URL to a context-path-stripped path so absolute ground-truth URLs and relative
-     * scanner-finding URLs compare equal.
-     *
-     * <p>Strips scheme + host + port, the {@code /VulnerableApp} context path, the query string,
-     * and a trailing slash. Leaves the path case unchanged.
-     */
-    static String normalizeUrl(String url) {
-        if (url == null) {
-            return "";
-        }
-        String s = url.trim();
-        int schemeIdx = s.indexOf("://");
-        if (schemeIdx >= 0) {
-            int pathIdx = s.indexOf('/', schemeIdx + 3);
-            s = (pathIdx >= 0) ? s.substring(pathIdx) : "/";
-        }
-        int queryIdx = s.indexOf('?');
-        if (queryIdx >= 0) {
-            s = s.substring(0, queryIdx);
-        }
-        if (s.equals(CONTEXT_PATH)) {
-            s = "/";
-        } else if (s.startsWith(CONTEXT_PATH + "/")) {
-            s = s.substring(CONTEXT_PATH.length());
-        }
-        if (s.length() > 1 && s.endsWith("/")) {
-            s = s.substring(0, s.length() - 1);
-        }
-        if (s.isEmpty()) {
-            return "/";
-        }
-        if (!s.startsWith("/")) {
-            s = "/" + s;
-        }
-        return s;
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkService.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkService.java
@@ -1,0 +1,167 @@
+package org.sasanlabs.benchmark.service;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.beans.ScannerResponseBean;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.service.IEndPointsInformationProvider;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.stereotype.Service;
+
+/**
+ * Compares a scanner's findings against VulnerableApp's DAST ground truth (the {@code /scanner}
+ * endpoint's data) and produces coverage / missed / false-positive metrics.
+ *
+ * <p>Matching is set-based on a key of {@code normalizedUrl + "::" + uppercaseType}. URLs are
+ * normalised to a context-path-stripped path; types are matched case-insensitively against {@link
+ * VulnerabilityType} names. Only {@code UNSECURE} ground-truth entries count toward expected — a
+ * scanner finding against a {@code SECURE} URL is treated as a false positive.
+ */
+@Service
+public class BenchmarkService {
+
+    private static final Logger LOGGER = LogManager.getLogger(BenchmarkService.class);
+
+    private static final String CONTEXT_PATH = "/VulnerableApp";
+    private static final String UNSECURE_VARIANT = "UNSECURE";
+    private static final String KEY_SEPARATOR = "::";
+
+    private final IEndPointsInformationProvider endPointsInformationProvider;
+
+    public BenchmarkService(IEndPointsInformationProvider endPointsInformationProvider) {
+        this.endPointsInformationProvider = endPointsInformationProvider;
+    }
+
+    public BenchmarkResult compare(ScannerFindings input)
+            throws com.fasterxml.jackson.core.JsonProcessingException, UnknownHostException {
+        List<ScannerResponseBean> groundTruth =
+                endPointsInformationProvider.getScannerRelatedEndPointInformation();
+
+        Map<String, Finding> expectedByKey = buildExpectedIndex(groundTruth);
+        Map<String, Finding> foundByKey = buildFoundIndex(input.getFindings());
+
+        Set<String> detectedKeys = new LinkedHashSet<>(expectedByKey.keySet());
+        detectedKeys.retainAll(foundByKey.keySet());
+
+        List<Finding> missedItems = new ArrayList<>();
+        for (Map.Entry<String, Finding> entry : expectedByKey.entrySet()) {
+            if (!foundByKey.containsKey(entry.getKey())) {
+                missedItems.add(entry.getValue());
+            }
+        }
+
+        List<Finding> falsePositiveItems = new ArrayList<>();
+        for (Map.Entry<String, Finding> entry : foundByKey.entrySet()) {
+            if (!expectedByKey.containsKey(entry.getKey())) {
+                falsePositiveItems.add(entry.getValue());
+            }
+        }
+
+        int totalExpected = expectedByKey.size();
+        int detected = detectedKeys.size();
+        double coverage;
+        if (totalExpected == 0) {
+            LOGGER.warn(
+                    "Ground truth is empty; coverage cannot be computed and will be reported as"
+                            + " 0.0");
+            coverage = 0.0;
+        } else {
+            coverage = detected * 100.0 / totalExpected;
+        }
+
+        return new BenchmarkResult(
+                input.getTool(),
+                coverage,
+                totalExpected,
+                detected,
+                missedItems.size(),
+                falsePositiveItems.size(),
+                missedItems,
+                falsePositiveItems);
+    }
+
+    private Map<String, Finding> buildExpectedIndex(List<ScannerResponseBean> groundTruth) {
+        Map<String, Finding> index = new LinkedHashMap<>();
+        for (ScannerResponseBean entry : groundTruth) {
+            if (!UNSECURE_VARIANT.equalsIgnoreCase(entry.getVariant())) {
+                continue;
+            }
+            String normalizedUrl = normalizeUrl(entry.getUrl());
+            List<VulnerabilityType> types = entry.getVulnerabilityTypes();
+            if (types == null) {
+                continue;
+            }
+            for (VulnerabilityType type : types) {
+                String key = normalizedUrl + KEY_SEPARATOR + type.name();
+                index.putIfAbsent(key, new Finding(normalizedUrl, type.name()));
+            }
+        }
+        return index;
+    }
+
+    private Map<String, Finding> buildFoundIndex(List<Finding> findings) {
+        if (findings == null || findings.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Finding> index = new LinkedHashMap<>();
+        for (Finding finding : findings) {
+            if (finding == null || finding.getUrl() == null || finding.getType() == null) {
+                continue;
+            }
+            String normalizedUrl = normalizeUrl(finding.getUrl());
+            String normalizedType = finding.getType().trim().toUpperCase(Locale.ROOT);
+            String key = normalizedUrl + KEY_SEPARATOR + normalizedType;
+            index.putIfAbsent(key, new Finding(normalizedUrl, normalizedType));
+        }
+        return index;
+    }
+
+    /**
+     * Normalises a URL to a context-path-stripped path so absolute ground-truth URLs and relative
+     * scanner-finding URLs compare equal.
+     *
+     * <p>Strips scheme + host + port, the {@code /VulnerableApp} context path, the query string,
+     * and a trailing slash. Leaves the path case unchanged.
+     */
+    static String normalizeUrl(String url) {
+        if (url == null) {
+            return "";
+        }
+        String s = url.trim();
+        int schemeIdx = s.indexOf("://");
+        if (schemeIdx >= 0) {
+            int pathIdx = s.indexOf('/', schemeIdx + 3);
+            s = (pathIdx >= 0) ? s.substring(pathIdx) : "/";
+        }
+        int queryIdx = s.indexOf('?');
+        if (queryIdx >= 0) {
+            s = s.substring(0, queryIdx);
+        }
+        if (s.equals(CONTEXT_PATH)) {
+            s = "/";
+        } else if (s.startsWith(CONTEXT_PATH + "/")) {
+            s = s.substring(CONTEXT_PATH.length());
+        }
+        if (s.length() > 1 && s.endsWith("/")) {
+            s = s.substring(0, s.length() - 1);
+        }
+        if (s.isEmpty()) {
+            return "/";
+        }
+        if (!s.startsWith("/")) {
+            s = "/" + s;
+        }
+        return s;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkStrategy.java
@@ -1,0 +1,15 @@
+package org.sasanlabs.benchmark.service;
+
+import java.io.IOException;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+
+/**
+ * Compares a scanner's findings against a specific kind of ground truth (e.g. DAST endpoints, SAST
+ * source-level expected issues) and produces coverage / missed / false-positive metrics. Each
+ * implementation owns its ground-truth source and matching rules for one scan type.
+ */
+public interface BenchmarkStrategy {
+
+    BenchmarkResult compare(ScannerFindings input) throws IOException;
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/BenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/BenchmarkStrategy.java
@@ -6,7 +6,7 @@ import org.sasanlabs.benchmark.model.ScannerFindings;
 
 /**
  * Compares a scanner's findings against a specific kind of ground truth (e.g. DAST endpoints, SAST
- * source-level expected issues) and produces coverage / missed / false-positive metrics. Each
+ * source-level expected issues) and produces coverage / missed / unmatched metrics. Each
  * implementation owns its ground-truth source and matching rules for one scan type.
  */
 public interface BenchmarkStrategy {

--- a/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
@@ -1,0 +1,89 @@
+package org.sasanlabs.benchmark.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.benchmark.model.ExpectedIssue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads SAST ground truth from a CSV file with columns {@code CWE, Vulnerability Type, File, Line,
+ * Number of Sources}. The default path points at {@code scanner/sast/expectedIssues.csv} in the
+ * project root; override via the {@code benchmark.sast.ground-truth.path} property.
+ *
+ * <p>The first line is treated as a header and skipped. Blank lines and rows that fail to parse
+ * (wrong column count, non-integer line/sources) are logged and skipped — one bad row should not
+ * abort an entire benchmark run.
+ */
+@Component
+public class CsvExpectedIssuesProvider implements IExpectedIssuesProvider {
+
+    private static final Logger LOGGER = LogManager.getLogger(CsvExpectedIssuesProvider.class);
+
+    private static final int EXPECTED_COLUMNS = 5;
+
+    private final String csvPath;
+
+    public CsvExpectedIssuesProvider(
+            @Value("${benchmark.sast.ground-truth.path:scanner/sast/expectedIssues.csv}")
+                    String csvPath) {
+        this.csvPath = csvPath;
+    }
+
+    @Override
+    public List<ExpectedIssue> getExpectedIssues() throws IOException {
+        Path path = Paths.get(csvPath);
+        List<ExpectedIssue> issues = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            String raw;
+            int lineNo = 0;
+            while ((raw = reader.readLine()) != null) {
+                lineNo++;
+                if (lineNo == 1) {
+                    continue;
+                }
+                String trimmed = raw.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                String[] cols = trimmed.split(",", -1);
+                if (cols.length < EXPECTED_COLUMNS) {
+                    LOGGER.warn(
+                            "Skipping malformed SAST CSV row at line {} of {}: expected {}"
+                                    + " columns, got {}",
+                            lineNo,
+                            csvPath,
+                            EXPECTED_COLUMNS,
+                            cols.length);
+                    continue;
+                }
+                try {
+                    issues.add(
+                            new ExpectedIssue(
+                                    cols[0].trim(),
+                                    cols[1].trim(),
+                                    cols[2].trim(),
+                                    Integer.parseInt(cols[3].trim()),
+                                    Integer.parseInt(cols[4].trim())));
+                } catch (NumberFormatException nfe) {
+                    LOGGER.warn(
+                            "Skipping SAST CSV row at line {} of {}: non-integer line or sources"
+                                    + " column ({})",
+                            lineNo,
+                            csvPath,
+                            nfe.getMessage());
+                }
+            }
+        }
+        LOGGER.info("Loaded {} expected SAST issues from {}", issues.size(), csvPath);
+        return issues;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
@@ -1,13 +1,16 @@
 package org.sasanlabs.benchmark.service;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sasanlabs.benchmark.model.ExpectedIssue;
@@ -15,20 +18,33 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Loads SAST ground truth from a CSV file with columns {@code CWE, Vulnerability Type, File, Line,
- * Number of Sources}. The default path points at {@code scanner/sast/expectedIssues.csv} in the
- * project root; override via the {@code benchmark.sast.ground-truth.path} property.
+ * Loads SAST ground truth from a CSV file with header columns {@code CWE}, {@code Vulnerability
+ * Type}, {@code File}, {@code Line}, {@code Number of Sources}. The default path points at {@code
+ * scanner/sast/expectedIssues.csv} in the project root; override via the {@code
+ * benchmark.sast.ground-truth.path} property.
  *
- * <p>The first line is treated as a header and skipped. Blank lines and rows that fail to parse
- * (wrong column count, non-integer line/sources) are logged and skipped — one bad row should not
- * abort an entire benchmark run.
+ * <p>Rows that fail to parse (missing columns, non-integer line / sources) are logged and skipped —
+ * one bad row should not abort an entire benchmark run.
  */
 @Component
 public class CsvExpectedIssuesProvider implements IExpectedIssuesProvider {
 
     private static final Logger LOGGER = LogManager.getLogger(CsvExpectedIssuesProvider.class);
 
-    private static final int EXPECTED_COLUMNS = 5;
+    private static final String COL_CWE = "CWE";
+    private static final String COL_TYPE = "Vulnerability Type";
+    private static final String COL_FILE = "File";
+    private static final String COL_LINE = "Line";
+    private static final String COL_SOURCES = "Number of Sources";
+
+    private static final CSVFormat FORMAT =
+            CSVFormat.DEFAULT
+                    .builder()
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .setIgnoreEmptyLines(true)
+                    .setTrim(true)
+                    .build();
 
     private final String csvPath;
 
@@ -42,48 +58,42 @@ public class CsvExpectedIssuesProvider implements IExpectedIssuesProvider {
     public List<ExpectedIssue> getExpectedIssues() throws IOException {
         Path path = Paths.get(csvPath);
         List<ExpectedIssue> issues = new ArrayList<>();
-        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            String raw;
-            int lineNo = 0;
-            while ((raw = reader.readLine()) != null) {
-                lineNo++;
-                if (lineNo == 1) {
-                    continue;
-                }
-                String trimmed = raw.trim();
-                if (trimmed.isEmpty()) {
-                    continue;
-                }
-                String[] cols = trimmed.split(",", -1);
-                if (cols.length < EXPECTED_COLUMNS) {
-                    LOGGER.warn(
-                            "Skipping malformed SAST CSV row at line {} of {}: expected {}"
-                                    + " columns, got {}",
-                            lineNo,
-                            csvPath,
-                            EXPECTED_COLUMNS,
-                            cols.length);
-                    continue;
-                }
-                try {
-                    issues.add(
-                            new ExpectedIssue(
-                                    cols[0].trim(),
-                                    cols[1].trim(),
-                                    cols[2].trim(),
-                                    Integer.parseInt(cols[3].trim()),
-                                    Integer.parseInt(cols[4].trim())));
-                } catch (NumberFormatException nfe) {
-                    LOGGER.warn(
-                            "Skipping SAST CSV row at line {} of {}: non-integer line or sources"
-                                    + " column ({})",
-                            lineNo,
-                            csvPath,
-                            nfe.getMessage());
+        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8);
+                CSVParser parser = FORMAT.parse(reader)) {
+            for (CSVRecord row : parser) {
+                ExpectedIssue issue = parseRow(row);
+                if (issue != null) {
+                    issues.add(issue);
                 }
             }
         }
         LOGGER.info("Loaded {} expected SAST issues from {}", issues.size(), csvPath);
         return issues;
+    }
+
+    private ExpectedIssue parseRow(CSVRecord row) {
+        if (!row.isMapped(COL_CWE) || !row.isSet(COL_LINE) || !row.isSet(COL_SOURCES)) {
+            LOGGER.warn(
+                    "Skipping malformed SAST CSV row at line {} of {}: missing required columns",
+                    row.getRecordNumber(),
+                    csvPath);
+            return null;
+        }
+        try {
+            return new ExpectedIssue(
+                    row.get(COL_CWE),
+                    row.get(COL_TYPE),
+                    row.get(COL_FILE),
+                    Integer.parseInt(row.get(COL_LINE)),
+                    Integer.parseInt(row.get(COL_SOURCES)));
+        } catch (NumberFormatException nfe) {
+            LOGGER.warn(
+                    "Skipping SAST CSV row at line {} of {}: non-integer line or sources column"
+                            + " ({})",
+                    row.getRecordNumber(),
+                    csvPath,
+                    nfe.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProvider.java
@@ -72,7 +72,11 @@ public class CsvExpectedIssuesProvider implements IExpectedIssuesProvider {
     }
 
     private ExpectedIssue parseRow(CSVRecord row) {
-        if (!row.isMapped(COL_CWE) || !row.isSet(COL_LINE) || !row.isSet(COL_SOURCES)) {
+        if (!row.isSet(COL_CWE)
+                || !row.isSet(COL_TYPE)
+                || !row.isSet(COL_FILE)
+                || !row.isSet(COL_LINE)
+                || !row.isSet(COL_SOURCES)) {
             LOGGER.warn(
                     "Skipping malformed SAST CSV row at line {} of {}: missing required columns",
                     row.getRecordNumber(),

--- a/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
@@ -1,0 +1,167 @@
+package org.sasanlabs.benchmark.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.beans.ScannerResponseBean;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.service.IEndPointsInformationProvider;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.stereotype.Service;
+
+/**
+ * Compares scanner findings against VulnerableApp's DAST ground truth (the {@code /scanner}
+ * endpoint's data) and produces coverage / missed / false-positive metrics.
+ *
+ * <p>Matching is set-based on a key of {@code normalizedUrl + "::" + uppercaseType}. URLs are
+ * normalised to a context-path-stripped path; types are matched case-insensitively against {@link
+ * VulnerabilityType} names. Only {@code UNSECURE} ground-truth entries count toward expected — a
+ * scanner finding against a {@code SECURE} URL is treated as a false positive.
+ */
+@Service
+public class DastBenchmarkStrategy implements BenchmarkStrategy {
+
+    private static final Logger LOGGER = LogManager.getLogger(DastBenchmarkStrategy.class);
+
+    private static final String CONTEXT_PATH = "/VulnerableApp";
+    private static final String UNSECURE_VARIANT = "UNSECURE";
+    private static final String KEY_SEPARATOR = "::";
+
+    private final IEndPointsInformationProvider endPointsInformationProvider;
+
+    public DastBenchmarkStrategy(IEndPointsInformationProvider endPointsInformationProvider) {
+        this.endPointsInformationProvider = endPointsInformationProvider;
+    }
+
+    @Override
+    public BenchmarkResult compare(ScannerFindings input) throws IOException {
+        List<ScannerResponseBean> groundTruth =
+                endPointsInformationProvider.getScannerRelatedEndPointInformation();
+
+        Map<String, Finding> expectedByKey = buildExpectedIndex(groundTruth);
+        Map<String, Finding> foundByKey = buildFoundIndex(input.getFindings());
+
+        Set<String> detectedKeys = new LinkedHashSet<>(expectedByKey.keySet());
+        detectedKeys.retainAll(foundByKey.keySet());
+
+        List<Finding> missedItems = new ArrayList<>();
+        for (Map.Entry<String, Finding> entry : expectedByKey.entrySet()) {
+            if (!foundByKey.containsKey(entry.getKey())) {
+                missedItems.add(entry.getValue());
+            }
+        }
+
+        List<Finding> falsePositiveItems = new ArrayList<>();
+        for (Map.Entry<String, Finding> entry : foundByKey.entrySet()) {
+            if (!expectedByKey.containsKey(entry.getKey())) {
+                falsePositiveItems.add(entry.getValue());
+            }
+        }
+
+        int totalExpected = expectedByKey.size();
+        int detected = detectedKeys.size();
+        double coverage;
+        if (totalExpected == 0) {
+            LOGGER.warn(
+                    "Ground truth is empty; coverage cannot be computed and will be reported as"
+                            + " 0.0");
+            coverage = 0.0;
+        } else {
+            coverage = detected * 100.0 / totalExpected;
+        }
+
+        return new BenchmarkResult(
+                input.getTool(),
+                coverage,
+                totalExpected,
+                detected,
+                missedItems.size(),
+                falsePositiveItems.size(),
+                missedItems,
+                falsePositiveItems);
+    }
+
+    private Map<String, Finding> buildExpectedIndex(List<ScannerResponseBean> groundTruth) {
+        Map<String, Finding> index = new LinkedHashMap<>();
+        for (ScannerResponseBean entry : groundTruth) {
+            if (!UNSECURE_VARIANT.equalsIgnoreCase(entry.getVariant())) {
+                continue;
+            }
+            String normalizedUrl = normalizeUrl(entry.getUrl());
+            List<VulnerabilityType> types = entry.getVulnerabilityTypes();
+            if (types == null) {
+                continue;
+            }
+            for (VulnerabilityType type : types) {
+                String key = normalizedUrl + KEY_SEPARATOR + type.name();
+                index.putIfAbsent(key, new Finding(normalizedUrl, type.name()));
+            }
+        }
+        return index;
+    }
+
+    private Map<String, Finding> buildFoundIndex(List<Finding> findings) {
+        if (findings == null || findings.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Finding> index = new LinkedHashMap<>();
+        for (Finding finding : findings) {
+            if (finding == null || finding.getUrl() == null || finding.getType() == null) {
+                continue;
+            }
+            String normalizedUrl = normalizeUrl(finding.getUrl());
+            String normalizedType = finding.getType().trim().toUpperCase(Locale.ROOT);
+            String key = normalizedUrl + KEY_SEPARATOR + normalizedType;
+            index.putIfAbsent(key, new Finding(normalizedUrl, normalizedType));
+        }
+        return index;
+    }
+
+    /**
+     * Normalises a URL to a context-path-stripped path so absolute ground-truth URLs and relative
+     * scanner-finding URLs compare equal.
+     *
+     * <p>Strips scheme + host + port, the {@code /VulnerableApp} context path, the query string,
+     * and a trailing slash. Leaves the path case unchanged.
+     */
+    static String normalizeUrl(String url) {
+        if (url == null) {
+            return "";
+        }
+        String s = url.trim();
+        int schemeIdx = s.indexOf("://");
+        if (schemeIdx >= 0) {
+            int pathIdx = s.indexOf('/', schemeIdx + 3);
+            s = (pathIdx >= 0) ? s.substring(pathIdx) : "/";
+        }
+        int queryIdx = s.indexOf('?');
+        if (queryIdx >= 0) {
+            s = s.substring(0, queryIdx);
+        }
+        if (s.equals(CONTEXT_PATH)) {
+            s = "/";
+        } else if (s.startsWith(CONTEXT_PATH + "/")) {
+            s = s.substring(CONTEXT_PATH.length());
+        }
+        if (s.length() > 1 && s.endsWith("/")) {
+            s = s.substring(0, s.length() - 1);
+        }
+        if (s.isEmpty()) {
+            return "/";
+        }
+        if (!s.startsWith("/")) {
+            s = "/" + s;
+        }
+        return s;
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
@@ -2,7 +2,9 @@ package org.sasanlabs.benchmark.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -15,18 +17,29 @@ import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.benchmark.model.BenchmarkResult;
 import org.sasanlabs.benchmark.model.Finding;
 import org.sasanlabs.benchmark.model.ScannerFindings;
-import org.sasanlabs.service.IEndPointsInformationProvider;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
 /**
- * Compares scanner findings against VulnerableApp's DAST ground truth (the {@code /scanner}
- * endpoint's data) and produces coverage / missed / false-positive metrics.
+ * Compares scanner findings against VulnerableApp's DAST ground truth (fetched from the {@code
+ * /scanner} HTTP endpoint) and produces coverage / missed / unmatched metrics.
  *
- * <p>Matching is set-based on a key of {@code normalizedUrl + "::" + uppercaseType}. URLs are
- * normalised to a context-path-stripped path; types are matched case-insensitively against {@link
- * VulnerabilityType} names. Only {@code UNSECURE} ground-truth entries count toward expected — a
- * scanner finding against a {@code SECURE} URL is treated as a false positive.
+ * <p>The ground-truth source is an HTTP URL rather than an in-process bean so the comparator works
+ * unchanged when VulnerableApp is composed behind VulnerableApp-facade with other backing apps —
+ * point the property at the facade's aggregated endpoint and coverage reflects the full attack
+ * surface.
+ *
+ * <p>Matching is set-based and tolerant to scanner-specific vocabularies: a scanner finding matches
+ * a ground-truth row when the URL agrees AND <em>any one of</em> the type-name, CWE, or WASC axes
+ * agrees. Scanners that don't speak {@link VulnerabilityType} names (most of them) can therefore
+ * still be graded by emitting a CWE or WASC ID alongside their finding.
+ *
+ * <p>Only {@code UNSECURE} ground-truth entries count toward expected — a scanner finding against a
+ * {@code SECURE} URL is treated as unmatched (out of scope rather than a true false positive, since
+ * hardening / SSL-style alerts on a SECURE URL aren't modelled here as vulnerabilities).
  */
 @Service
 public class DastBenchmarkStrategy implements BenchmarkStrategy {
@@ -36,40 +49,79 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
     private static final String CONTEXT_PATH = "/VulnerableApp";
     private static final String UNSECURE_VARIANT = "UNSECURE";
     private static final String KEY_SEPARATOR = "::";
+    private static final String AXIS_TYPE = "TYPE";
+    private static final String AXIS_CWE = "CWE";
+    private static final String AXIS_WASC = "WASC";
+    private static final String METHOD_ANY = "ANY";
 
-    private final IEndPointsInformationProvider endPointsInformationProvider;
+    private final RestTemplate restTemplate;
+    private final String groundTruthUrl;
 
-    public DastBenchmarkStrategy(IEndPointsInformationProvider endPointsInformationProvider) {
-        this.endPointsInformationProvider = endPointsInformationProvider;
+    public DastBenchmarkStrategy(
+            RestTemplate restTemplate,
+            @Value("${benchmark.dast.ground-truth.url}") String groundTruthUrl) {
+        this.restTemplate = restTemplate;
+        this.groundTruthUrl = groundTruthUrl;
     }
 
     @Override
     public BenchmarkResult compare(ScannerFindings input) throws IOException {
-        List<ScannerResponseBean> groundTruth =
-                endPointsInformationProvider.getScannerRelatedEndPointInformation();
+        List<ScannerResponseBean> groundTruth = fetchGroundTruth();
 
-        Map<String, Finding> expectedByKey = buildExpectedIndex(groundTruth);
-        Map<String, Finding> foundByKey = buildFoundIndex(input.getFindings());
+        List<Finding> expectedRows = new ArrayList<>();
+        Map<String, Set<Integer>> keyToExpected = buildExpectedIndex(groundTruth, expectedRows);
 
-        Set<String> detectedKeys = new LinkedHashSet<>(expectedByKey.keySet());
-        detectedKeys.retainAll(foundByKey.keySet());
+        Set<Integer> detectedIndices = new LinkedHashSet<>();
+        List<Finding> unmatchedItems = new ArrayList<>();
+        Set<String> seenFindingSignatures = new HashSet<>();
+
+        List<Finding> rawFindings =
+                (input.getFindings() != null) ? input.getFindings() : new ArrayList<>();
+        for (Finding finding : rawFindings) {
+            if (finding == null || finding.getUrl() == null) {
+                continue;
+            }
+            String url = normalizeUrl(finding.getUrl());
+            List<String> keys = keysForFinding(url, finding);
+            if (keys.isEmpty()) {
+                continue;
+            }
+            String signature = String.join("|", keys);
+            if (!seenFindingSignatures.add(signature)) {
+                continue;
+            }
+
+            Set<Integer> hits = new LinkedHashSet<>();
+            for (String key : keys) {
+                Set<Integer> rows = keyToExpected.get(key);
+                if (rows != null) {
+                    hits.addAll(rows);
+                }
+            }
+            if (hits.isEmpty()) {
+                unmatchedItems.add(
+                        new Finding(
+                                url,
+                                finding.getType(),
+                                null,
+                                null,
+                                finding.getCwe(),
+                                finding.getWascId(),
+                                finding.getMethod()));
+            } else {
+                detectedIndices.addAll(hits);
+            }
+        }
 
         List<Finding> missedItems = new ArrayList<>();
-        for (Map.Entry<String, Finding> entry : expectedByKey.entrySet()) {
-            if (!foundByKey.containsKey(entry.getKey())) {
-                missedItems.add(entry.getValue());
+        for (int i = 0; i < expectedRows.size(); i++) {
+            if (!detectedIndices.contains(i)) {
+                missedItems.add(expectedRows.get(i));
             }
         }
 
-        List<Finding> falsePositiveItems = new ArrayList<>();
-        for (Map.Entry<String, Finding> entry : foundByKey.entrySet()) {
-            if (!expectedByKey.containsKey(entry.getKey())) {
-                falsePositiveItems.add(entry.getValue());
-            }
-        }
-
-        int totalExpected = expectedByKey.size();
-        int detected = detectedKeys.size();
+        int totalExpected = expectedRows.size();
+        int detected = detectedIndices.size();
         double coverage;
         if (totalExpected == 0) {
             LOGGER.warn(
@@ -86,45 +138,136 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
                 totalExpected,
                 detected,
                 missedItems.size(),
-                falsePositiveItems.size(),
+                unmatchedItems.size(),
                 missedItems,
-                falsePositiveItems);
+                unmatchedItems);
     }
 
-    private Map<String, Finding> buildExpectedIndex(List<ScannerResponseBean> groundTruth) {
-        Map<String, Finding> index = new LinkedHashMap<>();
+    private List<ScannerResponseBean> fetchGroundTruth() throws IOException {
+        try {
+            ScannerResponseBean[] response =
+                    restTemplate.getForObject(groundTruthUrl, ScannerResponseBean[].class);
+            return (response == null) ? Collections.emptyList() : Arrays.asList(response);
+        } catch (RestClientException rce) {
+            throw new IOException("Failed to fetch DAST ground truth from " + groundTruthUrl, rce);
+        }
+    }
+
+    private Map<String, Set<Integer>> buildExpectedIndex(
+            List<ScannerResponseBean> groundTruth, List<Finding> rowsOut) {
+        Map<String, Set<Integer>> keyToRows = new LinkedHashMap<>();
+        Set<String> seenRowSignatures = new HashSet<>();
         for (ScannerResponseBean entry : groundTruth) {
             if (!UNSECURE_VARIANT.equalsIgnoreCase(entry.getVariant())) {
                 continue;
             }
-            String normalizedUrl = normalizeUrl(entry.getUrl());
+            String url = normalizeUrl(entry.getUrl());
+            String method =
+                    (entry.getRequestMethod() != null)
+                            ? entry.getRequestMethod().name()
+                            : METHOD_ANY;
             List<VulnerabilityType> types = entry.getVulnerabilityTypes();
             if (types == null) {
                 continue;
             }
             for (VulnerabilityType type : types) {
-                String key = normalizedUrl + KEY_SEPARATOR + type.name();
-                index.putIfAbsent(key, new Finding(normalizedUrl, type.name()));
+                String rowSignature = url + KEY_SEPARATOR + method + KEY_SEPARATOR + type.name();
+                if (!seenRowSignatures.add(rowSignature)) {
+                    continue;
+                }
+                int rowIndex = rowsOut.size();
+                rowsOut.add(buildExpectedFinding(url, type, method));
+                addAxisKeys(keyToRows, rowIndex, url, method, type);
+                addAxisKeys(keyToRows, rowIndex, url, METHOD_ANY, type);
             }
         }
-        return index;
+        return keyToRows;
     }
 
-    private Map<String, Finding> buildFoundIndex(List<Finding> findings) {
-        if (findings == null || findings.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        Map<String, Finding> index = new LinkedHashMap<>();
-        for (Finding finding : findings) {
-            if (finding == null || finding.getUrl() == null || finding.getType() == null) {
-                continue;
+    private static void addAxisKeys(
+            Map<String, Set<Integer>> keyToRows,
+            int rowIndex,
+            String url,
+            String method,
+            VulnerabilityType type) {
+        addKey(keyToRows, typeKey(url, method, type.name()), rowIndex);
+        if (type.getCweID() != null) {
+            String cwe = normalizeNumericId(type.getCweID().toString());
+            if (!cwe.isEmpty()) {
+                addKey(keyToRows, cweKey(url, method, cwe), rowIndex);
             }
-            String normalizedUrl = normalizeUrl(finding.getUrl());
-            String normalizedType = finding.getType().trim().toUpperCase(Locale.ROOT);
-            String key = normalizedUrl + KEY_SEPARATOR + normalizedType;
-            index.putIfAbsent(key, new Finding(normalizedUrl, normalizedType));
         }
-        return index;
+        if (type.getWascID() != null) {
+            String wasc = normalizeNumericId(type.getWascID().toString());
+            if (!wasc.isEmpty()) {
+                addKey(keyToRows, wascKey(url, method, wasc), rowIndex);
+            }
+        }
+    }
+
+    private static Finding buildExpectedFinding(String url, VulnerabilityType type, String method) {
+        String cwe = (type.getCweID() != null) ? "CWE-" + type.getCweID() : null;
+        String wasc = (type.getWascID() != null) ? type.getWascID().toString() : null;
+        return new Finding(url, type.name(), null, null, cwe, wasc, method);
+    }
+
+    private static List<String> keysForFinding(String url, Finding finding) {
+        String method =
+                (finding.getMethod() != null && !finding.getMethod().trim().isEmpty())
+                        ? finding.getMethod().trim().toUpperCase(Locale.ROOT)
+                        : METHOD_ANY;
+        List<String> keys = new ArrayList<>(3);
+        if (finding.getType() != null && !finding.getType().trim().isEmpty()) {
+            keys.add(typeKey(url, method, finding.getType()));
+        }
+        String cwe = normalizeNumericId(finding.getCwe());
+        if (!cwe.isEmpty()) {
+            keys.add(cweKey(url, method, cwe));
+        }
+        String wasc = normalizeNumericId(finding.getWascId());
+        if (!wasc.isEmpty()) {
+            keys.add(wascKey(url, method, wasc));
+        }
+        return keys;
+    }
+
+    private static void addKey(Map<String, Set<Integer>> map, String key, int rowIndex) {
+        map.computeIfAbsent(key, k -> new LinkedHashSet<>()).add(rowIndex);
+    }
+
+    private static String typeKey(String url, String method, String typeName) {
+        return AXIS_TYPE
+                + KEY_SEPARATOR
+                + method
+                + KEY_SEPARATOR
+                + url
+                + KEY_SEPARATOR
+                + typeName.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private static String cweKey(String url, String method, String cweDigits) {
+        return AXIS_CWE + KEY_SEPARATOR + method + KEY_SEPARATOR + url + KEY_SEPARATOR + cweDigits;
+    }
+
+    private static String wascKey(String url, String method, String wascDigits) {
+        return AXIS_WASC
+                + KEY_SEPARATOR
+                + method
+                + KEY_SEPARATOR
+                + url
+                + KEY_SEPARATOR
+                + wascDigits;
+    }
+
+    /**
+     * Reduces a CWE/WASC string to its digit run so {@code "CWE-89"}, {@code "cwe89"}, and {@code
+     * "89"} all hash the same. Returns the empty string for {@code null} or all-non-digit input.
+     */
+    static String normalizeNumericId(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        return raw.replaceAll("\\D", "");
     }
 
     /**

--- a/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
@@ -260,14 +260,23 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
     }
 
     /**
-     * Reduces a CWE/WASC string to its digit run so {@code "CWE-89"}, {@code "cwe89"}, and {@code
-     * "89"} all hash the same. Returns the empty string for {@code null} or all-non-digit input.
+     * Reduces a CWE/WASC string to its canonical digit form so {@code "CWE-89"}, {@code "cwe89"},
+     * {@code "89"}, and zero-padded variants like {@code "CWE-089"} all hash the same. Returns the
+     * empty string for {@code null} or all-non-digit input.
      */
     static String normalizeNumericId(String raw) {
         if (raw == null) {
             return "";
         }
-        return raw.replaceAll("\\D", "");
+        String digits = raw.replaceAll("\\D", "");
+        if (digits.isEmpty()) {
+            return "";
+        }
+        try {
+            return Long.toString(Long.parseLong(digits));
+        } catch (NumberFormatException nfe) {
+            return digits;
+        }
     }
 
     /**

--- a/src/main/java/org/sasanlabs/benchmark/service/IExpectedIssuesProvider.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/IExpectedIssuesProvider.java
@@ -1,0 +1,14 @@
+package org.sasanlabs.benchmark.service;
+
+import java.io.IOException;
+import java.util.List;
+import org.sasanlabs.benchmark.model.ExpectedIssue;
+
+/**
+ * Source of SAST ground truth — the set of known vulnerability sites in VulnerableApp's source
+ * tree. Implementations can read from a CSV file, an annotation harvest, or any other store.
+ */
+public interface IExpectedIssuesProvider {
+
+    List<ExpectedIssue> getExpectedIssues() throws IOException;
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
@@ -67,10 +67,17 @@ public class SastBenchmarkStrategy implements BenchmarkStrategy {
             if (keys.isEmpty()) {
                 continue;
             }
-            String primary = keys.get(0);
-            if (!primaryKeysSeen.add(primary)) {
+            boolean alreadySeen = false;
+            for (String key : keys) {
+                if (primaryKeysSeen.contains(key)) {
+                    alreadySeen = true;
+                    break;
+                }
+            }
+            if (alreadySeen) {
                 continue;
             }
+            primaryKeysSeen.addAll(keys);
             uniqueFindings.add(f);
             for (String key : keys) {
                 foundByKey.putIfAbsent(key, f);

--- a/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
@@ -1,0 +1,182 @@
+package org.sasanlabs.benchmark.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.ExpectedIssue;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.springframework.stereotype.Service;
+
+/**
+ * Compares scanner findings against VulnerableApp's SAST ground truth (the {@link
+ * IExpectedIssuesProvider}, backed by {@code scanner/sast/expectedIssues.csv} by default) and
+ * produces coverage / missed / false-positive metrics.
+ *
+ * <p>Each ground-truth row contributes up to two match keys: one keyed on CWE and one keyed on the
+ * vulnerability-type label. A scanner finding matches if it shares the {@code (filePath, line)}
+ * pair AND either the CWE or the type label (case-insensitive). Scanner findings are expected to
+ * emit project-relative paths; backslashes and leading {@code ./} are normalised.
+ */
+@Service
+public class SastBenchmarkStrategy implements BenchmarkStrategy {
+
+    private static final Logger LOGGER = LogManager.getLogger(SastBenchmarkStrategy.class);
+
+    private static final String KEY_SEPARATOR = "::";
+    private static final String CWE_TAG = "CWE";
+    private static final String TYPE_TAG = "TYPE";
+
+    private final IExpectedIssuesProvider expectedIssuesProvider;
+
+    public SastBenchmarkStrategy(IExpectedIssuesProvider expectedIssuesProvider) {
+        this.expectedIssuesProvider = expectedIssuesProvider;
+    }
+
+    @Override
+    public BenchmarkResult compare(ScannerFindings input) throws IOException {
+        List<ExpectedIssue> expected = expectedIssuesProvider.getExpectedIssues();
+
+        Map<String, ExpectedIssue> expectedByKey = new LinkedHashMap<>();
+        for (ExpectedIssue ei : expected) {
+            for (String key : keysFor(ei)) {
+                expectedByKey.putIfAbsent(key, ei);
+            }
+        }
+
+        List<Finding> rawFindings =
+                (input.getFindings() != null) ? input.getFindings() : new ArrayList<>();
+
+        Map<String, Finding> foundByKey = new LinkedHashMap<>();
+        List<Finding> uniqueFindings = new ArrayList<>();
+        Set<String> primaryKeysSeen = new HashSet<>();
+        for (Finding f : rawFindings) {
+            if (f == null || f.getFilePath() == null || f.getLine() == null) {
+                continue;
+            }
+            List<String> keys = keysFor(f);
+            if (keys.isEmpty()) {
+                continue;
+            }
+            String primary = keys.get(0);
+            if (!primaryKeysSeen.add(primary)) {
+                continue;
+            }
+            uniqueFindings.add(f);
+            for (String key : keys) {
+                foundByKey.putIfAbsent(key, f);
+            }
+        }
+
+        Set<ExpectedIssue> detectedSet = new LinkedHashSet<>();
+        List<Finding> missedItems = new ArrayList<>();
+        for (ExpectedIssue ei : expected) {
+            boolean hit = false;
+            for (String key : keysFor(ei)) {
+                if (foundByKey.containsKey(key)) {
+                    hit = true;
+                    break;
+                }
+            }
+            if (hit) {
+                detectedSet.add(ei);
+            } else {
+                missedItems.add(toFinding(ei));
+            }
+        }
+
+        List<Finding> falsePositiveItems = new ArrayList<>();
+        for (Finding f : uniqueFindings) {
+            boolean hit = false;
+            for (String key : keysFor(f)) {
+                if (expectedByKey.containsKey(key)) {
+                    hit = true;
+                    break;
+                }
+            }
+            if (!hit) {
+                falsePositiveItems.add(f);
+            }
+        }
+
+        int totalExpected = expected.size();
+        int detected = detectedSet.size();
+        double coverage;
+        if (totalExpected == 0) {
+            LOGGER.warn(
+                    "SAST ground truth is empty; coverage cannot be computed and will be reported"
+                            + " as 0.0");
+            coverage = 0.0;
+        } else {
+            coverage = detected * 100.0 / totalExpected;
+        }
+
+        return new BenchmarkResult(
+                input.getTool(),
+                coverage,
+                totalExpected,
+                detected,
+                missedItems.size(),
+                falsePositiveItems.size(),
+                missedItems,
+                falsePositiveItems);
+    }
+
+    private static List<String> keysFor(ExpectedIssue ei) {
+        return buildKeys(ei.getFilePath(), ei.getLine(), ei.getCwe(), ei.getVulnerabilityType());
+    }
+
+    private static List<String> keysFor(Finding f) {
+        return buildKeys(f.getFilePath(), f.getLine(), f.getCwe(), f.getType());
+    }
+
+    private static List<String> buildKeys(String filePath, Integer line, String cwe, String type) {
+        if (filePath == null || line == null) {
+            return new ArrayList<>();
+        }
+        String path = normalizeFilePath(filePath);
+        String prefix = path + KEY_SEPARATOR + line + KEY_SEPARATOR;
+        List<String> keys = new ArrayList<>(2);
+        if (cwe != null && !cwe.trim().isEmpty()) {
+            keys.add(prefix + CWE_TAG + KEY_SEPARATOR + cwe.trim().toUpperCase(Locale.ROOT));
+        }
+        if (type != null && !type.trim().isEmpty()) {
+            keys.add(prefix + TYPE_TAG + KEY_SEPARATOR + type.trim().toLowerCase(Locale.ROOT));
+        }
+        return keys;
+    }
+
+    /**
+     * Normalises a SAST file path to a project-relative form: backslashes → forward slashes,
+     * leading {@code ./} stripped, surrounding whitespace trimmed. Scanner authors are expected to
+     * emit project-root-relative paths; absolute paths or unexpected prefixes will not match.
+     */
+    static String normalizeFilePath(String path) {
+        if (path == null) {
+            return "";
+        }
+        String s = path.trim().replace('\\', '/');
+        while (s.startsWith("./")) {
+            s = s.substring(2);
+        }
+        return s;
+    }
+
+    private static Finding toFinding(ExpectedIssue ei) {
+        return new Finding(
+                null,
+                ei.getVulnerabilityType(),
+                normalizeFilePath(ei.getFilePath()),
+                ei.getLine(),
+                ei.getCwe());
+    }
+}

--- a/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategy.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
 /**
  * Compares scanner findings against VulnerableApp's SAST ground truth (the {@link
  * IExpectedIssuesProvider}, backed by {@code scanner/sast/expectedIssues.csv} by default) and
- * produces coverage / missed / false-positive metrics.
+ * produces coverage / missed / unmatched metrics.
  *
  * <p>Each ground-truth row contributes up to two match keys: one keyed on CWE and one keyed on the
  * vulnerability-type label. A scanner finding matches if it shares the {@code (filePath, line)}
@@ -101,7 +101,7 @@ public class SastBenchmarkStrategy implements BenchmarkStrategy {
             }
         }
 
-        List<Finding> falsePositiveItems = new ArrayList<>();
+        List<Finding> unmatchedItems = new ArrayList<>();
         for (Finding f : uniqueFindings) {
             boolean hit = false;
             for (String key : keysFor(f)) {
@@ -111,7 +111,7 @@ public class SastBenchmarkStrategy implements BenchmarkStrategy {
                 }
             }
             if (!hit) {
-                falsePositiveItems.add(f);
+                unmatchedItems.add(f);
             }
         }
 
@@ -133,9 +133,9 @@ public class SastBenchmarkStrategy implements BenchmarkStrategy {
                 totalExpected,
                 detected,
                 missedItems.size(),
-                falsePositiveItems.size(),
+                unmatchedItems.size(),
                 missedItems,
-                falsePositiveItems);
+                unmatchedItems);
     }
 
     private static List<String> keysFor(ExpectedIssue ei) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,10 @@ gistId.sasanlabs.projects=bbf2e2183b8f6252061663ce0ddee79b
 # Directory where scanner benchmark result files are written by /scanner/benchmark
 benchmark.output.dir=benchmarks
 
+# Path (relative to the working directory or absolute) of the SAST ground-truth CSV
+# consumed by /scanner/benchmark when scanType=SAST
+benchmark.sast.ground-truth.path=scanner/sast/expectedIssues.csv
+
 ##Details for KeyPair generation in application
 #keytool -genkeypair -alias SasanLabs -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore sasanlabs.p12 -validity 3650
 #password for pkcs12, sasanlabs.p12 is "changeIt"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,9 @@ logging.level.org.hibernate=DEBUG
 
 gistId.sasanlabs.projects=bbf2e2183b8f6252061663ce0ddee79b
 
+# Directory where scanner benchmark result files are written by /scanner/benchmark
+benchmark.output.dir=benchmarks
+
 ##Details for KeyPair generation in application
 #keytool -genkeypair -alias SasanLabs -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore sasanlabs.p12 -validity 3650
 #password for pkcs12, sasanlabs.p12 is "changeIt"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,12 @@ benchmark.output.dir=benchmarks
 # consumed by /scanner/benchmark when scanType=SAST
 benchmark.sast.ground-truth.path=scanner/sast/expectedIssues.csv
 
+# URL of the DAST ground-truth endpoint that /scanner/benchmark grades against.
+# Defaults to a self-call against the running app; override (e.g., to the
+# VulnerableApp-facade aggregated /scanner/dast endpoint) when running in a
+# multi-app deployment so coverage reflects the full attack surface.
+benchmark.dast.ground-truth.url=http://localhost:${server.port:9090}${server.servlet.context-path:/VulnerableApp}/scanner
+
 ##Details for KeyPair generation in application
 #keytool -genkeypair -alias SasanLabs -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore sasanlabs.p12 -validity 3650
 #password for pkcs12, sasanlabs.p12 is "changeIt"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,12 @@ benchmark.sast.ground-truth.path=scanner/sast/expectedIssues.csv
 # multi-app deployment so coverage reflects the full attack surface.
 benchmark.dast.ground-truth.url=http://localhost:${server.port:9090}${server.servlet.context-path:/VulnerableApp}/scanner
 
+# Connect / read timeouts (ms) for the DAST ground-truth fetch. Tight defaults
+# so a slow or unreachable endpoint fails fast instead of hanging Tomcat
+# request threads. Bump these if your facade or network is genuinely slower.
+benchmark.dast.ground-truth.connect-timeout-ms=5000
+benchmark.dast.ground-truth.read-timeout-ms=10000
+
 ##Details for KeyPair generation in application
 #keytool -genkeypair -alias SasanLabs -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore sasanlabs.p12 -validity 3650
 #password for pkcs12, sasanlabs.p12 is "changeIt"

--- a/src/test/java/org/sasanlabs/benchmark/controller/BenchmarkControllerTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/controller/BenchmarkControllerTest.java
@@ -1,0 +1,136 @@
+package org.sasanlabs.benchmark.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.benchmark.service.BenchmarkResultWriter;
+import org.sasanlabs.benchmark.service.BenchmarkService;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class BenchmarkControllerTest {
+
+    @Mock private BenchmarkService benchmarkService;
+
+    @Mock private BenchmarkResultWriter benchmarkResultWriter;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        BenchmarkController controller =
+                new BenchmarkController(benchmarkService, benchmarkResultWriter);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void validRequest_returns200_andWritesResultFile() throws Exception {
+        BenchmarkResult mockResult =
+                new BenchmarkResult(
+                        "ZAP", 100.0, 1, 1, 0, 0, Collections.emptyList(), Collections.emptyList());
+        when(benchmarkService.compare(any(ScannerFindings.class))).thenReturn(mockResult);
+        when(benchmarkResultWriter.write(any(BenchmarkResult.class)))
+                .thenReturn(Paths.get("benchmarks/zap-results.json"));
+
+        String body =
+                "{\"tool\":\"ZAP\",\"findings\":["
+                        + "{\"url\":\"/SQLInjection/LEVEL_1\",\"type\":\"BLIND_SQL_INJECTION\"}]}";
+
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tool").value("ZAP"))
+                .andExpect(jsonPath("$.coverage").value(100.0))
+                .andExpect(jsonPath("$.totalExpected").value(1))
+                .andExpect(jsonPath("$.detected").value(1));
+
+        verify(benchmarkResultWriter, times(1)).write(argThat(r -> "ZAP".equals(r.getTool())));
+    }
+
+    @Test
+    void missingToolField_returns400() throws Exception {
+        String body =
+                "{\"findings\":["
+                        + "{\"url\":\"/SQLInjection/LEVEL_1\",\"type\":\"BLIND_SQL_INJECTION\"}]}";
+
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void blankToolField_returns400() throws Exception {
+        String body =
+                "{\"tool\":\"   \",\"findings\":["
+                        + "{\"url\":\"/SQLInjection/LEVEL_1\",\"type\":\"BLIND_SQL_INJECTION\"}]}";
+
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void missingFindingsField_returns400() throws Exception {
+        String body = "{\"tool\":\"ZAP\"}";
+
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void malformedJson_returns400() throws Exception {
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{not valid json"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void writerFailure_stillReturns200WithBody() throws Exception {
+        BenchmarkResult mockResult =
+                new BenchmarkResult(
+                        "ZAP", 50.0, 2, 1, 1, 0, Collections.emptyList(), Collections.emptyList());
+        when(benchmarkService.compare(any(ScannerFindings.class))).thenReturn(mockResult);
+        when(benchmarkResultWriter.write(any(BenchmarkResult.class)))
+                .thenThrow(new IOException("disk full"));
+
+        String body = "{\"tool\":\"ZAP\",\"findings\":[]}";
+
+        mockMvc.perform(
+                        post("/scanner/benchmark")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tool").value("ZAP"))
+                .andExpect(jsonPath("$.coverage").value(50.0));
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/controller/BenchmarkControllerTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/controller/BenchmarkControllerTest.java
@@ -115,7 +115,7 @@ class BenchmarkControllerTest {
     }
 
     @Test
-    void writerFailure_stillReturns200WithBody() throws Exception {
+    void writerFailure_returns500WithResultAndPersistenceError() throws Exception {
         BenchmarkResult mockResult =
                 new BenchmarkResult(
                         "ZAP", 50.0, 2, 1, 1, 0, Collections.emptyList(), Collections.emptyList());
@@ -129,8 +129,11 @@ class BenchmarkControllerTest {
                         post("/scanner/benchmark")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(body))
-                .andExpect(status().isOk())
+                .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.tool").value("ZAP"))
-                .andExpect(jsonPath("$.coverage").value(50.0));
+                .andExpect(jsonPath("$.coverage").value(50.0))
+                .andExpect(
+                        jsonPath("$.persistenceError")
+                                .value(org.hamcrest.Matchers.containsString("disk full")));
     }
 }

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
@@ -1,0 +1,117 @@
+package org.sasanlabs.benchmark.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.Finding;
+
+class BenchmarkResultWriterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void write_persistsResultToToolNamedFileInDefaultDir(@TempDir Path tempDir) throws Exception {
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+
+        Path target = writer.write(sampleResult("ZAP"));
+
+        assertThat(target).isEqualTo(tempDir.resolve("zap-results.json"));
+        assertThat(Files.exists(target)).isTrue();
+
+        BenchmarkResult roundTripped = MAPPER.readValue(target.toFile(), BenchmarkResult.class);
+        assertThat(roundTripped.getTool()).isEqualTo("ZAP");
+        assertThat(roundTripped.getCoverage()).isEqualTo(50.0);
+        assertThat(roundTripped.getTotalExpected()).isEqualTo(2);
+        assertThat(roundTripped.getDetected()).isEqualTo(1);
+        assertThat(roundTripped.getMissedItems())
+                .extracting(Finding::getUrl)
+                .containsExactly("/SQLInjection/LEVEL_2");
+    }
+
+    @Test
+    void write_overwritesExistingFileForSameTool(@TempDir Path tempDir) throws Exception {
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+        writer.write(sampleResult("ZAP"));
+
+        BenchmarkResult second =
+                new BenchmarkResult(
+                        "ZAP", 100.0, 1, 1, 0, 0, Collections.emptyList(), Collections.emptyList());
+        Path target = writer.write(second);
+
+        try (java.util.stream.Stream<Path> entries = Files.list(tempDir)) {
+            assertThat(entries).hasSize(1);
+        }
+        BenchmarkResult roundTripped = MAPPER.readValue(target.toFile(), BenchmarkResult.class);
+        assertThat(roundTripped.getCoverage()).isEqualTo(100.0);
+        assertThat(roundTripped.getMissed()).isZero();
+    }
+
+    @Test
+    void write_createsBenchmarksDirectoryIfMissing(@TempDir Path tempDir) throws Exception {
+        Path nested = tempDir.resolve("does/not/exist/yet");
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(nested.toString());
+
+        Path target = writer.write(sampleResult("ZAP"));
+
+        assertThat(Files.isDirectory(nested)).isTrue();
+        assertThat(target).isEqualTo(nested.resolve("zap-results.json"));
+    }
+
+    @Test
+    void write_withCustomDir_overridesDefault(@TempDir Path tempDir) throws Exception {
+        Path defaultDir = tempDir.resolve("default");
+        Path overrideDir = tempDir.resolve("override");
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(defaultDir.toString());
+
+        Path target = writer.write(sampleResult("ZAP"), overrideDir.toString());
+
+        assertThat(target).isEqualTo(overrideDir.resolve("zap-results.json"));
+        assertThat(Files.exists(target)).isTrue();
+        assertThat(Files.exists(defaultDir)).isFalse();
+    }
+
+    @Test
+    void write_withWhitespaceAndUppercaseTool_sanitisesFileName(@TempDir Path tempDir)
+            throws Exception {
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+
+        Path target = writer.write(sampleResult("  Burp Suite 2.14  "));
+
+        assertThat(target.getFileName().toString()).isEqualTo("burpsuite214-results.json");
+    }
+
+    @Test
+    void sanitizeToolName_handlesNullEmptyAndAllSymbols() {
+        assertThat(BenchmarkResultWriter.sanitizeToolName(null)).isEqualTo("unknown");
+        assertThat(BenchmarkResultWriter.sanitizeToolName("")).isEqualTo("unknown");
+        assertThat(BenchmarkResultWriter.sanitizeToolName("   ")).isEqualTo("unknown");
+        assertThat(BenchmarkResultWriter.sanitizeToolName("***!!!")).isEqualTo("unknown");
+    }
+
+    @Test
+    void sanitizeToolName_lowercasesAndKeepsAlphanumericUnderscoreAndHyphen() {
+        assertThat(BenchmarkResultWriter.sanitizeToolName("ZAP")).isEqualTo("zap");
+        assertThat(BenchmarkResultWriter.sanitizeToolName("OWASP-ZAP_v2"))
+                .isEqualTo("owasp-zap_v2");
+        assertThat(BenchmarkResultWriter.sanitizeToolName("../etc/passwd")).isEqualTo("etcpasswd");
+    }
+
+    private static BenchmarkResult sampleResult(String tool) {
+        return new BenchmarkResult(
+                tool,
+                50.0,
+                2,
+                1,
+                1,
+                0,
+                Arrays.asList(new Finding("/SQLInjection/LEVEL_2", "BLIND_SQL_INJECTION")),
+                Collections.emptyList());
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
@@ -18,7 +18,7 @@ class BenchmarkResultWriterTest {
 
     @Test
     void write_persistsResultToToolNamedFileInDefaultDir(@TempDir Path tempDir) throws Exception {
-        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(MAPPER, tempDir.toString());
 
         Path target = writer.write(sampleResult("ZAP"));
 
@@ -37,7 +37,7 @@ class BenchmarkResultWriterTest {
 
     @Test
     void write_overwritesExistingFileForSameTool(@TempDir Path tempDir) throws Exception {
-        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(MAPPER, tempDir.toString());
         writer.write(sampleResult("ZAP"));
 
         BenchmarkResult second =
@@ -56,7 +56,7 @@ class BenchmarkResultWriterTest {
     @Test
     void write_createsBenchmarksDirectoryIfMissing(@TempDir Path tempDir) throws Exception {
         Path nested = tempDir.resolve("does/not/exist/yet");
-        BenchmarkResultWriter writer = new BenchmarkResultWriter(nested.toString());
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(MAPPER, nested.toString());
 
         Path target = writer.write(sampleResult("ZAP"));
 
@@ -68,7 +68,7 @@ class BenchmarkResultWriterTest {
     void write_withCustomDir_overridesDefault(@TempDir Path tempDir) throws Exception {
         Path defaultDir = tempDir.resolve("default");
         Path overrideDir = tempDir.resolve("override");
-        BenchmarkResultWriter writer = new BenchmarkResultWriter(defaultDir.toString());
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(MAPPER, defaultDir.toString());
 
         Path target = writer.write(sampleResult("ZAP"), overrideDir.toString());
 
@@ -80,7 +80,7 @@ class BenchmarkResultWriterTest {
     @Test
     void write_withWhitespaceAndUppercaseTool_sanitisesFileName(@TempDir Path tempDir)
             throws Exception {
-        BenchmarkResultWriter writer = new BenchmarkResultWriter(tempDir.toString());
+        BenchmarkResultWriter writer = new BenchmarkResultWriter(MAPPER, tempDir.toString());
 
         Path target = writer.write(sampleResult("  Burp Suite 2.14  "));
 

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkResultWriterTest.java
@@ -96,6 +96,19 @@ class BenchmarkResultWriterTest {
     }
 
     @Test
+    void sanitizeToolName_truncatesOverlongInput() {
+        StringBuilder veryLong = new StringBuilder();
+        for (int i = 0; i < 500; i++) {
+            veryLong.append('a');
+        }
+
+        String result = BenchmarkResultWriter.sanitizeToolName(veryLong.toString());
+
+        assertThat(result).hasSize(64);
+        assertThat(result).matches("^a+$");
+    }
+
+    @Test
     void sanitizeToolName_lowercasesAndKeepsAlphanumericUnderscoreAndHyphen() {
         assertThat(BenchmarkResultWriter.sanitizeToolName("ZAP")).isEqualTo("zap");
         assertThat(BenchmarkResultWriter.sanitizeToolName("OWASP-ZAP_v2"))

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
@@ -55,11 +55,14 @@ class BenchmarkServiceTest {
 
     @Test
     void omittedScanType_defaultsToDast() throws Exception {
+        BenchmarkResult dastResult = result("ZAP");
         ScannerFindings input = new ScannerFindings("ZAP", Collections.emptyList());
-        when(dastStrategy.compare(input)).thenReturn(result("ZAP"));
+        when(dastStrategy.compare(input)).thenReturn(dastResult);
 
-        service.compare(input);
+        BenchmarkResult out = service.compare(input);
 
+        assertThat(out).isSameAs(dastResult);
+        verify(dastStrategy).compare(input);
         verify(sastStrategy, never()).compare(input);
     }
 

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
@@ -1,227 +1,70 @@
 package org.sasanlabs.benchmark.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.benchmark.model.BenchmarkResult;
-import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScanType;
 import org.sasanlabs.benchmark.model.ScannerFindings;
-import org.sasanlabs.service.IEndPointsInformationProvider;
-import org.sasanlabs.vulnerability.types.VulnerabilityType;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 @ExtendWith(MockitoExtension.class)
 class BenchmarkServiceTest {
 
-    @Mock private IEndPointsInformationProvider provider;
+    @Mock private DastBenchmarkStrategy dastStrategy;
+    @Mock private SastBenchmarkStrategy sastStrategy;
 
     private BenchmarkService service;
 
     @BeforeEach
     void setUp() {
-        service = new BenchmarkService(provider);
+        service = new BenchmarkService(dastStrategy, sastStrategy);
     }
 
     @Test
-    void perfectMatch_yields100Coverage() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS)));
+    void dastScanType_routesToDastStrategy() throws Exception {
+        BenchmarkResult dastResult = result("ZAP");
+        ScannerFindings input = new ScannerFindings("ZAP", ScanType.DAST, Collections.emptyList());
+        when(dastStrategy.compare(input)).thenReturn(dastResult);
 
-        BenchmarkResult result =
-                service.compare(
-                        input(
-                                "ZAP",
-                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
-                                new Finding("/XSS/LEVEL_1", "REFLECTED_XSS")));
+        BenchmarkResult out = service.compare(input);
 
-        assertThat(result.getCoverage()).isEqualTo(100.0);
-        assertThat(result.getTotalExpected()).isEqualTo(2);
-        assertThat(result.getDetected()).isEqualTo(2);
-        assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isZero();
-        assertThat(result.getMissedItems()).isEmpty();
-        assertThat(result.getFalsePositiveItems()).isEmpty();
+        assertThat(out).isSameAs(dastResult);
+        verify(sastStrategy, never()).compare(input);
     }
 
     @Test
-    void allMissed_yieldsZeroCoverageAndNoFalsePositives() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS)));
+    void sastScanType_routesToSastStrategy() throws Exception {
+        BenchmarkResult sastResult = result("Semgrep");
+        ScannerFindings input =
+                new ScannerFindings("Semgrep", ScanType.SAST, Collections.emptyList());
+        when(sastStrategy.compare(input)).thenReturn(sastResult);
 
-        BenchmarkResult result = service.compare(input("ZAP"));
+        BenchmarkResult out = service.compare(input);
 
-        assertThat(result.getCoverage()).isEqualTo(0.0);
-        assertThat(result.getTotalExpected()).isEqualTo(2);
-        assertThat(result.getDetected()).isZero();
-        assertThat(result.getMissed()).isEqualTo(2);
-        assertThat(result.getFalsePositives()).isZero();
-        assertThat(result.getMissedItems())
-                .extracting(Finding::getUrl, Finding::getType)
-                .containsExactlyInAnyOrder(
-                        tuple("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
-                        tuple("/XSS/LEVEL_1", "REFLECTED_XSS"));
+        assertThat(out).isSameAs(sastResult);
+        verify(dastStrategy, never()).compare(input);
     }
 
     @Test
-    void mixedDetectedMissedAndFalsePositive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/CommandInjection/LEVEL_1",
-                                        VulnerabilityType.COMMAND_INJECTION)));
+    void omittedScanType_defaultsToDast() throws Exception {
+        ScannerFindings input = new ScannerFindings("ZAP", Collections.emptyList());
+        when(dastStrategy.compare(input)).thenReturn(result("ZAP"));
 
-        BenchmarkResult result =
-                service.compare(
-                        input(
-                                "ZAP",
-                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
-                                new Finding("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL")));
+        service.compare(input);
 
-        assertThat(result.getTotalExpected()).isEqualTo(3);
-        assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getMissed()).isEqualTo(2);
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getCoverage())
-                .isCloseTo(33.33, org.assertj.core.data.Offset.offset(0.01));
-        assertThat(result.getFalsePositiveItems())
-                .extracting(Finding::getUrl, Finding::getType)
-                .containsExactly(tuple("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL"));
+        verify(sastStrategy, never()).compare(input);
     }
 
-    @Test
-    void findingAgainstSecureUrl_isCountedAsFalsePositive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                secure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_2",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
-
-        BenchmarkResult result =
-                service.compare(
-                        input("ZAP", new Finding("/SQLInjection/LEVEL_2", "BLIND_SQL_INJECTION")));
-
-        assertThat(result.getTotalExpected()).isEqualTo(1);
-        assertThat(result.getDetected()).isZero();
-        assertThat(result.getMissed()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getFalsePositiveItems())
-                .extracting(Finding::getUrl)
-                .containsExactly("/SQLInjection/LEVEL_2");
-    }
-
-    @Test
-    void emptyFindingsList_allExpectedAreMissed() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Collections.singletonList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
-
-        BenchmarkResult result =
-                service.compare(new ScannerFindings("ZAP", Collections.emptyList()));
-
-        assertThat(result.getTotalExpected()).isEqualTo(1);
-        assertThat(result.getDetected()).isZero();
-        assertThat(result.getMissed()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
-        assertThat(result.getCoverage()).isEqualTo(0.0);
-    }
-
-    @Test
-    void emptyExpected_yieldsZeroCoverageAndAllFindingsBecomeFalsePositives() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation()).thenReturn(Collections.emptyList());
-
-        BenchmarkResult result =
-                service.compare(
-                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION")));
-
-        assertThat(result.getTotalExpected()).isZero();
-        assertThat(result.getDetected()).isZero();
-        assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getCoverage()).isEqualTo(0.0);
-    }
-
-    @Test
-    void typeMatchIsCaseInsensitive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Collections.singletonList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
-
-        BenchmarkResult result =
-                service.compare(
-                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "blind_sql_injection")));
-
-        assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
-    }
-
-    @Test
-    void urlNormalization_acceptsAbsoluteRelativeAndContextStrippedForms() {
-        assertThat(
-                        BenchmarkService.normalizeUrl(
-                                "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1"))
-                .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(BenchmarkService.normalizeUrl("/VulnerableApp/SQLInjection/LEVEL_1"))
-                .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1"))
-                .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1/"))
-                .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1?attack=1' OR 1=1--"))
-                .isEqualTo("/SQLInjection/LEVEL_1");
-    }
-
-    private static ScannerResponseBean unsecure(String url, VulnerabilityType... types) {
-        return new ScannerResponseBean(url, "UNSECURE", RequestMethod.GET, Arrays.asList(types));
-    }
-
-    private static ScannerResponseBean secure(String url, VulnerabilityType... types) {
-        return new ScannerResponseBean(url, "SECURE", RequestMethod.GET, Arrays.asList(types));
-    }
-
-    private static ScannerFindings input(String tool, Finding... findings) {
-        List<Finding> list =
-                findings.length == 0 ? Collections.emptyList() : Arrays.asList(findings);
-        return new ScannerFindings(tool, list);
+    private static BenchmarkResult result(String tool) {
+        return new BenchmarkResult(
+                tool, 0.0, 0, 0, 0, 0, Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/BenchmarkServiceTest.java
@@ -1,0 +1,227 @@
+package org.sasanlabs.benchmark.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.beans.ScannerResponseBean;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.service.IEndPointsInformationProvider;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@ExtendWith(MockitoExtension.class)
+class BenchmarkServiceTest {
+
+    @Mock private IEndPointsInformationProvider provider;
+
+    private BenchmarkService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BenchmarkService(provider);
+    }
+
+    @Test
+    void perfectMatch_yields100Coverage() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS)));
+
+        BenchmarkResult result =
+                service.compare(
+                        input(
+                                "ZAP",
+                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                                new Finding("/XSS/LEVEL_1", "REFLECTED_XSS")));
+
+        assertThat(result.getCoverage()).isEqualTo(100.0);
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isEqualTo(2);
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getMissedItems()).isEmpty();
+        assertThat(result.getFalsePositiveItems()).isEmpty();
+    }
+
+    @Test
+    void allMissed_yieldsZeroCoverageAndNoFalsePositives() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS)));
+
+        BenchmarkResult result = service.compare(input("ZAP"));
+
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(2);
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getMissedItems())
+                .extracting(Finding::getUrl, Finding::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                        tuple("/XSS/LEVEL_1", "REFLECTED_XSS"));
+    }
+
+    @Test
+    void mixedDetectedMissedAndFalsePositive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/CommandInjection/LEVEL_1",
+                                        VulnerabilityType.COMMAND_INJECTION)));
+
+        BenchmarkResult result =
+                service.compare(
+                        input(
+                                "ZAP",
+                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                                new Finding("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL")));
+
+        assertThat(result.getTotalExpected()).isEqualTo(3);
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getMissed()).isEqualTo(2);
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getCoverage())
+                .isCloseTo(33.33, org.assertj.core.data.Offset.offset(0.01));
+        assertThat(result.getFalsePositiveItems())
+                .extracting(Finding::getUrl, Finding::getType)
+                .containsExactly(tuple("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL"));
+    }
+
+    @Test
+    void findingAgainstSecureUrl_isCountedAsFalsePositive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                secure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_2",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                service.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_2", "BLIND_SQL_INJECTION")));
+
+        assertThat(result.getTotalExpected()).isEqualTo(1);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getFalsePositiveItems())
+                .extracting(Finding::getUrl)
+                .containsExactly("/SQLInjection/LEVEL_2");
+    }
+
+    @Test
+    void emptyFindingsList_allExpectedAreMissed() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Collections.singletonList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                service.compare(new ScannerFindings("ZAP", Collections.emptyList()));
+
+        assertThat(result.getTotalExpected()).isEqualTo(1);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void emptyExpected_yieldsZeroCoverageAndAllFindingsBecomeFalsePositives() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation()).thenReturn(Collections.emptyList());
+
+        BenchmarkResult result =
+                service.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION")));
+
+        assertThat(result.getTotalExpected()).isZero();
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void typeMatchIsCaseInsensitive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Collections.singletonList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                service.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "blind_sql_injection")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void urlNormalization_acceptsAbsoluteRelativeAndContextStrippedForms() {
+        assertThat(
+                        BenchmarkService.normalizeUrl(
+                                "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(BenchmarkService.normalizeUrl("/VulnerableApp/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1/"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(BenchmarkService.normalizeUrl("/SQLInjection/LEVEL_1?attack=1' OR 1=1--"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+    }
+
+    private static ScannerResponseBean unsecure(String url, VulnerabilityType... types) {
+        return new ScannerResponseBean(url, "UNSECURE", RequestMethod.GET, Arrays.asList(types));
+    }
+
+    private static ScannerResponseBean secure(String url, VulnerabilityType... types) {
+        return new ScannerResponseBean(url, "SECURE", RequestMethod.GET, Arrays.asList(types));
+    }
+
+    private static ScannerFindings input(String tool, Finding... findings) {
+        List<Finding> list =
+                findings.length == 0 ? Collections.emptyList() : Arrays.asList(findings);
+        return new ScannerFindings(tool, list);
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
@@ -1,0 +1,131 @@
+package org.sasanlabs.benchmark.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sasanlabs.benchmark.model.ExpectedIssue;
+
+class CsvExpectedIssuesProviderTest {
+
+    private static final String HEADER = "CWE,Vulnerability Type,File,Line,Number of Sources\n";
+
+    @Test
+    void parsesHeaderAndAllValidRows(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                HEADER
+                        + "CWE-89,SQL Injection,src/main/java/Foo.java,56,1\n"
+                        + "CWE-79,Reflected XSS,src/main/java/Bar.java,42,3\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues)
+                .extracting(
+                        ExpectedIssue::getCwe,
+                        ExpectedIssue::getVulnerabilityType,
+                        ExpectedIssue::getFilePath,
+                        ExpectedIssue::getLine,
+                        ExpectedIssue::getNumberOfSources)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                "CWE-89", "SQL Injection", "src/main/java/Foo.java", 56, 1),
+                        org.assertj.core.groups.Tuple.tuple(
+                                "CWE-79", "Reflected XSS", "src/main/java/Bar.java", 42, 3));
+    }
+
+    @Test
+    void trimsWhitespaceInsideCells(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(csv, HEADER + "CWE-22,Path Traversal,src/main/java/Baz.java,65,12 \n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).hasSize(1);
+        assertThat(issues.get(0).getNumberOfSources()).isEqualTo(12);
+    }
+
+    @Test
+    void skipsBlankLines(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                HEADER
+                        + "\n"
+                        + "CWE-89,SQL Injection,src/main/java/Foo.java,56,1\n"
+                        + "   \n"
+                        + "CWE-79,Reflected XSS,src/main/java/Bar.java,42,3\n"
+                        + "\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).hasSize(2);
+    }
+
+    @Test
+    void skipsRowsWithTooFewColumns(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                HEADER
+                        + "CWE-89,SQL Injection,src/main/java/Foo.java,56,1\n"
+                        + "CWE-79,Reflected XSS,only,three\n"
+                        + "CWE-77,Command Injection,src/main/java/Cmd.java,46,5\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).hasSize(2);
+        assertThat(issues).extracting(ExpectedIssue::getCwe).containsExactly("CWE-89", "CWE-77");
+    }
+
+    @Test
+    void skipsRowsWithNonIntegerLineOrSources(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                HEADER
+                        + "CWE-89,SQL Injection,src/main/java/Foo.java,not-a-number,1\n"
+                        + "CWE-79,Reflected XSS,src/main/java/Bar.java,42,three\n"
+                        + "CWE-77,Command Injection,src/main/java/Cmd.java,46,5\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).hasSize(1);
+        assertThat(issues.get(0).getCwe()).isEqualTo("CWE-77");
+    }
+
+    @Test
+    void emptyFileWithOnlyHeader_returnsEmptyList(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(csv, HEADER);
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void missingFile_throwsIOException(@TempDir Path tempDir) {
+        String missing = tempDir.resolve("does-not-exist.csv").toString();
+
+        assertThatThrownBy(() -> new CsvExpectedIssuesProvider(missing).getExpectedIssues())
+                .isInstanceOf(IOException.class);
+    }
+
+    private static void write(Path path, String content) throws IOException {
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
@@ -107,6 +107,26 @@ class CsvExpectedIssuesProviderTest {
     }
 
     @Test
+    void quotedFieldWithEmbeddedCommas_isParsedAsSingleColumn(@TempDir Path tempDir)
+            throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                HEADER
+                        + "CWE-89,\"Injection, SQL\",src/main/java/Foo.java,56,1\n"
+                        + "CWE-79,\"XSS, Reflected\",src/main/java/Bar.java,42,3\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues)
+                .extracting(ExpectedIssue::getVulnerabilityType, ExpectedIssue::getLine)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("Injection, SQL", 56),
+                        org.assertj.core.groups.Tuple.tuple("XSS, Reflected", 42));
+    }
+
+    @Test
     void emptyFileWithOnlyHeader_returnsEmptyList(@TempDir Path tempDir) throws Exception {
         Path csv = tempDir.resolve("expected.csv");
         write(csv, HEADER);

--- a/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/CsvExpectedIssuesProviderTest.java
@@ -127,6 +127,19 @@ class CsvExpectedIssuesProviderTest {
     }
 
     @Test
+    void csvMissingRequiredHeader_skipsRowsAndReturnsEmpty(@TempDir Path tempDir) throws Exception {
+        Path csv = tempDir.resolve("expected.csv");
+        write(
+                csv,
+                "CWE,Vulnerability Type,Line,Number of Sources\n" + "CWE-89,SQL Injection,56,1\n");
+
+        List<ExpectedIssue> issues =
+                new CsvExpectedIssuesProvider(csv.toString()).getExpectedIssues();
+
+        assertThat(issues).isEmpty();
+    }
+
+    @Test
     void emptyFileWithOnlyHeader_returnsEmptyList(@TempDir Path tempDir) throws Exception {
         Path csv = tempDir.resolve("expected.csv");
         write(csv, HEADER);

--- a/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
@@ -1,0 +1,227 @@
+package org.sasanlabs.benchmark.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.beans.ScannerResponseBean;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+import org.sasanlabs.service.IEndPointsInformationProvider;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@ExtendWith(MockitoExtension.class)
+class DastBenchmarkStrategyTest {
+
+    @Mock private IEndPointsInformationProvider provider;
+
+    private DastBenchmarkStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new DastBenchmarkStrategy(provider);
+    }
+
+    @Test
+    void perfectMatch_yields100Coverage() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input(
+                                "ZAP",
+                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                                new Finding("/XSS/LEVEL_1", "REFLECTED_XSS")));
+
+        assertThat(result.getCoverage()).isEqualTo(100.0);
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isEqualTo(2);
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getMissedItems()).isEmpty();
+        assertThat(result.getFalsePositiveItems()).isEmpty();
+    }
+
+    @Test
+    void allMissed_yieldsZeroCoverageAndNoFalsePositives() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS)));
+
+        BenchmarkResult result = strategy.compare(input("ZAP"));
+
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(2);
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getMissedItems())
+                .extracting(Finding::getUrl, Finding::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                        tuple("/XSS/LEVEL_1", "REFLECTED_XSS"));
+    }
+
+    @Test
+    void mixedDetectedMissedAndFalsePositive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                                        VulnerabilityType.REFLECTED_XSS),
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/CommandInjection/LEVEL_1",
+                                        VulnerabilityType.COMMAND_INJECTION)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input(
+                                "ZAP",
+                                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION"),
+                                new Finding("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL")));
+
+        assertThat(result.getTotalExpected()).isEqualTo(3);
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getMissed()).isEqualTo(2);
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getCoverage())
+                .isCloseTo(33.33, org.assertj.core.data.Offset.offset(0.01));
+        assertThat(result.getFalsePositiveItems())
+                .extracting(Finding::getUrl, Finding::getType)
+                .containsExactly(tuple("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL"));
+    }
+
+    @Test
+    void findingAgainstSecureUrl_isCountedAsFalsePositive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Arrays.asList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION),
+                                secure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_2",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_2", "BLIND_SQL_INJECTION")));
+
+        assertThat(result.getTotalExpected()).isEqualTo(1);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getFalsePositiveItems())
+                .extracting(Finding::getUrl)
+                .containsExactly("/SQLInjection/LEVEL_2");
+    }
+
+    @Test
+    void emptyFindingsList_allExpectedAreMissed() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Collections.singletonList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                strategy.compare(new ScannerFindings("ZAP", Collections.emptyList()));
+
+        assertThat(result.getTotalExpected()).isEqualTo(1);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void emptyExpected_yieldsZeroCoverageAndAllFindingsBecomeFalsePositives() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation()).thenReturn(Collections.emptyList());
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION")));
+
+        assertThat(result.getTotalExpected()).isZero();
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void typeMatchIsCaseInsensitive() throws Exception {
+        when(provider.getScannerRelatedEndPointInformation())
+                .thenReturn(
+                        Collections.singletonList(
+                                unsecure(
+                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "blind_sql_injection")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void urlNormalization_acceptsAbsoluteRelativeAndContextStrippedForms() {
+        assertThat(
+                        DastBenchmarkStrategy.normalizeUrl(
+                                "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/VulnerableApp/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1/"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1?attack=1' OR 1=1--"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+    }
+
+    private static ScannerResponseBean unsecure(String url, VulnerabilityType... types) {
+        return new ScannerResponseBean(url, "UNSECURE", RequestMethod.GET, Arrays.asList(types));
+    }
+
+    private static ScannerResponseBean secure(String url, VulnerabilityType... types) {
+        return new ScannerResponseBean(url, "SECURE", RequestMethod.GET, Arrays.asList(types));
+    }
+
+    private static ScannerFindings input(String tool, Finding... findings) {
+        List<Finding> list =
+                findings.length == 0 ? Collections.emptyList() : Arrays.asList(findings);
+        return new ScannerFindings(tool, list);
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
@@ -368,6 +368,9 @@ class DastBenchmarkStrategyTest {
         assertThat(DastBenchmarkStrategy.normalizeNumericId("89")).isEqualTo("89");
         assertThat(DastBenchmarkStrategy.normalizeNumericId(" 89 ")).isEqualTo("89");
         assertThat(DastBenchmarkStrategy.normalizeNumericId("cwe89")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("WASC-08")).isEqualTo("8");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("CWE-089")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("00079")).isEqualTo("79");
         assertThat(DastBenchmarkStrategy.normalizeNumericId(null)).isEmpty();
         assertThat(DastBenchmarkStrategy.normalizeNumericId("not-a-number")).isEmpty();
     }

--- a/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
@@ -2,6 +2,8 @@ package org.sasanlabs.benchmark.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -16,33 +18,37 @@ import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.benchmark.model.BenchmarkResult;
 import org.sasanlabs.benchmark.model.Finding;
 import org.sasanlabs.benchmark.model.ScannerFindings;
-import org.sasanlabs.service.IEndPointsInformationProvider;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class DastBenchmarkStrategyTest {
 
-    @Mock private IEndPointsInformationProvider provider;
+    private static final String GROUND_TRUTH_URL = "http://localhost:9090/VulnerableApp/scanner";
+
+    @Mock private RestTemplate restTemplate;
 
     private DastBenchmarkStrategy strategy;
 
     @BeforeEach
     void setUp() {
-        strategy = new DastBenchmarkStrategy(provider);
+        strategy = new DastBenchmarkStrategy(restTemplate, GROUND_TRUTH_URL);
+    }
+
+    private void stubGroundTruth(ScannerResponseBean... beans) {
+        when(restTemplate.getForObject(eq(GROUND_TRUTH_URL), any(Class.class))).thenReturn(beans);
     }
 
     @Test
     void perfectMatch_yields100Coverage() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS)));
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION),
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                        VulnerabilityType.REFLECTED_XSS));
 
         BenchmarkResult result =
                 strategy.compare(
@@ -55,22 +61,20 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(2);
         assertThat(result.getDetected()).isEqualTo(2);
         assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
         assertThat(result.getMissedItems()).isEmpty();
-        assertThat(result.getFalsePositiveItems()).isEmpty();
+        assertThat(result.getUnmatchedItems()).isEmpty();
     }
 
     @Test
-    void allMissed_yieldsZeroCoverageAndNoFalsePositives() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS)));
+    void allMissed_yieldsZeroCoverageAndNoUnmatched() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION),
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                        VulnerabilityType.REFLECTED_XSS));
 
         BenchmarkResult result = strategy.compare(input("ZAP"));
 
@@ -78,7 +82,7 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(2);
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isEqualTo(2);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
         assertThat(result.getMissedItems())
                 .extracting(Finding::getUrl, Finding::getType)
                 .containsExactlyInAnyOrder(
@@ -87,19 +91,17 @@ class DastBenchmarkStrategyTest {
     }
 
     @Test
-    void mixedDetectedMissedAndFalsePositive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
-                                        VulnerabilityType.REFLECTED_XSS),
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/CommandInjection/LEVEL_1",
-                                        VulnerabilityType.COMMAND_INJECTION)));
+    void mixedDetectedMissedAndUnmatched() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION),
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                        VulnerabilityType.REFLECTED_XSS),
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/CommandInjection/LEVEL_1",
+                        VulnerabilityType.COMMAND_INJECTION));
 
         BenchmarkResult result =
                 strategy.compare(
@@ -111,25 +113,23 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(3);
         assertThat(result.getDetected()).isEqualTo(1);
         assertThat(result.getMissed()).isEqualTo(2);
-        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isEqualTo(1);
         assertThat(result.getCoverage())
                 .isCloseTo(33.33, org.assertj.core.data.Offset.offset(0.01));
-        assertThat(result.getFalsePositiveItems())
+        assertThat(result.getUnmatchedItems())
                 .extracting(Finding::getUrl, Finding::getType)
                 .containsExactly(tuple("/PathTraversal/LEVEL_1", "PATH_TRAVERSAL"));
     }
 
     @Test
-    void findingAgainstSecureUrl_isCountedAsFalsePositive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Arrays.asList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION),
-                                secure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_2",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+    void findingAgainstSecureUrl_isCountedAsUnmatched() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION),
+                secure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_2",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
 
         BenchmarkResult result =
                 strategy.compare(
@@ -138,20 +138,18 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(1);
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getFalsePositiveItems())
+        assertThat(result.getUnmatched()).isEqualTo(1);
+        assertThat(result.getUnmatchedItems())
                 .extracting(Finding::getUrl)
                 .containsExactly("/SQLInjection/LEVEL_2");
     }
 
     @Test
     void emptyFindingsList_allExpectedAreMissed() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Collections.singletonList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
 
         BenchmarkResult result =
                 strategy.compare(new ScannerFindings("ZAP", Collections.emptyList()));
@@ -159,13 +157,13 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(1);
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
         assertThat(result.getCoverage()).isEqualTo(0.0);
     }
 
     @Test
-    void emptyExpected_yieldsZeroCoverageAndAllFindingsBecomeFalsePositives() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation()).thenReturn(Collections.emptyList());
+    void emptyExpected_yieldsZeroCoverageAndAllFindingsBecomeUnmatched() throws Exception {
+        stubGroundTruth();
 
         BenchmarkResult result =
                 strategy.compare(
@@ -174,25 +172,204 @@ class DastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isZero();
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isEqualTo(1);
         assertThat(result.getCoverage()).isEqualTo(0.0);
     }
 
     @Test
     void typeMatchIsCaseInsensitive() throws Exception {
-        when(provider.getScannerRelatedEndPointInformation())
-                .thenReturn(
-                        Collections.singletonList(
-                                unsecure(
-                                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
-                                        VulnerabilityType.BLIND_SQL_INJECTION)));
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
 
         BenchmarkResult result =
                 strategy.compare(
                         input("ZAP", new Finding("/SQLInjection/LEVEL_1", "blind_sql_injection")));
 
         assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void cweMatch_detectsEvenWhenScannerEmitsForeignTypeName() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        Finding scannerFinding =
+                new Finding(
+                        "/SQLInjection/LEVEL_1",
+                        "SQL Injection - Boolean Based",
+                        null,
+                        null,
+                        "CWE-89");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void cweOnlyFinding_isDetected() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/XSS/LEVEL_1",
+                        VulnerabilityType.REFLECTED_XSS));
+
+        Finding scannerFinding = new Finding("/XSS/LEVEL_1", null, null, null, "79");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void wascOnlyFinding_isDetected() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/PathTraversal/LEVEL_1",
+                        VulnerabilityType.PATH_TRAVERSAL));
+
+        Finding scannerFinding =
+                new Finding("/PathTraversal/LEVEL_1", null, null, null, null, "33");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void cweMismatchOnDifferentUrl_isStillUnmatched() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        Finding scannerFinding =
+                new Finding("/SomeOtherEndpoint/LEVEL_1", null, null, null, "CWE-89");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getUnmatched()).isEqualTo(1);
+    }
+
+    @Test
+    void cweAndTypeBothCorrect_countsAsOneDetection() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        Finding scannerFinding =
+                new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION", null, null, "CWE-89");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getTotalExpected()).isEqualTo(1);
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void methodStrictMatch_whenScannerEmitsMatchingMethod() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        RequestMethod.GET,
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        Finding scannerFinding =
+                new Finding(
+                        "/SQLInjection/LEVEL_1",
+                        "BLIND_SQL_INJECTION",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "GET");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void methodMismatch_isUnmatched() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        RequestMethod.GET,
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        Finding scannerFinding =
+                new Finding(
+                        "/SQLInjection/LEVEL_1",
+                        "BLIND_SQL_INJECTION",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "POST");
+
+        BenchmarkResult result = strategy.compare(input("ZAP", scannerFinding));
+
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getUnmatched()).isEqualTo(1);
+        assertThat(result.getUnmatchedItems())
+                .extracting(Finding::getMethod)
+                .containsExactly("POST");
+    }
+
+    @Test
+    void methodOmitted_matchesAnyGroundTruthMethod() throws Exception {
+        stubGroundTruth(
+                unsecure(
+                        "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                        RequestMethod.POST,
+                        VulnerabilityType.BLIND_SQL_INJECTION));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        input("ZAP", new Finding("/SQLInjection/LEVEL_1", "BLIND_SQL_INJECTION")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isZero();
+    }
+
+    @Test
+    void groundTruthFetchFailure_isWrappedInIOException() {
+        when(restTemplate.getForObject(eq(GROUND_TRUTH_URL), any(Class.class)))
+                .thenThrow(new org.springframework.web.client.ResourceAccessException("connect"));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () ->
+                                strategy.compare(
+                                        input(
+                                                "ZAP",
+                                                new Finding(
+                                                        "/SQLInjection/LEVEL_1",
+                                                        "BLIND_SQL_INJECTION"))))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessageContaining(GROUND_TRUTH_URL);
+    }
+
+    @Test
+    void numericIdNormalization_acceptsCweDashAndBareDigits() {
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("CWE-89")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("cwe-89")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("89")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId(" 89 ")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("cwe89")).isEqualTo("89");
+        assertThat(DastBenchmarkStrategy.normalizeNumericId(null)).isEmpty();
+        assertThat(DastBenchmarkStrategy.normalizeNumericId("not-a-number")).isEmpty();
     }
 
     @Test
@@ -212,7 +389,12 @@ class DastBenchmarkStrategyTest {
     }
 
     private static ScannerResponseBean unsecure(String url, VulnerabilityType... types) {
-        return new ScannerResponseBean(url, "UNSECURE", RequestMethod.GET, Arrays.asList(types));
+        return unsecure(url, RequestMethod.GET, types);
+    }
+
+    private static ScannerResponseBean unsecure(
+            String url, RequestMethod method, VulnerabilityType... types) {
+        return new ScannerResponseBean(url, "UNSECURE", method, Arrays.asList(types));
     }
 
     private static ScannerResponseBean secure(String url, VulnerabilityType... types) {

--- a/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
@@ -1,0 +1,213 @@
+package org.sasanlabs.benchmark.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.benchmark.model.BenchmarkResult;
+import org.sasanlabs.benchmark.model.ExpectedIssue;
+import org.sasanlabs.benchmark.model.Finding;
+import org.sasanlabs.benchmark.model.ScanType;
+import org.sasanlabs.benchmark.model.ScannerFindings;
+
+@ExtendWith(MockitoExtension.class)
+class SastBenchmarkStrategyTest {
+
+    private static final String SQLI_FILE =
+            "src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/"
+                    + "BlindSQLInjectionVulnerability.java";
+    private static final String XSS_FILE =
+            "src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/"
+                    + "XSSWithHtmlTagInjection.java";
+
+    @Mock private IExpectedIssuesProvider provider;
+
+    private SastBenchmarkStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new SastBenchmarkStrategy(provider);
+    }
+
+    @Test
+    void perfectMatch_yields100Coverage() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Arrays.asList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56),
+                                expected("CWE-79", "Reflected XSS", XSS_FILE, 45)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection"),
+                                sastFinding(XSS_FILE, 45, "CWE-79", "Reflected XSS")));
+
+        assertThat(result.getCoverage()).isEqualTo(100.0);
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isEqualTo(2);
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void mixedDetectedMissedAndFalsePositive() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Arrays.asList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56),
+                                expected("CWE-79", "Reflected XSS", XSS_FILE, 45)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection"),
+                                sastFinding("src/main/java/Imaginary.java", 1, "CWE-99", "X")));
+
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getMissed()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getFalsePositiveItems())
+                .extracting(Finding::getFilePath, Finding::getLine)
+                .containsExactly(tuple("src/main/java/Imaginary.java", 1));
+    }
+
+    @Test
+    void cweOnlyFinding_matchesGroundTruth() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Collections.singletonList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56)));
+
+        BenchmarkResult result =
+                strategy.compare(sastInput("Semgrep", sastFinding(SQLI_FILE, 56, "CWE-89", null)));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void typeOnlyFindingCaseInsensitive_matchesGroundTruth() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Collections.singletonList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput("Semgrep", sastFinding(SQLI_FILE, 56, null, "sql injection")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void filePathNormalization_handlesBackslashesAndLeadingDotSlash() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Collections.singletonList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56)));
+
+        String windowsishPath = "./" + SQLI_FILE.replace('/', '\\');
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(windowsishPath, 56, "CWE-89", "SQL Injection")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void duplicateFindings_areCountedOnce() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Collections.singletonList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection"),
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection")));
+
+        assertThat(result.getDetected()).isEqualTo(1);
+        assertThat(result.getFalsePositives()).isZero();
+    }
+
+    @Test
+    void emptyExpected_allFindingsBecomeFalsePositives() throws Exception {
+        when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep", sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection")));
+
+        assertThat(result.getTotalExpected()).isZero();
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isZero();
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getCoverage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void emptyFindings_allExpectedAreMissed() throws Exception {
+        when(provider.getExpectedIssues())
+                .thenReturn(
+                        Arrays.asList(
+                                expected("CWE-89", "SQL Injection", SQLI_FILE, 56),
+                                expected("CWE-79", "Reflected XSS", XSS_FILE, 45)));
+
+        BenchmarkResult result =
+                strategy.compare(
+                        new ScannerFindings("Semgrep", ScanType.SAST, Collections.emptyList()));
+
+        assertThat(result.getTotalExpected()).isEqualTo(2);
+        assertThat(result.getDetected()).isZero();
+        assertThat(result.getMissed()).isEqualTo(2);
+        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getMissedItems())
+                .extracting(Finding::getFilePath, Finding::getLine, Finding::getCwe)
+                .containsExactlyInAnyOrder(
+                        tuple(SQLI_FILE, 56, "CWE-89"), tuple(XSS_FILE, 45, "CWE-79"));
+    }
+
+    @Test
+    void filePathNormalization_unitCases() {
+        assertThat(SastBenchmarkStrategy.normalizeFilePath("./src/main/java/Foo.java"))
+                .isEqualTo("src/main/java/Foo.java");
+        assertThat(SastBenchmarkStrategy.normalizeFilePath("src\\main\\java\\Foo.java"))
+                .isEqualTo("src/main/java/Foo.java");
+        assertThat(SastBenchmarkStrategy.normalizeFilePath("  ./src/main/Foo.java  "))
+                .isEqualTo("src/main/Foo.java");
+        assertThat(SastBenchmarkStrategy.normalizeFilePath(null)).isEqualTo("");
+    }
+
+    private static ExpectedIssue expected(String cwe, String type, String file, int line) {
+        return new ExpectedIssue(cwe, type, file, line, 1);
+    }
+
+    private static Finding sastFinding(String file, int line, String cwe, String type) {
+        return new Finding(null, type, file, line, cwe);
+    }
+
+    private static ScannerFindings sastInput(String tool, Finding... findings) {
+        List<Finding> list = Arrays.asList(findings);
+        return new ScannerFindings(tool, ScanType.SAST, list);
+    }
+}

--- a/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
@@ -150,6 +150,21 @@ class SastBenchmarkStrategyTest {
     }
 
     @Test
+    void duplicateFindingsWithDifferingOptionalFields_areCountedOnce() throws Exception {
+        when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection"),
+                                sastFinding(SQLI_FILE, 56, null, "SQL Injection")));
+
+        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getFalsePositiveItems()).hasSize(1);
+    }
+
+    @Test
     void emptyExpected_allFindingsBecomeFalsePositives() throws Exception {
         when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
 

--- a/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
@@ -165,6 +165,22 @@ class SastBenchmarkStrategyTest {
     }
 
     @Test
+    void duplicateFindingsWithDifferingOptionalFields_inverseOrder_areCountedOnce()
+            throws Exception {
+        when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
+
+        BenchmarkResult result =
+                strategy.compare(
+                        sastInput(
+                                "Semgrep",
+                                sastFinding(SQLI_FILE, 56, null, "SQL Injection"),
+                                sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection")));
+
+        assertThat(result.getUnmatched()).isEqualTo(1);
+        assertThat(result.getUnmatchedItems()).hasSize(1);
+    }
+
+    @Test
     void emptyExpected_allFindingsBecomeUnmatched() throws Exception {
         when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
 

--- a/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/SastBenchmarkStrategyTest.java
@@ -56,11 +56,11 @@ class SastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(2);
         assertThat(result.getDetected()).isEqualTo(2);
         assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
     }
 
     @Test
-    void mixedDetectedMissedAndFalsePositive() throws Exception {
+    void mixedDetectedMissedAndUnmatched() throws Exception {
         when(provider.getExpectedIssues())
                 .thenReturn(
                         Arrays.asList(
@@ -77,8 +77,8 @@ class SastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(2);
         assertThat(result.getDetected()).isEqualTo(1);
         assertThat(result.getMissed()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getFalsePositiveItems())
+        assertThat(result.getUnmatched()).isEqualTo(1);
+        assertThat(result.getUnmatchedItems())
                 .extracting(Finding::getFilePath, Finding::getLine)
                 .containsExactly(tuple("src/main/java/Imaginary.java", 1));
     }
@@ -94,7 +94,7 @@ class SastBenchmarkStrategyTest {
                 strategy.compare(sastInput("Semgrep", sastFinding(SQLI_FILE, 56, "CWE-89", null)));
 
         assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
     }
 
     @Test
@@ -109,7 +109,7 @@ class SastBenchmarkStrategyTest {
                         sastInput("Semgrep", sastFinding(SQLI_FILE, 56, null, "sql injection")));
 
         assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
     }
 
     @Test
@@ -128,7 +128,7 @@ class SastBenchmarkStrategyTest {
                                 sastFinding(windowsishPath, 56, "CWE-89", "SQL Injection")));
 
         assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
     }
 
     @Test
@@ -146,7 +146,7 @@ class SastBenchmarkStrategyTest {
                                 sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection")));
 
         assertThat(result.getDetected()).isEqualTo(1);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
     }
 
     @Test
@@ -160,12 +160,12 @@ class SastBenchmarkStrategyTest {
                                 sastFinding(SQLI_FILE, 56, "CWE-89", "SQL Injection"),
                                 sastFinding(SQLI_FILE, 56, null, "SQL Injection")));
 
-        assertThat(result.getFalsePositives()).isEqualTo(1);
-        assertThat(result.getFalsePositiveItems()).hasSize(1);
+        assertThat(result.getUnmatched()).isEqualTo(1);
+        assertThat(result.getUnmatchedItems()).hasSize(1);
     }
 
     @Test
-    void emptyExpected_allFindingsBecomeFalsePositives() throws Exception {
+    void emptyExpected_allFindingsBecomeUnmatched() throws Exception {
         when(provider.getExpectedIssues()).thenReturn(Collections.emptyList());
 
         BenchmarkResult result =
@@ -176,7 +176,7 @@ class SastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isZero();
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isZero();
-        assertThat(result.getFalsePositives()).isEqualTo(1);
+        assertThat(result.getUnmatched()).isEqualTo(1);
         assertThat(result.getCoverage()).isEqualTo(0.0);
     }
 
@@ -195,7 +195,7 @@ class SastBenchmarkStrategyTest {
         assertThat(result.getTotalExpected()).isEqualTo(2);
         assertThat(result.getDetected()).isZero();
         assertThat(result.getMissed()).isEqualTo(2);
-        assertThat(result.getFalsePositives()).isZero();
+        assertThat(result.getUnmatched()).isZero();
         assertThat(result.getMissedItems())
                 .extracting(Finding::getFilePath, Finding::getLine, Finding::getCwe)
                 .containsExactlyInAnyOrder(


### PR DESCRIPTION
## Summary

  Closes #553. 
  Adds a comparator that grades a scanner's findings against the ground truth VulnerableApp already ships, and writes a coverage / missed / false-positive report. 
  Supports both **DAST** (against `/scanner`) and **SAST** (against `scanner/sast/expectedIssues.csv`) through one endpoint.

 LLM-based scanner support is deliberately deferred — there is no equivalent ground-truth source yet, and we'd rather see real LLM scanner output formats before committing to a matcher.

  ## What's in this PR

  - **Endpoint:** `POST /scanner/benchmark` accepting tool-agnostic JSON with optional `scanType` (DAST or SAST, defaults to DAST).
  - **Strategy pattern:** `BenchmarkService` dispatches to `DastBenchmarkStrategy` or `SastBenchmarkStrategy`. Adding a third scan type later is mechanical.
  - **DAST matching:** set-based on `(normalizedUrl, vulnerabilityType)`. URLs are stripped to a context-relative path. SECURE-variant findings count as false positives.
  - **SAST matching:** `(filePath, line, CWE)` *or* `(filePath, line, type-label)` — either side wins. Path backslashes / leading `./` normalised; CWE upper-cased, type lower-cased; duplicate findings de-duped.
  - **Result file** at `benchmarks/<tool>-results.json` (override via `benchmark.output.dir`). Filename sanitised. Overwrites on rerun.
  - **SAST CSV path** configurable via `benchmark.sast.ground-truth.path` (default: `scanner/sast/expectedIssues.csv`).
  - **Samples:** `benchmarks/samples/zap-findings-sample.json` (DAST) and `benchmarks/samples/semgrep-sast-sample.json` (SAST), each with one deliberate FP for demo.
  - **Docs:** `benchmarks/README.md` rewritten for both modes; `docs/HOW-TO-USE-VulnerableApp.md` benchmark section extended.
  - **Tests:** ~40 benchmark tests across `BenchmarkServiceTest` (dispatch), `DastBenchmarkStrategyTest`, `SastBenchmarkStrategyTest`, `CsvExpectedIssuesProviderTest`, `BenchmarkResultWriterTest`,   
  `BenchmarkControllerTest`. `./gradlew build` green.

  ## Open questions for reviewers

  Real tradeoffs where I picked a default — happy to flip any of these.

  **DAST**

  1. **URL match strictness** — match key is `(normalizedPath, type)`. HTTP method appears in ground truth but isn't part of the key. OK?
  2. **Type vocabulary** — match against `VulnerabilityType` enum names. CWE-based DAST matching is a likely follow-up; no need to do it here?
  3. **SECURE-variant findings = false positives** (single bucket, no separate reason code). OK?
  4. **Result-file lifecycle** — rerun overwrites the previous file. Want timestamped files instead?

  **SAST**

  5. **CWE vs type for matching** — current contract is "either side wins". Should we require CWE (more rigorous, narrower scanner support) or type-only (easier, less precise)?
  6. **Path normalisation** — backslashes + leading `./` are stripped; absolute paths and unexpected prefixes don't match. Should we attempt suffix matching for absolute paths?
  7. **`Number of Sources` column** — currently full credit on first match. Should detection be weighted by the column?
  8. **LLM-as-follow-up** — confirming you're OK with shipping DAST+SAST now and tracking LLM separately once we see real LLM scanner output formats.

  ## How to test locally

  ```bash
  ./gradlew build       # all tests green
  ./gradlew bootRun     # in one shell

  # in another shell
  curl -X POST http://localhost:9090/VulnerableApp/scanner/benchmark \
    -H "Content-Type: application/json" \
    -d @benchmarks/samples/zap-findings-sample.json

  curl -X POST http://localhost:9090/VulnerableApp/scanner/benchmark \
    -H "Content-Type: application/json" \
    -d @benchmarks/samples/semgrep-sast-sample.json

  ls benchmarks/        # zap-results.json, semgrep-results.json
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scanner benchmarking feature with a POST /scanner/benchmark endpoint that evaluates DAST and SAST results, returns coverage/detected/missed/unmatched metrics and writes per-tool JSON reports.

* **Samples**
  * Included example benchmark payloads for ZAP and Semgrep to help format submissions.

* **Documentation**
  * Added detailed benchmarking docs and HOW‑TO with request/response examples, matching rules, normalization, and report locations.

* **Chores**
  * Ignored runtime benchmark output files (benchmarks/*-results.json).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->