### PR TITLE
docs: Add Reflected XSS vulnerability report for XSSWithHtmlTagInjection

### DIFF
--- a/docs/security-reports/XSSWithHtmlTagInjection.md
+++ b/docs/security-reports/XSSWithHtmlTagInjection.md
@@ -1,0 +1,21 @@
+# Reflected Cross-Site Scripting (XSS) via Unsanitized Query Parameter Reflection
+
+## Summary
+A Reflected Cross-Site Scripting (XSS) vulnerability exists in the `XSSWithHtmlTagInjection` controller at `LEVEL_1`. The application directly reflects arbitrary query parameter values into the HTML response without any output encoding or sanitization, allowing attackers to execute arbitrary JavaScript in the context of the victim's browser session.
+
+## Vulnerability Details
+- **Vulnerability Type**: Reflected XSS
+- **Affected URL**: `/VulnerableApp/XSSWithHtmlTagInjection/LEVEL_1`
+- **Affected Parameter**: Any URL query parameter
+
+The controller method `getVulnerablePayloadLevel1` extracts all query parameters and passes them directly to `String.format("<div>%s<div>", map.getValue())`. This formatted string is passed back to the client as an HTTP response. Because Spring Boot sets `Content-Type: text/html` by default for string responses, modern browsers render and execute injected `<script>` tags.
+
+## Steps to Reproduce
+1. Navigate to: `http://localhost:9090/VulnerableApp/XSSWithHtmlTagInjection/LEVEL_1?payload=<script>alert('XSS')</script>`
+2. Observe the execution of the JavaScript alert.
+
+## Impact
+If successfully exploited, an attacker can steal session cookies, hijack user sessions, perform unauthorized actions on behalf of the user, or redirect the user to malicious sites.
+
+## Remediation
+Apply strict context-aware output encoding to all user-supplied data before rendering it in the HTML response. In Spring, use `HtmlUtils.htmlEscape()` or `StringEscapeUtils.escapeHtml4()` on the parameter value before appending it to the payload builder.


### PR DESCRIPTION
### Description
This PR adds a comprehensive vulnerability report for the `LEVEL_1` Reflected XSS flaw in `XSSWithHtmlTagInjection.java`. This documentation is intended to support security testing and scanner benchmarking by providing a clear, reproducible baseline for this specific attack vector.

### Changes Made
- Added a new Markdown vulnerability report detailing the exact endpoint, payload, and vulnerable code snippet.
- Included reproducible steps tailored for a local Docker-based setup.

### Testing Instructions
1. Checkout this branch.
2. Ensure the local stack is running via Docker Compose.
3. Verify the payload works as documented by visiting `http://localhost/VulnerableApp/XSSWithHtmlTagInjection/LEVEL_1?payload=%3Cscript%3Ealert(document.domain)%3C/script%3E`.

Fixes #610


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security report documenting a reflected XSS vulnerability, including affected endpoints, reproduction steps, potential impact, and remediation guidance through proper output encoding techniques.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SasanLabs/VulnerableApp/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->