### PR TITLE
Add Mailpit SMTP service to docker-compose

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,14 +10,35 @@ services:
   VulnerableApp-php:
     image: sasanlabs/owasp-vulnerableapp-php:latest
   
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    # SMTP is reachable only inside the compose network on 1025; the web UI is
+    # published on 8025 so captured mail can be inspected from the host.
+    expose:
+      - "1025"
+    ports:
+      - "8025:8025"
+    environment:
+      - MP_MAX_MESSAGES=5000
+      - MP_DATABASE=/data/mailpit.db
+      - MP_SMTP_AUTH_ACCEPT_ANY=1
+      - MP_SMTP_AUTH_ALLOW_INSECURE=1
+    volumes:
+      - mailpit_data:/data
+
   VulnerableApp-facade:
     depends_on:
       - VulnerableApp-base
       - VulnerableApp-jsp
       - VulnerableApp-php
+      - mailpit
     image: sasanlabs/owasp-vulnerableapp-facade:latest
     ports:
       - "80:80"
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
+
+volumes:
+  mailpit_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,12 +73,34 @@ services:
           aliases:
             - llmforge
     
+    mailpit:
+      image: axllent/mailpit:latest
+      restart: unless-stopped
+      # SMTP is reachable only inside the compose network on 1025; the web UI is
+      # published on 8025 so captured mail can be inspected from the host.
+      expose:
+       - "1025"
+      ports:
+       - "8025:8025"
+      environment:
+       - MP_MAX_MESSAGES=5000
+       - MP_DATABASE=/data/mailpit.db
+       - MP_SMTP_AUTH_ACCEPT_ANY=1
+       - MP_SMTP_AUTH_ALLOW_INSECURE=1
+      volumes:
+       - mailpit_data:/data
+      networks:
+        app_net:
+          aliases:
+            - mailpit
+
     VulnerableApp-facade:
       depends_on:
         - VulnerableApp-base
         - VulnerableApp-jsp
         - VulnerableApp-php
         - llmforge
+        - mailpit
       image: sasanlabs/owasp-vulnerableapp-facade:latest
       volumes:
        - ./templates:/etc/nginx/templates
@@ -100,3 +122,4 @@ networks:
 
 volumes:
   ollama_data:
+  mailpit_data:


### PR DESCRIPTION
## Summary

Addresses #649 — adds a [Mailpit](https://github.com/axllent/mailpit) SMTP service so mail-sending flows in the lab can be captured and inspected instead of silently dropped.

## Changes
- New `mailpit` service (`axllent/mailpit:latest`) in both `docker-compose.yml` and `docker-compose.local.yml`.
- SMTP exposed on **1025 internal-only** (`expose:`); web UI published on **8025** to the host.
- New `mailpit_data` named volume for message persistence.
- `mailpit` added to `VulnerableApp-facade` `depends_on`.

## How to use
After `docker compose up`, point any app's SMTP at `mailpit:1025` (in-network) and open the inbox UI at **http://localhost:8025**.

## Notes
- `MP_SMTP_AUTH_ACCEPT_ANY` / `MP_SMTP_AUTH_ALLOW_INSECURE` are enabled since this is a deliberately vulnerable lab environment where any credentials should be accepted for testing.
- The facade/LLMForge repos mentioned in the issue are separate; this PR scopes to the VulnerableApp compose files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email service integration now available for development and testing environments with a dedicated web interface for managing test emails.

* **Chores**
  * Updated Docker Compose configuration to support email functionality with persistent data storage across service restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->