### PR TITLE
Added @Profile("public"/"unsafe") to all vulnerability controllers

### DIFF
--- a/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
+++ b/src/main/java/org/sasanlabs/benchmark/controller/BenchmarkController.java
@@ -9,6 +9,7 @@ import org.sasanlabs.benchmark.model.BenchmarkResult;
 import org.sasanlabs.benchmark.model.ScannerFindings;
 import org.sasanlabs.benchmark.service.BenchmarkResultWriter;
 import org.sasanlabs.benchmark.service.BenchmarkService;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  * REST entry point for benchmarking a scanner's findings against VulnerableApp's DAST ground truth.
  * Mounted alongside the existing {@code /scanner} and {@code /scanner/metadata} endpoints.
  */
+@Profile("unsafe")
 @RestController
 public class BenchmarkController {
 

--- a/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
+++ b/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
@@ -15,6 +15,7 @@ import org.sasanlabs.service.IEndPointsInformationProvider;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerableapp.facade.schema.VulnerabilityDefinition;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @RestController
 public class VulnerableAppRestController {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
@@ -9,6 +9,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author ayash911
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "AUTHENTICATION_VULNERABILITY",
         value = "AuthenticationVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
@@ -19,11 +19,13 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CACHE_POISONING_VULNERABILITY",
         value = "CachePoisoning")

--- a/src/main/java/org/sasanlabs/service/vulnerability/clickjacking/ClickjackingVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/clickjacking/ClickjackingVulnerability.java
@@ -7,6 +7,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 
@@ -25,6 +26,7 @@ import org.springframework.http.ResponseEntity;
  *
  * @author Roshan Banisetti banisettirosh@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CLICKJACKING_VULNERABILITY",
         value = "ClickjackingVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/commandInjection/CommandInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/commandInjection/CommandInjection.java
@@ -14,6 +14,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.exception.ServiceApplicationException;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("unsafe")
 @VulnerableAppRestController(
         descriptionLabel = "COMMAND_INJECTION_VULNERABILITY",
         value = "CommandInjection")

--- a/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "CRYPTOGRAPHIC_FAILURES_VULNERABILITY",
         value = "CryptographicFailures")

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/PreflightController.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/PreflightController.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import org.apache.commons.io.IOUtils;
 import org.sasanlabs.internal.utility.FrameworkConstants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("unsafe")
 @RestController
 public class PreflightController {
     private UnrestrictedFileUpload unrestrictedFileUpload;

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -26,6 +26,7 @@ import org.sasanlabs.service.exception.ServiceApplicationException;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -39,6 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
  *     <p>https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects
  *     <p>https://www.youtube.com/watch?v=CmF9sEyKZNo
  */
+@Profile("unsafe")
 @VulnerableAppRestController(
         descriptionLabel = "UNRESTRICTED_FILE_UPLOAD_VULNERABILITY",
         value = UnrestrictedFileUpload.CONTROLLER_PATH)

--- a/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORLoginController.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORLoginController.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile("public")
 @RestController
 @RequestMapping("IDORVulnerability")
 public class IDORLoginController {

--- a/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/idor/IDORVulnerability.java
@@ -9,12 +9,14 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Profile("public")
 @VulnerableAppRestController(descriptionLabel = "IDOR_VULNERABILITY", value = "IDORVulnerability")
 public class IDORVulnerability {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -24,6 +24,7 @@ import org.sasanlabs.service.vulnerability.jwt.keys.JWTAlgorithmKMS;
 import org.sasanlabs.service.vulnerability.jwt.keys.KeyStrength;
 import org.sasanlabs.service.vulnerability.jwt.keys.SymmetricAlgorithmKey;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "JWT_INJECTION_VULNERABILITY",
         value = "JWTVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
@@ -17,6 +17,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * <p>LDAP Injection occurs when user input is directly used in LDAP filters without sanitization,
  * allowing attackers to manipulate the query.
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "LDAP_INJECTION_VULNERABILITY",
         value = "LDAPInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
@@ -16,6 +16,7 @@ import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "OPEN_REDIRECTION_VULNERABILITY_3XX_BASED",
         value = "Http3xxStatusCodeBasedInjection")

--- a/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
@@ -18,6 +18,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("unsafe")
 @VulnerableAppRestController(
         descriptionLabel = "PATH_TRAVERSAL_VULNERABILITY",
         value = "PathTraversal")

--- a/src/main/java/org/sasanlabs/service/vulnerability/rfi/UrlParamBasedRFI.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/rfi/UrlParamBasedRFI.java
@@ -13,6 +13,7 @@ import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.pathTraversal.PathTraversalVulnerability;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,6 +22,7 @@ import org.springframework.web.client.RestTemplate;
 /**
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("unsafe")
 @VulnerableAppRestController(
         descriptionLabel = "URL_BASED_RFI_INJECTION",
         value = "RemoteFileInclusion")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/BlindSQLInjectionVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "BlindSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
@@ -14,6 +14,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "ErrorBasedSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -16,6 +16,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "SQL_INJECTION_VULNERABILITY",
         value = "UnionBasedSQLInjectionVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -18,6 +18,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author GitHub : gled02
  */
+@Profile("unsafe")
 @VulnerableAppRestController(descriptionLabel = "SSRF_VULNERABILITY", value = "SSRFVulnerability")
 public class SSRFVulnerability {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
@@ -11,6 +11,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author preetkaran20@gmail.com KSASAN
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "XSS_VULNERABILITY",
         value = "PersistentXSSInHTMLTagVulnerability")

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSInImgTagAttribute.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSInImgTagAttribute.java
@@ -10,6 +10,7 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,6 +24,7 @@ import org.springframework.web.util.HtmlUtils;
  * @author t0bel1x t0bel1x.git@gmail.com
  * @author pdelmonego philipp.delmonego@live.de
  */
+@Profile("public")
 @VulnerableAppRestController(descriptionLabel = "XSS_VULNERABILITY", value = "XSSInImgTagAttribute")
 public class XSSInImgTagAttribute {
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
@@ -10,6 +10,7 @@ import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +21,7 @@ import org.springframework.web.util.HtmlUtils;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("public")
 @VulnerableAppRestController(
         descriptionLabel = "XSS_VULNERABILITY",
         value = "XSSWithHtmlTagInjection")

--- a/src/main/java/org/sasanlabs/service/vulnerability/xxe/XXEVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xxe/XXEVulnerability.java
@@ -23,6 +23,7 @@ import org.sasanlabs.service.vulnerability.xxe.bean.ObjectFactory;
 import org.sasanlabs.service.vulnerability.xxe.dao.BookEntity;
 import org.sasanlabs.service.vulnerability.xxe.dao.BookEntityRepository;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -46,6 +47,7 @@ import org.xml.sax.SAXException;
  *
  * @author KSASAN preetkaran20@gmail.com
  */
+@Profile("unsafe")
 @VulnerableAppRestController(descriptionLabel = "XXE_VULNERABILITY", value = "XXEVulnerability")
 public class XXEVulnerability {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ spring.h2.console.settings.web-allow-others=true
 # Custom H2 Console URL
 spring.h2.console.path=/h2
 
+spring.profiles.active=public,unsafe
+
 # Pre-Populating data and schema is handled by DataSourceInitializer bean in VulnerableAppConfiguration.java
 spring.jpa.hibernate.ddl-auto=none
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.h2.console.settings.web-allow-others=true
 # Custom H2 Console URL
 spring.h2.console.path=/h2
 
-spring.profiles.active=public,unsafe
+spring.profiles.active=public
 
 # Pre-Populating data and schema is handled by DataSourceInitializer bean in VulnerableAppConfiguration.java
 spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.h2.console.settings.web-allow-others=true
 # Custom H2 Console URL
 spring.h2.console.path=/h2
 
-spring.profiles.active=public
+spring.profiles.active=public,unsafe
 
 # Pre-Populating data and schema is handled by DataSourceInitializer bean in VulnerableAppConfiguration.java
 spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/sampleVulnerability/sampleVulnerability/SampleVulnerability.java
+++ b/src/main/resources/sampleVulnerability/sampleVulnerability/SampleVulnerability.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  * {@code VulnerableAppRestController} annotation is similar to {@link
  * org.springframework.stereotype.Controller} Annotation
  */
+@Profile("public")
 @VulnerableAppRestController(
         /**
          * "descriptionLabel" parameter of annotation is i18n label stored in {@link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Demo controllers and endpoints are now environment-gated and only load for the relevant profile ("public" or "unsafe").
  * Default active profiles now include both "public" and "unsafe", enabling both sets of demo features by default.
  * Benchmarking and unsafe-demo endpoints remain restricted to the "unsafe" profile for selective activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SasanLabs/VulnerableApp/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->