### PR TITLE
feat: Add Email Header Injection vulnerability module (#651)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ tasks.register('GenerateSampleVulnerability'){
 dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
 
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-mail
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
+
     // https://mvnrepository.com/artifact/org.mockito/mockito-core
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.5.13'
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailHeaderInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailHeaderInjection.java
@@ -1,0 +1,201 @@
+package org.sasanlabs.service.vulnerability.emailHeaderInjection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * This class contains vulnerabilities related to <strong>Email Header Injection</strong> (also
+ * known as SMTP Header Injection).
+ *
+ * <p>Email Header Injection occurs when user-controlled data is inserted into SMTP message headers
+ * (such as {@code To}, {@code Subject}, {@code CC}, or {@code BCC}) without stripping CRLF ({@code
+ * \r\n}) sequences. Because SMTP uses CRLF as a header delimiter, an attacker can inject additional
+ * headers to:
+ *
+ * <ul>
+ *   <li>Add unintended recipients via injected {@code CC:} / {@code BCC:} headers
+ *   <li>Relay spam through a trusted mail server
+ *   <li>Perform phishing attacks using the application's mail infrastructure
+ * </ul>
+ *
+ * <p>Three levels are provided:
+ *
+ * <ul>
+ *   <li><strong>Level 1 (Fully Vulnerable):</strong> User-supplied {@code toEmail} and {@code
+ *       subject} are used directly — no sanitization at all.
+ *   <li><strong>Level 2 (Partially Mitigated):</strong> Only {@code \n} (LF) is checked and
+ *       rejected; {@code \r} (CR) alone or the sequence {@code \r\n} encoded differently can still
+ *       bypass this check.
+ *   <li><strong>Level 3 (Secure):</strong> All CRLF characters ({@code \r} and {@code \n}) are
+ *       stripped from both {@code toEmail} and {@code subject} before the email is sent.
+ * </ul>
+ *
+ * @see <a href="https://owasp.org/www-community/attacks/Email_Header_Injection">OWASP – Email
+ *     Header Injection</a>
+ * @see <a href="https://cwe.mitre.org/data/definitions/93.html">CWE-93 – Improper Neutralization of
+ *     CRLF Sequences</a>
+ * @author VulnerableApp contributors
+ */
+@Profile("unsafe")
+@VulnerableAppRestController(
+        descriptionLabel = "EMAIL_HEADER_INJECTION_VULNERABILITY",
+        value = "EmailHeaderInjection")
+public class EmailHeaderInjection {
+
+    private static final transient Logger LOGGER = LogManager.getLogger(EmailHeaderInjection.class);
+
+    private static final String TO_EMAIL_PARAM = "toEmail";
+    private static final String SUBJECT_PARAM = "subject";
+    private static final String BODY_PARAM = "body";
+    private static final String DEFAULT_BODY = "This is a test email from VulnerableApp.";
+
+    private final EmailService emailService;
+
+    public EmailHeaderInjection(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    // -------------------------------------------------------------------------
+    // LEVEL 1 – No validation whatsoever
+    // -------------------------------------------------------------------------
+
+    /**
+     * <strong>Level 1 – Fully Vulnerable (No Sanitization)</strong>
+     *
+     * <p>The {@code toEmail} and {@code subject} request parameters are passed directly to the mail
+     * sender without any validation or encoding. An attacker can inject a CRLF sequence into either
+     * parameter to add arbitrary SMTP headers.
+     *
+     * <p><strong>Example exploit (subject injection):</strong>
+     *
+     * <pre>
+     * subject=Hello%0D%0ACC:%20attacker@evil.com
+     * </pre>
+     *
+     * <p>The resulting SMTP message will contain an injected {@code CC} header, causing a copy of
+     * the email to be delivered to {@code attacker@evil.com}.
+     */
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.EMAIL_HEADER_INJECTION,
+            description = "EMAIL_HEADER_INJECTION_NO_VALIDATION",
+            payload = "EMAIL_HEADER_INJECTION_PAYLOAD_LEVEL_1")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_1,
+            htmlTemplate = "LEVEL_1/EmailHeaderInjection")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel1(
+            @RequestParam(TO_EMAIL_PARAM) String toEmail,
+            @RequestParam(value = SUBJECT_PARAM, defaultValue = "Test Email") String subject,
+            @RequestParam(value = BODY_PARAM, defaultValue = DEFAULT_BODY) String body) {
+        try {
+            emailService.sendEmail(toEmail, subject, body);
+            return successResponse("Email sent to: " + toEmail + " with subject: " + subject);
+        } catch (Exception e) {
+            LOGGER.error("Failed to send email at Level 1", e);
+            return errorResponse("Failed to send email: " + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // LEVEL 2 – Partial mitigation: checks \n but misses \r
+    // -------------------------------------------------------------------------
+
+    /**
+     * <strong>Level 2 – Partially Mitigated (Incomplete CRLF Check)</strong>
+     *
+     * <p>This level attempts to prevent header injection by rejecting values that contain a
+     * linefeed ({@code \n}) character. However, it fails to check for a bare carriage return
+     * ({@code \r}). Some SMTP implementations treat {@code \r} alone as a line terminator, making
+     * this validation bypassable.
+     *
+     * <p><strong>Bypass technique:</strong> Use {@code %0D} (URL-encoded {@code \r}) instead of the
+     * more commonly blocked {@code %0A} ({@code \n}).
+     *
+     * <pre>
+     * subject=Hello%0DCC:%20attacker@evil.com
+     * </pre>
+     */
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.EMAIL_HEADER_INJECTION,
+            description = "EMAIL_HEADER_INJECTION_NEWLINE_CHECK_ONLY",
+            payload = "EMAIL_HEADER_INJECTION_PAYLOAD_LEVEL_2")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_2,
+            htmlTemplate = "LEVEL_1/EmailHeaderInjection")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel2(
+            @RequestParam(TO_EMAIL_PARAM) String toEmail,
+            @RequestParam(value = SUBJECT_PARAM, defaultValue = "Test Email") String subject,
+            @RequestParam(value = BODY_PARAM, defaultValue = DEFAULT_BODY) String body) {
+        // Incomplete check: only \n is blocked; \r alone still bypasses this guard
+        if (toEmail.contains("\n") || subject.contains("\n")) {
+            return errorResponse(
+                    "Invalid input: newline characters are not allowed in email headers.");
+        }
+        try {
+            emailService.sendEmail(toEmail, subject, body);
+            return successResponse("Email sent to: " + toEmail + " with subject: " + subject);
+        } catch (Exception e) {
+            LOGGER.error("Failed to send email at Level 2", e);
+            return errorResponse("Failed to send email: " + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // LEVEL 3 – Secure: strip all CRLF characters
+    // -------------------------------------------------------------------------
+
+    /**
+     * <strong>Level 3 – Secure (Complete CRLF Sanitization)</strong>
+     *
+     * <p>All carriage-return ({@code \r}) and newline ({@code \n}) characters are stripped from
+     * both {@code toEmail} and {@code subject} before constructing the SMTP message. This prevents
+     * header injection regardless of how the attacker encodes the CRLF sequence.
+     *
+     * <p>This is the recommended approach for preventing email header injection in Java
+     * applications.
+     */
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.EMAIL_HEADER_INJECTION,
+            description = "EMAIL_HEADER_INJECTION_CRLF_SANITIZATION")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_3,
+            htmlTemplate = "LEVEL_1/EmailHeaderInjection",
+            variant = Variant.SECURE)
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel3(
+            @RequestParam(TO_EMAIL_PARAM) String toEmail,
+            @RequestParam(value = SUBJECT_PARAM, defaultValue = "Test Email") String subject,
+            @RequestParam(value = BODY_PARAM, defaultValue = DEFAULT_BODY) String body) {
+        try {
+            emailService.sendEmailSanitized(toEmail, subject, body);
+            return successResponse("Email sent using sanitized headers.");
+        } catch (Exception e) {
+            LOGGER.error("Failed to send email at Level 3", e);
+            return errorResponse("Failed to send email: " + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<String>> successResponse(
+            String message) {
+        return new ResponseEntity<>(
+                new GenericVulnerabilityResponseBean<>(message, true), HttpStatus.OK);
+    }
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<String>> errorResponse(String message) {
+        return new ResponseEntity<>(
+                new GenericVulnerabilityResponseBean<>(message, false), HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailService.java
@@ -1,0 +1,41 @@
+package org.sasanlabs.service.vulnerability.emailHeaderInjection;
+
+/**
+ * Service interface for sending emails within the EmailHeaderInjection vulnerability module.
+ *
+ * <p>Provides two variants:
+ *
+ * <ul>
+ *   <li>{@link #sendEmail(String, String, String)} – sends the email without any sanitization of
+ *       headers, intentionally leaving the caller responsible for header safety (or lack thereof).
+ *   <li>{@link #sendEmailSanitized(String, String, String)} – strips CRLF characters from the
+ *       {@code to} and {@code subject} fields before constructing the SMTP message, preventing
+ *       header injection.
+ * </ul>
+ *
+ * @author VulnerableApp contributors
+ */
+public interface EmailService {
+
+    /**
+     * Sends a plain-text email <strong>without</strong> sanitizing the {@code to} or {@code
+     * subject} parameters. This method is intentionally unsafe and is used by the vulnerable levels
+     * of {@link EmailHeaderInjection} to demonstrate email header injection attacks.
+     *
+     * @param to recipient address (may contain injected CRLF sequences)
+     * @param subject email subject (may contain injected CRLF sequences)
+     * @param body email body text
+     */
+    void sendEmail(String to, String subject, String body);
+
+    /**
+     * Sends a plain-text email after stripping {@code \r} and {@code \n} characters from the {@code
+     * to} and {@code subject} parameters. This is the secure variant used by the safe level of
+     * {@link EmailHeaderInjection}.
+     *
+     * @param to recipient address (sanitized)
+     * @param subject email subject (sanitized)
+     * @param body email body text
+     */
+    void sendEmailSanitized(String to, String subject, String body);
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailServiceImpl.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailServiceImpl.java
@@ -1,0 +1,94 @@
+package org.sasanlabs.service.vulnerability.emailHeaderInjection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of {@link EmailService} that delegates to Spring's {@link JavaMailSender}.
+ *
+ * <p>Two variants are provided:
+ *
+ * <ul>
+ *   <li>{@link #sendEmail} – no header sanitization (intentionally unsafe, used by vulnerable
+ *       levels)
+ *   <li>{@link #sendEmailSanitized} – strips CRLF characters before setting headers (secure, used
+ *       by the safe level)
+ * </ul>
+ *
+ * @author VulnerableApp contributors
+ */
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private static final transient Logger LOGGER = LogManager.getLogger(EmailServiceImpl.class);
+
+    /** CRLF characters that an attacker can inject to add arbitrary SMTP headers. */
+    private static final String CRLF_REGEX = "[\r\n]";
+
+    private final JavaMailSender mailSender;
+    private final String fromAddress;
+
+    public EmailServiceImpl(
+            JavaMailSender mailSender, @Value("${vulnerableapp.email.from}") String fromAddress) {
+        this.mailSender = mailSender;
+        this.fromAddress = fromAddress;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p><strong>Intentionally unsafe:</strong> the {@code to} and {@code subject} values are
+     * passed directly to {@link SimpleMailMessage} without stripping CRLF sequences. An attacker
+     * who controls these fields can inject additional SMTP headers (e.g., {@code CC:}, {@code
+     * BCC:}) enabling spam relaying or phishing campaigns.
+     */
+    @Override
+    public void sendEmail(String to, String subject, String body) {
+        LOGGER.debug("Sending email (unsanitized) to: {}, subject: {}", to, subject);
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(body);
+        mailSender.send(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p><strong>Secure variant:</strong> strips all {@code \r} and {@code \n} characters from
+     * {@code to} and {@code subject} before constructing the SMTP message. This prevents an
+     * attacker from injecting additional SMTP headers through these fields.
+     */
+    @Override
+    public void sendEmailSanitized(String to, String subject, String body) {
+        String sanitizedTo = sanitizeHeader(to);
+        String sanitizedSubject = sanitizeHeader(subject);
+        LOGGER.debug(
+                "Sending email (sanitized) to: {}, subject: {}", sanitizedTo, sanitizedSubject);
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(sanitizedTo);
+        message.setSubject(sanitizedSubject);
+        message.setText(body);
+        mailSender.send(message);
+    }
+
+    /**
+     * Removes all carriage-return ({@code \r}) and newline ({@code \n}) characters from the
+     * supplied header value to prevent CRLF / email header injection.
+     *
+     * @param headerValue raw header value supplied by the caller
+     * @return sanitized header value with no CRLF characters
+     */
+    String sanitizeHeader(String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
+        return headerValue.replaceAll(CRLF_REGEX, "");
+    }
+}

--- a/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java
+++ b/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java
@@ -60,6 +60,9 @@ public enum VulnerabilityType {
     // LDAP Injection Vulnerability
     LDAP_INJECTION(90, 29),
 
+    // Email Header Injection Vulnerability (CWE-93: Improper Neutralization of CRLF Sequences)
+    EMAIL_HEADER_INJECTION(93, null),
+
     WEB_CACHE_POISONING(null, null);
 
     private Integer cweID;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,3 +51,23 @@ benchmark.dast.ground-truth.read-timeout-ms=10000
 ##Details for KeyPair generation in application
 #keytool -genkeypair -alias SasanLabs -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore sasanlabs.p12 -validity 3650
 #password for pkcs12, sasanlabs.p12 is "changeIt"
+
+# ============================================================
+# Email / SMTP configuration (used by EmailHeaderInjection vulnerability)
+# Override via environment variables for different environments.
+# Defaults point to a local dev mail catcher (e.g., MailHog / MailDev).
+# ============================================================
+spring.mail.host=${MAIL_HOST:localhost}
+spring.mail.port=${MAIL_PORT:1025}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.connectiontimeout=${MAIL_SMTP_CONNECTION_TIMEOUT_MS:5000}
+spring.mail.properties.mail.smtp.timeout=${MAIL_SMTP_READ_TIMEOUT_MS:10000}
+spring.mail.properties.mail.smtp.writetimeout=${MAIL_SMTP_WRITE_TIMEOUT_MS:10000}
+spring.mail.properties.mail.smtp.auth=${MAIL_SMTP_AUTH:false}
+spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SMTP_STARTTLS:false}
+
+# VulnerableApp-specific email defaults used by the EmailHeaderInjection module
+vulnerableapp.email.from=${EMAIL_FROM:vulnerable@example.com}
+vulnerableapp.email.recipient.default=${EMAIL_RECIPIENT:victim@example.com}
+

--- a/src/main/resources/attackvectors/EmailHeaderInjectionPayload.properties
+++ b/src/main/resources/attackvectors/EmailHeaderInjectionPayload.properties
@@ -1,0 +1,8 @@
+EMAIL_HEADER_INJECTION_PAYLOAD_LEVEL_1=In an Email Header Injection attack, an attacker can inject new headers into the email by introducing carriage return (\\r) and linefeed (\\n) sequences into header parameters.<br/>\\
+<b>How to exploit this level?</b><br/>\\
+There are no validations present at this level. You can inject additional recipients by appending CRLF and a CC or BCC header to the subject parameter, for example:<br/>\\
+<code>subject=Test%0D%0ACC:attacker@evil.com</code>
+EMAIL_HEADER_INJECTION_PAYLOAD_LEVEL_2=In an Email Header Injection attack, an attacker can inject new headers into the email by introducing carriage return (\\r) and linefeed (\\n) sequences into header parameters.<br/>\\
+<b>How to exploit this level?</b><br/>\\
+This level rejects input containing a linefeed (\\n / %0A) character. However, it fails to check for carriage returns (\\r / %0D). Some SMTP implementations treat a carriage return alone as a line separator. You can bypass the validation by injecting %0D alone, for example:<br/>\\
+<code>subject=Test%0DCC:attacker@evil.com</code>

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -434,3 +434,14 @@ CACHE_POISONING_LEVEL_3_JS_INJECTION=JavaScript Injection via Cache Poisoning. S
 CACHE_POISONING_LEVEL_4_PUBLIC_CACHE_PERSONALIZED_CONTENT=This level demonstrates the danger of caching personalized content (driven by cookies) as public. The response body varies per user (username, email, last login IP) because it reads the <code>demo_user</code> cookie, but the cookie is an <b>unkeyed input</b> - it never participates in the cache key. The shared cache stores the response under the route alone with <code>Cache-Control: public</code>, so the first requester's PII is served to every subsequent visitor for the rest of the TTL.
 CACHE_POISONING_LEVEL_5_SECURE_CACHE_POLICY=This secure level demonstrates proper cache isolation. It ignores untrusted forwarding headers and marks personalized or sensitive responses as <code>private</code> and <code>no-store</code>, preventing shared caches from storing and reusing them across different users.
 
+
+# Email Header Injection Vulnerability
+EMAIL_HEADER_INJECTION_VULNERABILITY=Email Header Injection (or SMTP Header Injection) occurs when user-supplied input is inserted directly into email headers (such as To, Subject, From, CC, BCC) without stripping CRLF (\\r\\n) sequences. Because SMTP uses CRLF to separate headers, an attacker can inject arbitrary headers to relay spam, BCC external recipients, or spoof sender details.<br/><br/>\
+Important Links:<br/>\
+<ol>\
+ <li> <a href="https://owasp.org/www-community/attacks/Email_Header_Injection" target="_blank">OWASP - Email Header Injection</a> \
+ <li> <a href="https://cwe.mitre.org/data/definitions/93.html" target="_blank">CWE-93 - Improper Neutralization of CRLF Sequences</a> \
+</ol>
+EMAIL_HEADER_INJECTION_NO_VALIDATION=The application does not validate the email headers. User-controlled values are appended directly.
+EMAIL_HEADER_INJECTION_NEWLINE_CHECK_ONLY=The application checks for \\n (linefeed) but does not check for \\r (carriage return) which can still be used as a header separator in many SMTP systems.
+EMAIL_HEADER_INJECTION_CRLF_SANITIZATION=The application strips all \\r and \\n characters from the email headers before sending.

--- a/src/main/resources/i18n/messages_en_US.properties
+++ b/src/main/resources/i18n/messages_en_US.properties
@@ -311,3 +311,15 @@ CACHE_POISONING_LEVEL_3_UNKEYED_FORWARDED_HOST=This level includes the query par
 CACHE_POISONING_LEVEL_3_JS_INJECTION=JavaScript Injection via Cache Poisoning. Since the application trusts the X-Forwarded-Host header to build asset URLs, an attacker can poison the cache to point to a malicious domain, causing all users to load and execute external scripts.
 CACHE_POISONING_LEVEL_4_PUBLIC_CACHE_PERSONALIZED_CONTENT=This level demonstrates the danger of caching personalized content (driven by cookies) as public. The response body varies per user (username, email, last login IP) because it reads the <code>demo_user</code> cookie, but the cookie is an <b>unkeyed input</b> - it never participates in the cache key. The shared cache stores the response under the route alone with <code>Cache-Control: public</code>, so the first requester's PII is served to every subsequent visitor for the rest of the TTL.
 CACHE_POISONING_LEVEL_5_SECURE_CACHE_POLICY=This secure level demonstrates proper cache isolation. It ignores untrusted forwarding headers and marks personalized or sensitive responses as <code>private</code> and <code>no-store</code>, preventing shared caches from storing and reusing them across different users.
+
+
+# Email Header Injection Vulnerability
+EMAIL_HEADER_INJECTION_VULNERABILITY=Email Header Injection (or SMTP Header Injection) occurs when user-supplied input is inserted directly into email headers (such as To, Subject, From, CC, BCC) without stripping CRLF (\\r\\n) sequences. Because SMTP uses CRLF to separate headers, an attacker can inject arbitrary headers to relay spam, BCC external recipients, or spoof sender details.<br/><br/>\
+Important Links:<br/>\
+<ol>\
+ <li> <a href="https://owasp.org/www-community/attacks/Email_Header_Injection" target="_blank">OWASP - Email Header Injection</a> \
+ <li> <a href="https://cwe.mitre.org/data/definitions/93.html" target="_blank">CWE-93 - Improper Neutralization of CRLF Sequences</a> \
+</ol>
+EMAIL_HEADER_INJECTION_NO_VALIDATION=The application does not validate the email headers. User-controlled values are appended directly.
+EMAIL_HEADER_INJECTION_NEWLINE_CHECK_ONLY=The application checks for \\n (linefeed) but does not check for \\r (carriage return) which can still be used as a header separator in many SMTP systems.
+EMAIL_HEADER_INJECTION_CRLF_SANITIZATION=The application strips all \\r and \\n characters from the email headers before sending.

--- a/src/test/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailHeaderInjectionTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/emailHeaderInjection/EmailHeaderInjectionTest.java
@@ -1,0 +1,226 @@
+package org.sasanlabs.service.vulnerability.emailHeaderInjection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@ExtendWith(MockitoExtension.class)
+class EmailHeaderInjectionTest {
+
+    @Mock private JavaMailSender mailSender;
+
+    private EmailServiceImpl emailService;
+    private EmailHeaderInjection controller;
+
+    private static final String FROM_ADDRESS = "sender@vulnerableapp.org";
+    private static final String TO_ADDRESS = "recipient@vulnerableapp.org";
+    private static final String SUBJECT = "Hello Subject";
+    private static final String BODY = "Hello Body";
+
+    @BeforeEach
+    void setUp() {
+        emailService = new EmailServiceImpl(mailSender, FROM_ADDRESS);
+        controller = new EmailHeaderInjection(emailService);
+    }
+
+    // =========================================================================
+    // EmailServiceImpl Unit Tests
+    // =========================================================================
+
+    @Test
+    void testSanitizeHeader() {
+        assertThat(emailService.sanitizeHeader(null)).isNull();
+        assertThat(emailService.sanitizeHeader("hello")).isEqualTo("hello");
+        assertThat(emailService.sanitizeHeader("hello\rworld")).isEqualTo("helloworld");
+        assertThat(emailService.sanitizeHeader("hello\nworld")).isEqualTo("helloworld");
+        assertThat(emailService.sanitizeHeader("hello\r\nworld")).isEqualTo("helloworld");
+    }
+
+    @Test
+    void testSendEmail() {
+        emailService.sendEmail(TO_ADDRESS, SUBJECT, BODY);
+
+        ArgumentCaptor<SimpleMailMessage> messageCaptor =
+                ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender, times(1)).send(messageCaptor.capture());
+
+        SimpleMailMessage sentMessage = messageCaptor.getValue();
+        assertThat(sentMessage.getFrom()).isEqualTo(FROM_ADDRESS);
+        assertThat(sentMessage.getTo()).containsExactly(TO_ADDRESS);
+        assertThat(sentMessage.getSubject()).isEqualTo(SUBJECT);
+        assertThat(sentMessage.getText()).isEqualTo(BODY);
+    }
+
+    @Test
+    void testSendEmailSanitized() {
+        String unsafeTo = "recipient@vulnerableapp.org\r\nCC:attacker@evil.com";
+        String unsafeSubject = "Subject\r\nBCC:attacker@evil.com";
+
+        emailService.sendEmailSanitized(unsafeTo, unsafeSubject, BODY);
+
+        ArgumentCaptor<SimpleMailMessage> messageCaptor =
+                ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender, times(1)).send(messageCaptor.capture());
+
+        SimpleMailMessage sentMessage = messageCaptor.getValue();
+        assertThat(sentMessage.getFrom()).isEqualTo(FROM_ADDRESS);
+        assertThat(sentMessage.getTo())
+                .containsExactly("recipient@vulnerableapp.orgCC:attacker@evil.com");
+        assertThat(sentMessage.getSubject()).isEqualTo("SubjectBCC:attacker@evil.com");
+        assertThat(sentMessage.getText()).isEqualTo(BODY);
+    }
+
+    // =========================================================================
+    // EmailHeaderInjection Controller Tests
+    // =========================================================================
+
+    @Test
+    void testLevel1_Success() {
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel1(TO_ADDRESS, SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isTrue();
+        assertThat(response.getBody().getContent())
+                .contains("Email sent to: " + TO_ADDRESS)
+                .contains("with subject: " + SUBJECT);
+
+        verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void testLevel1_Failure() {
+        doThrow(new RuntimeException("Mail server down"))
+                .when(mailSender)
+                .send(any(SimpleMailMessage.class));
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel1(TO_ADDRESS, SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isFalse();
+        assertThat(response.getBody().getContent())
+                .contains("Failed to send email: Mail server down");
+    }
+
+    @Test
+    void testLevel2_Success() {
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel2(TO_ADDRESS, SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isTrue();
+
+        verify(mailSender, times(1)).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void testLevel2_RejectsNewline() {
+        // Blocks \n
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> responseTo =
+                controller.getVulnerablePayloadLevel2(
+                        "recipient@vulnerableapp.org\nCC:attacker@evil.com", SUBJECT, BODY);
+        assertThat(responseTo.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseTo.getBody().getIsValid()).isFalse();
+        assertThat(responseTo.getBody().getContent())
+                .contains("Invalid input: newline characters are not allowed");
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> responseSubject =
+                controller.getVulnerablePayloadLevel2(
+                        TO_ADDRESS, "Subject\nBCC:attacker@evil.com", BODY);
+        assertThat(responseSubject.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseSubject.getBody().getIsValid()).isFalse();
+
+        verifyNoInteractions(mailSender);
+    }
+
+    @Test
+    void testLevel2_AllowsCarriageReturn_Bypass() {
+        // Allows \r alone (bypass)
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel2(
+                        "recipient@vulnerableapp.org\rCC:attacker@evil.com", SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getIsValid()).isTrue();
+
+        ArgumentCaptor<SimpleMailMessage> messageCaptor =
+                ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender, times(1)).send(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getTo())
+                .containsExactly("recipient@vulnerableapp.org\rCC:attacker@evil.com");
+    }
+
+    @Test
+    void testLevel3_Success() {
+        String unsafeTo = "recipient@vulnerableapp.org\r\nCC:attacker@evil.com";
+        String unsafeSubject = "Subject\r\nBCC:attacker@evil.com";
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel3(unsafeTo, unsafeSubject, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isTrue();
+        assertThat(response.getBody().getContent())
+                .isEqualTo("Email sent using sanitized headers.");
+
+        ArgumentCaptor<SimpleMailMessage> messageCaptor =
+                ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mailSender, times(1)).send(messageCaptor.capture());
+        SimpleMailMessage sentMessage = messageCaptor.getValue();
+        assertThat(sentMessage.getTo())
+                .containsExactly("recipient@vulnerableapp.orgCC:attacker@evil.com");
+        assertThat(sentMessage.getSubject()).isEqualTo("SubjectBCC:attacker@evil.com");
+    }
+
+    @Test
+    void testLevel2_Failure() {
+        doThrow(new RuntimeException("Mail server down"))
+                .when(mailSender)
+                .send(any(SimpleMailMessage.class));
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel2(TO_ADDRESS, SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isFalse();
+        assertThat(response.getBody().getContent())
+                .contains("Failed to send email: Mail server down");
+    }
+
+    @Test
+    void testLevel3_Failure() {
+        doThrow(new RuntimeException("Mail server down"))
+                .when(mailSender)
+                .send(any(SimpleMailMessage.class));
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                controller.getVulnerablePayloadLevel3(TO_ADDRESS, SUBJECT, BODY);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getIsValid()).isFalse();
+        assertThat(response.getBody().getContent())
+                .contains("Failed to send email: Mail server down");
+    }
+}


### PR DESCRIPTION
### Summary
This PR implements the **Email Header Injection** (CWE-93) vulnerability module as requested in #651. It introduces a modular email sending service alongside a new three-level vulnerability controller to educate users on SMTP/Email Header Injection vulnerabilities and CRLF sanitization techniques.

### Details
- **Email Infrastructure:** Adds `spring-boot-starter-mail` and basic SMTP configurations with environment variables.
- **Service Layer:** `EmailService` and `EmailServiceImpl` using `JavaMailSender`.
- **Controller Levels:**
  - **Level 1:** Zero validation (injectable via CRLF).
  - **Level 2:** Checks/rejects `\n` but misses `\r`, which acts as a separator in some SMTP server configurations (bypassable).
  - **Level 3 (Secure):** Performs complete CRLF (`\r`, `\n`) stripping.
- **i18n and Attack Vectors:** Adds descriptive translation labels and attack vectors/payload definitions.
- **Tests:** Integrates JUnit 5 Mockito tests covering all service methods and controller actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an email header injection module with three progressive levels and an email sending service supporting vulnerable and sanitized modes.
* **Configuration**
  * Added SMTP/email configuration and default sender/recipient settings.
* **Localization & Payloads**
  * Added i18n messages and attack-vector payload descriptions for the new module.
* **Tests**
  * Added comprehensive tests covering success/failure and sanitization behaviors.
* **Chores**
  * Added mail starter dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->