### PR TITLE
feat: added @Profile("public") to infra-safe vulnerability controllers

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
@@ -9,6 +9,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author ayash911
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "AUTHENTICATION_VULNERABILITY",
         value = "AuthenticationVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
@@ -19,11 +19,13 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CACHE_POISONING_VULNERABILITY",
         value = "CachePoisoning")

--- a/src/main/java/org/sasanlabs/service/vulnerability/clickjacking/ClickjackingVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/clickjacking/ClickjackingVulnerability.java
@@ -7,6 +7,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 
@@ -25,6 +26,7 @@ import org.springframework.http.ResponseEntity;
  *
  * @author Roshan Banisetti banisettirosh@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CLICKJACKING_VULNERABILITY",
         value = "ClickjackingVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CRYPTOGRAPHIC_FAILURES_VULNERABILITY",
         value = "CryptographicFailures")

--- a/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORVulnerability.java
@@ -9,12 +9,14 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Profile("public")
 @VulnerableAppRestController(descriptionLabel = "IDOR_VULNERABILITY", value = "IDORVulnerability")
 public class IDORVulnerability {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -24,6 +24,7 @@ import org.sasanlabs.service.vulnerability.jwt.keys.JWTAlgorithmKMS;
 import org.sasanlabs.service.vulnerability.jwt.keys.KeyStrength;
 import org.sasanlabs.service.vulnerability.jwt.keys.SymmetricAlgorithmKey;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "JWT_INJECTION_VULNERABILITY",
         value = "JWTVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
@@ -17,6 +17,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * <p>LDAP Injection occurs when user input is directly used in LDAP filters without sanitization,
  * allowing attackers to manipulate the query.
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "LDAP_INJECTION_VULNERABILITY",
         value = "LDAPInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
@@ -16,6 +16,7 @@ import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "OPEN_REDIRECTION_VULNERABILITY_3XX_BASED",
         value = "Http3xxStatusCodeBasedInjection")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "BlindSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
@@ -14,6 +14,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "ErrorBasedSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -16,6 +16,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "UnionBasedSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "XSS_VULNERABILITY",
         value = "PersistentXSSInHTMLTagVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSInImgTagAttribute.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSInImgTagAttribute.java
@@ -10,6 +10,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,6 +24,7 @@ import org.springframework.web.util.HtmlUtils;
  * @author t0bel1x t0bel1x.git@gmail.com
  * @author pdelmonego philipp.delmonego@live.de
  */
+@Profile("public")
 @VulnerableAppRestController(descriptionLabel = "XSS_VULNERABILITY", value = "XSSInImgTagAttribute")
 public class XSSInImgTagAttribute {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
@@ -10,6 +10,7 @@ import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +21,7 @@ import org.springframework.web.util.HtmlUtils;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "XSS_VULNERABILITY",
         value = "XSSWithHtmlTagInjection")


### PR DESCRIPTION
Changes
Added @Profile("public") to 14 public-safe vulnerability controllers whose impact is within the app or browser.

Controllers tagged @Profile("public") will load only when the app is started with spring.profiles.active=public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated vulnerability demonstration components to be profile-aware. Multiple controllers and services are now conditionally loaded only when the 'public' Spring profile is active, providing better control over component availability across different deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SasanLabs/VulnerableApp/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->