### PR TITLE
Modify sitemapForPassiveScanners to accept HttpServletRequest

### DIFF
--- a/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
+++ b/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
@@ -4,22 +4,20 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.sasanlabs.beans.AllEndPointsResponseBean;
 import org.sasanlabs.beans.ScannerMetaResponseBean;
 import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.internal.utility.FrameworkConstants;
-import org.sasanlabs.internal.utility.GenericUtils;
 import org.sasanlabs.internal.utility.JSONSerializationUtils;
 import org.sasanlabs.internal.utility.annotations.RequestParameterLocation;
 import org.sasanlabs.service.IEndPointsInformationProvider;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.sasanlabs.vulnerableapp.facade.schema.VulnerabilityDefinition;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author KSASAN preetkaran20@gmail.com
@@ -32,8 +30,7 @@ public class VulnerableAppRestController {
 
     private int port;
 
-    public VulnerableAppRestController(
-            IEndPointsInformationProvider getAllSupportedEndPoints) {
+    public VulnerableAppRestController(IEndPointsInformationProvider getAllSupportedEndPoints) {
         this.getAllSupportedEndPoints = getAllSupportedEndPoints;
         this.port = port;
     }
@@ -123,13 +120,14 @@ public class VulnerableAppRestController {
      * @throws UnknownHostException
      */
     @RequestMapping("/sitemap.xml")
-    public String sitemapForPassiveScanners(HttpServletRequest request) throws JsonProcessingException, UnknownHostException {
+    public String sitemapForPassiveScanners(HttpServletRequest request)
+            throws JsonProcessingException, UnknownHostException {
         List<AllEndPointsResponseBean> allEndPoints = allEndPointsJsonResponse();
-           // Dynamically resolve host from the incoming request
-            String scheme = request.getScheme();             // http or https
-            String serverName = request.getServerName();     // actual hostname/IP
-            int serverPort = request.getServerPort();        // actual port
-    
+        // Dynamically resolve host from the incoming request
+        String scheme = request.getScheme(); // http or https
+        String serverName = request.getServerName(); // actual hostname/IP
+        int serverPort = request.getServerPort(); // actual port
+
         StringBuilder xmlBuilder =
                 new StringBuilder(
                         FrameworkConstants.GENERAL_XML_HEADER

--- a/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
+++ b/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author KSASAN preetkaran20@gmail.com
@@ -32,8 +33,7 @@ public class VulnerableAppRestController {
     private int port;
 
     public VulnerableAppRestController(
-            IEndPointsInformationProvider getAllSupportedEndPoints,
-            @Value("${server.port}") int port) {
+            IEndPointsInformationProvider getAllSupportedEndPoints) {
         this.getAllSupportedEndPoints = getAllSupportedEndPoints;
         this.port = port;
     }
@@ -123,8 +123,13 @@ public class VulnerableAppRestController {
      * @throws UnknownHostException
      */
     @RequestMapping("/sitemap.xml")
-    public String sitemapForPassiveScanners() throws JsonProcessingException, UnknownHostException {
+    public String sitemapForPassiveScanners(HttpServletRequest request) throws JsonProcessingException, UnknownHostException {
         List<AllEndPointsResponseBean> allEndPoints = allEndPointsJsonResponse();
+           // Dynamically resolve host from the incoming request
+            String scheme = request.getScheme();             // http or https
+            String serverName = request.getServerName();     // actual hostname/IP
+            int serverPort = request.getServerPort();        // actual port
+    
         StringBuilder xmlBuilder =
                 new StringBuilder(
                         FrameworkConstants.GENERAL_XML_HEADER
@@ -138,10 +143,11 @@ public class VulnerableAppRestController {
                                         .append(FrameworkConstants.NEXT_LINE)
                                         .append(FrameworkConstants.SITEMAP_LOC_TAG_START)
                                         .append(FrameworkConstants.NEXT_LINE)
-                                        .append(FrameworkConstants.HTTP)
-                                        .append(GenericUtils.LOCALHOST)
+                                        .append(scheme)
+                                        .append("://")
+                                        .append(serverName)
                                         .append(FrameworkConstants.COLON)
-                                        .append(port)
+                                        .append(serverPort)
                                         .append(FrameworkConstants.SLASH)
                                         .append(FrameworkConstants.VULNERABLE_APP)
                                         .append(FrameworkConstants.SLASH)


### PR DESCRIPTION
Updated sitemapForPassiveScanners method to use HttpServletRequest for dynamic host resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sitemap URL generation to dynamically use the request's scheme, domain, and port instead of hardcoded values. This ensures sitemap links correctly reflect how the application is accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->