### PR TITLE
Added ChallengeCard annotation to OpenRedirect and corresponding message keys to message.properties

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
@@ -72,6 +72,16 @@ public class Http3xxStatusCodeBasedInjection {
     @AttackVector(
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description = "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER")
+        @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_1_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_1_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_1_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
@@ -88,6 +98,16 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_OR_DOMAIN_IS_SAME")
+        @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_2_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_2_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_2_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
@@ -111,6 +131,16 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_//_OR_DOMAIN_IS_SAME")
+        @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_3_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_3_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_3_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
@@ -133,7 +163,17 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_WWW_HTTPS_//_NULL_BYTE_OR_DOMAIN_IS_SAME")
-    @VulnerableAppRequestMapping(
+    @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_4_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_4_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_4_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_4_PAYLOAD_VALUE"))
+        @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
     public ResponseEntity<?> getVulnerablePayloadLevel4(
@@ -159,7 +199,17 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_//_WWW_%_OR_DOMAIN_IS_SAME")
-    @VulnerableAppRequestMapping(
+    @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_5_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_5_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_5_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_5_PAYLOAD_VALUE"))
+        @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
     public ResponseEntity<?> getVulnerablePayloadLevel5(
@@ -184,7 +234,17 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADDED_TO_LOCATION_HEADER_BY_ADDING_DOMAIN_AS_PREFIX")
-    @VulnerableAppRequestMapping(
+    @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_6_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_6_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_6_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_6_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_6_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_6_PAYLOAD_VALUE"))
+        @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
     public ResponseEntity<?> getVulnerablePayloadLevel6(
@@ -203,6 +263,16 @@ public class Http3xxStatusCodeBasedInjection {
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description =
                     "OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADDED_TO_LOCATION_HEADER_BY_ADDING_DOMAIN_AS_PREFIX")
+        @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_7_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_7_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_7_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_7_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_7_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_7,
             htmlTemplate = "LEVEL_1/Http3xxStatusCodeBasedInjection")
@@ -241,6 +311,16 @@ public class Http3xxStatusCodeBasedInjection {
     @AttackVector(
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description = "OPEN_REDIRECT_PHISHING_NO_WARNING")
+         @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_9_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_9_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_9_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_9_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_9_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_9_PAYLOAD_VALUE"))       
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,
             htmlTemplate = "LEVEL_9/Http3xxStatusCodeBasedInjection")
@@ -255,6 +335,16 @@ public class Http3xxStatusCodeBasedInjection {
     @AttackVector(
             vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
             description = "OPEN_REDIRECT_PHISHING_WARNING_BEFORE_REDIRECT")
+        @ChallengeCard(
+            challengeText = "OPEN_REDIRECT_LEVEL_10_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "OPEN_REDIRECT_LEVEL_10_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "OPEN_REDIRECT_LEVEL_10_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "OPEN_REDIRECT_LEVEL_10_HINT_3")
+            },
+            payload = @ChallengeCard.Payload(
+                    description = "OPEN_REDIRECT_LEVEL_10_PAYLOAD_DESCRIPTION",
+                    value = "OPEN_REDIRECT_LEVEL_10_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_10,
             htmlTemplate = "LEVEL_10/Http3xxStatusCodeBasedInjection")

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -466,10 +466,10 @@ OPEN_REDIRECT_LEVEL_4_PAYLOAD_VALUE=/%09/localdomain.pw
 
 OPEN_REDIRECT_LEVEL_5_CHALLENGE=Defeat strict filters blocking web keywords, double-slashes, explicit null characters, and ASCII hex limits lower than decimal 20.
 OPEN_REDIRECT_LEVEL_5_HINT_1=The filter rejects any direct inputs where the structural start index holds low non-printable hex characters.
-OPEN_REDIRECT_LEVEL_5_HINT_2=Can browser layout engines handle backslashes ('\') identically to standard forward slashes inside path parameters?
+OPEN_REDIRECT_LEVEL_5_HINT_2=Can browser layout engines handle backslashes ('\\') identically to standard forward slashes inside path parameters?
 OPEN_REDIRECT_LEVEL_5_HINT_3=Try constructing variant target chains via reverse backslash schemes like '\/google.com' or '\\/localdomain.pw/'.
 OPEN_REDIRECT_LEVEL_5_PAYLOAD_DESCRIPTION=Backslash alternative path separator transformation payload.
-OPEN_REDIRECT_LEVEL_5_PAYLOAD_VALUE=\/google.com
+OPEN_REDIRECT_LEVEL_5_PAYLOAD_VALUE=\\/google.com
 
 OPEN_REDIRECT_LEVEL_6_CHALLENGE=Break the application's concatenation logic where it automatically attaches your input to the local domain authority string.
 OPEN_REDIRECT_LEVEL_6_HINT_1=The application prefixes your raw parameter directly onto 'protocol://authority' to prevent changing origins.
@@ -483,7 +483,7 @@ OPEN_REDIRECT_LEVEL_7_HINT_1=The application monitors path parameter entries and
 OPEN_REDIRECT_LEVEL_7_HINT_2=If a single slash is safely removed, what sequence happens when multiple forward or backslash patterns are combined?
 OPEN_REDIRECT_LEVEL_7_HINT_3=Inject a backslash structure combined with credentials or directory traversals to break the string reconstruction logic.
 OPEN_REDIRECT_LEVEL_7_PAYLOAD_DESCRIPTION=Slash removal compensation sequence utilizing backward path configurations.
-OPEN_REDIRECT_LEVEL_7_PAYLOAD_VALUE=\\/google.com
+OPEN_REDIRECT_LEVEL_7_PAYLOAD_VALUE=\\\/google.com
 
 OPEN_REDIRECT_LEVEL_9_CHALLENGE=Execute a realistic phishing social engineering flow by sending a user seamlessly to a credential harvesting interface.
 OPEN_REDIRECT_LEVEL_9_HINT_1=This challenge mimics an immediate Open Redirect context used within multi-stage targeted phishing attacks.

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -434,3 +434,67 @@ CACHE_POISONING_LEVEL_3_JS_INJECTION=JavaScript Injection via Cache Poisoning. S
 CACHE_POISONING_LEVEL_4_PUBLIC_CACHE_PERSONALIZED_CONTENT=This level demonstrates the danger of caching personalized content (driven by cookies) as public. The response body varies per user (username, email, last login IP) because it reads the <code>demo_user</code> cookie, but the cookie is an <b>unkeyed input</b> - it never participates in the cache key. The shared cache stores the response under the route alone with <code>Cache-Control: public</code>, so the first requester's PII is served to every subsequent visitor for the rest of the TTL.
 CACHE_POISONING_LEVEL_5_SECURE_CACHE_POLICY=This secure level demonstrates proper cache isolation. It ignores untrusted forwarding headers and marks personalized or sensitive responses as <code>private</code> and <code>no-store</code>, preventing shared caches from storing and reusing them across different users.
 
+# OpenRedirect Challenge Mode
+
+OPEN_REDIRECT_LEVEL_1_CHALLENGE=Redirect the user to an external, untrusted web platform by leveraging the basic unvalidated parameter.
+OPEN_REDIRECT_LEVEL_1_HINT_1=Look at the 'returnTo' parameter values inside your current URL path.
+OPEN_REDIRECT_LEVEL_1_HINT_2=The application adds the raw value directly to the HTTP Location header string without executing validation filters.
+OPEN_REDIRECT_LEVEL_1_HINT_3=Try executing a protocol-relative input structure such as '//facebook.com' or standard external schema hooks.
+OPEN_REDIRECT_LEVEL_1_PAYLOAD_DESCRIPTION=Protocol-relative payload configuration targeting external resources.
+OPEN_REDIRECT_LEVEL_1_PAYLOAD_VALUE=//facebook.com
+
+OPEN_REDIRECT_LEVEL_2_CHALLENGE=Bypass the prefix protocol restriction logic to trigger an open redirect context.
+OPEN_REDIRECT_LEVEL_2_HINT_1=The validation check restricts strings starting with 'http', 'https', or 'www'.
+OPEN_REDIRECT_LEVEL_2_HINT_2=Are web-based application schemas the only protocol handles accepted by local web engines?
+OPEN_REDIRECT_LEVEL_2_HINT_3=Leverage completely different protocol mechanisms like File or File Transfer options to fool prefix handlers.
+OPEN_REDIRECT_LEVEL_2_PAYLOAD_DESCRIPTION=Alternative scheme validation bypass leveraging FTP addresses.
+OPEN_REDIRECT_LEVEL_2_PAYLOAD_VALUE=ftp://ftp.dlptest.com/
+
+OPEN_REDIRECT_LEVEL_3_CHALLENGE=Bypass the enhanced schema matching rules that explicitly blacklisted early forward-slash sets.
+OPEN_REDIRECT_LEVEL_3_HINT_1=The verification rule set safely restricts basic instances of 'http', 'https', 'www', and '//'.
+OPEN_REDIRECT_LEVEL_3_HINT_2=Think about url-encoding formats. Can control strings or horizontal tabs be injected before external address chains?
+OPEN_REDIRECT_LEVEL_3_HINT_3=Try injecting url-encoded horizontal tab segments (%09) or specialized null markers prior to defining external routes.
+OPEN_REDIRECT_LEVEL_3_PAYLOAD_DESCRIPTION=Encoded whitespace horizontal tab injection bypass.
+OPEN_REDIRECT_LEVEL_3_PAYLOAD_VALUE=/%09/localdomain.pw
+
+OPEN_REDIRECT_LEVEL_4_CHALLENGE=Evade advanced validation configurations that blacklist standard protocol markers along with common Null Byte expressions.
+OPEN_REDIRECT_LEVEL_4_HINT_1=This filter explicitly adds protection checks against common standard null characters via code variables.
+OPEN_REDIRECT_LEVEL_4_HINT_2=Is the application filtering non-printable ASCII configurations outside basic null markers, like lower-range control codes?
+OPEN_REDIRECT_LEVEL_4_HINT_3=Look beyond the singular '%00' character to achieve string evaluation separation. Try horizontal-tab URL configurations.
+OPEN_REDIRECT_LEVEL_4_PAYLOAD_DESCRIPTION=Horizontal tab character payload evading standard blacklisted null checks.
+OPEN_REDIRECT_LEVEL_4_PAYLOAD_VALUE=/%09/localdomain.pw
+
+OPEN_REDIRECT_LEVEL_5_CHALLENGE=Defeat strict filters blocking web keywords, double-slashes, explicit null characters, and ASCII hex limits lower than decimal 20.
+OPEN_REDIRECT_LEVEL_5_HINT_1=The filter rejects any direct inputs where the structural start index holds low non-printable hex characters.
+OPEN_REDIRECT_LEVEL_5_HINT_2=Can browser layout engines handle backslashes ('\') identically to standard forward slashes inside path parameters?
+OPEN_REDIRECT_LEVEL_5_HINT_3=Try constructing variant target chains via reverse backslash schemes like '\/google.com' or '\\/localdomain.pw/'.
+OPEN_REDIRECT_LEVEL_5_PAYLOAD_DESCRIPTION=Backslash alternative path separator transformation payload.
+OPEN_REDIRECT_LEVEL_5_PAYLOAD_VALUE=\/google.com
+
+OPEN_REDIRECT_LEVEL_6_CHALLENGE=Break the application's concatenation logic where it automatically attaches your input to the local domain authority string.
+OPEN_REDIRECT_LEVEL_6_HINT_1=The application prefixes your raw parameter directly onto 'protocol://authority' to prevent changing origins.
+OPEN_REDIRECT_LEVEL_6_HINT_2=If the base setup ends up looking like 'http://localhost:8080[YOUR_INPUT]', how can you cleanly pivot out?
+OPEN_REDIRECT_LEVEL_6_HINT_3=Utilize '@' authority delimiters within the input parameter to turn the original domain host prefix into basic user credentials.
+OPEN_REDIRECT_LEVEL_6_PAYLOAD_DESCRIPTION=Host authority manipulation via credential delimiter syntax injection.
+OPEN_REDIRECT_LEVEL_6_PAYLOAD_VALUE=@google.com
+
+OPEN_REDIRECT_LEVEL_7_CHALLENGE=Bypass structural path sanitization logic that actively detects and strips leading path slashes ('/').
+OPEN_REDIRECT_LEVEL_7_HINT_1=The application monitors path parameter entries and actively deletes a leading front-slash characters when found.
+OPEN_REDIRECT_LEVEL_7_HINT_2=If a single slash is safely removed, what sequence happens when multiple forward or backslash patterns are combined?
+OPEN_REDIRECT_LEVEL_7_HINT_3=Inject a backslash structure combined with credentials or directory traversals to break the string reconstruction logic.
+OPEN_REDIRECT_LEVEL_7_PAYLOAD_DESCRIPTION=Slash removal compensation sequence utilizing backward path configurations.
+OPEN_REDIRECT_LEVEL_7_PAYLOAD_VALUE=\\/google.com
+
+OPEN_REDIRECT_LEVEL_9_CHALLENGE=Execute a realistic phishing social engineering flow by sending a user seamlessly to a credential harvesting interface.
+OPEN_REDIRECT_LEVEL_9_HINT_1=This challenge mimics an immediate Open Redirect context used within multi-stage targeted phishing attacks.
+OPEN_REDIRECT_LEVEL_9_HINT_2=No interception warning prompts are presented to the browser client during processing.
+OPEN_REDIRECT_LEVEL_9_HINT_3=Supply a target parameter linking cleanly to a simulated external fake layout template.
+OPEN_REDIRECT_LEVEL_9_PAYLOAD_DESCRIPTION=Phishing route redirection payload lacking intermediate platform warning barriers.
+OPEN_REDIRECT_LEVEL_9_PAYLOAD_VALUE=//evil-phishing-login.com
+
+OPEN_REDIRECT_LEVEL_10_CHALLENGE=Bypass or complete the user journey across an interstitial confirmation modal to land on an external asset.
+OPEN_REDIRECT_LEVEL_10_HINT_1=The page displays an intermediate warning card to alert users of external target routing.
+OPEN_REDIRECT_LEVEL_10_HINT_2=Look at the mechanism running when the interactive confirmation button is pressed.
+OPEN_REDIRECT_LEVEL_10_HINT_3=The action still forwards the value back to the raw endpoint; any arbitrary external site link will trigger execution once approved.
+OPEN_REDIRECT_LEVEL_10_PAYLOAD_DESCRIPTION=Phishing demonstration payload executing past confirmation step cards.
+OPEN_REDIRECT_LEVEL_10_PAYLOAD_VALUE=/VulnerableApp/phishing/fake-login.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **OpenRedirect Challenge Mode** with **10 progressive training levels** (levels **1–7** and **9–10**), each providing challenge text, three ordered hints, and payload descriptions/values.
  * Updated challenge metadata and localized message content so the new level prompts render correctly across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->