### PR TITLE
fix: replace llmforge local build context with Docker Hub image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,7 @@ services:
         - app_net
 
     llmforge:
-      build:
-        context: ../llmforge
+      image: sasanlabs/llmforge:latest
       depends_on:
         ollama:
           condition: service_healthy


### PR DESCRIPTION

Closes #629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to use a prebuilt container image instead of building from local source, enabling faster and more consistent deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SasanLabs/VulnerableApp/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->