### PR TITLE
Update getScannerRelatedInformation to use HttpServletRequest

### DIFF
--- a/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
+++ b/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
@@ -89,9 +89,23 @@ public class VulnerableAppRestController {
      */
     @GetMapping
     @RequestMapping("/scanner")
-    public List<ScannerResponseBean> getScannerRelatedInformation()
+    public List<ScannerResponseBean> getScannerRelatedInformation(HttpServletRequest request)
             throws JsonProcessingException, UnknownHostException {
-        return getAllSupportedEndPoints.getScannerRelatedEndPointInformation();
+        String scheme = request.getScheme(); // http or https
+        String serverName = request.getServerName(); // actual hostname/IP
+        int serverPort = request.getServerPort(); // actual port
+        String appUrl =
+                new StringBuilder()
+                        .append(scheme)
+                        .append("://")
+                        .append(serverName)
+                        .append(FrameworkConstants.COLON)
+                        .append(serverPort)
+                        .append(FrameworkConstants.SLASH)
+                        .append(FrameworkConstants.VULNERABLE_APP)
+                        .append(FrameworkConstants.SLASH)
+                        .toString();
+        return getAllSupportedEndPoints.getScannerRelatedEndPointInformation(appUrl);
     }
 
     /**

--- a/src/main/java/org/sasanlabs/service/IEndPointsInformationProvider.java
+++ b/src/main/java/org/sasanlabs/service/IEndPointsInformationProvider.java
@@ -41,6 +41,6 @@ public interface IEndPointsInformationProvider {
      * @throws JsonProcessingException
      * @throws UnknownHostException
      */
-    List<ScannerResponseBean> getScannerRelatedEndPointInformation()
+    List<ScannerResponseBean> getScannerRelatedEndPointInformation(String appUrl)
             throws JsonProcessingException, UnknownHostException;
 }

--- a/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
+++ b/src/main/java/org/sasanlabs/service/impl/EndPointsInformationProvider.java
@@ -16,7 +16,6 @@ import org.sasanlabs.beans.ScannerResponseBean;
 import org.sasanlabs.configuration.VulnerableAppProperties;
 import org.sasanlabs.internal.utility.EnvUtils;
 import org.sasanlabs.internal.utility.FrameworkConstants;
-import org.sasanlabs.internal.utility.GenericUtils;
 import org.sasanlabs.internal.utility.MessageBundle;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
 import org.sasanlabs.internal.utility.annotations.ChallengeCard;
@@ -141,7 +140,7 @@ public class EndPointsInformationProvider implements IEndPointsInformationProvid
     }
 
     @Override
-    public List<ScannerResponseBean> getScannerRelatedEndPointInformation()
+    public List<ScannerResponseBean> getScannerRelatedEndPointInformation(String appUrl)
             throws JsonProcessingException, UnknownHostException {
         List<AllEndPointsResponseBean> allEndPointsResponseBeans = this.getSupportedEndPoints();
         List<ScannerResponseBean> scannerResponseBeans = new ArrayList<>();
@@ -153,13 +152,7 @@ public class EndPointsInformationProvider implements IEndPointsInformationProvid
                     scannerResponseBeans.add(
                             new ScannerResponseBean(
                                     new StringBuilder()
-                                            .append(FrameworkConstants.HTTP)
-                                            .append(GenericUtils.LOCALHOST)
-                                            .append(FrameworkConstants.COLON)
-                                            .append(port)
-                                            .append(FrameworkConstants.SLASH)
-                                            .append(FrameworkConstants.VULNERABLE_APP)
-                                            .append(FrameworkConstants.SLASH)
+                                            .append(appUrl)
                                             .append(allEndPointsResponseBean.getName())
                                             .append(FrameworkConstants.SLASH)
                                             .append(levelResponseBean.getLevel())


### PR DESCRIPTION
Modified getScannerRelatedInformation method to accept HttpServletRequest and construct the application URL for endpoint information retrieval.