### PR TITLE
Add Challenge mode to Authentication Vulnerability

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
@@ -365,6 +365,24 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.WEAK_PASSWORD_HASHING,
             description = "AUTH_LEVEL_10_LOW_ITERATION_HASHING",
             payload = "AUTH_PAYLOAD_LEVEL_10")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_10_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_10_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_10_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_10,
             htmlTemplate = "LEVEL_8/Auth",

--- a/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/authentication/AuthenticationVulnerability.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
@@ -40,6 +41,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
             description = "AUTH_LEVEL_1_SQL_INJECTION",
             payload = "AUTH_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_1_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1SQLi(
             @RequestParam(required = false) String username,
@@ -60,6 +77,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.PLAINTEXT_PASSWORD_STORAGE,
             description = "AUTH_LEVEL_2_LOGGING",
             payload = "AUTH_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_2_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2Logging(
             @RequestParam(required = false) String username,
@@ -80,6 +113,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.PLAINTEXT_PASSWORD_STORAGE,
             description = "AUTH_LEVEL_3_PLAINTEXT",
             payload = "AUTH_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3Plaintext(
             @RequestParam(required = false) String username,
@@ -102,6 +151,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.WEAK_PASSWORD_HASHING,
             description = "AUTH_LEVEL_4_MD5",
             payload = "AUTH_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4Md5(
             @RequestParam(required = false) String username,
@@ -124,6 +189,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.WEAK_PASSWORD_HASHING,
             description = "AUTH_LEVEL_5_SHA1",
             payload = "AUTH_PAYLOAD_LEVEL_5")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5Sha1(
             @RequestParam(required = false) String username,
@@ -147,6 +228,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.WEAK_PASSWORD_HASHING,
             description = "AUTH_LEVEL_6_SHA256_NOSALT",
             payload = "AUTH_PAYLOAD_LEVEL_6")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_6_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_6, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level6Sha256NoSalt(
             @RequestParam(required = false) String username,
@@ -169,6 +266,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.USERNAME_ENUMERATION,
             description = "AUTH_LEVEL_7_USERNAME_ENUMERATION",
             payload = "AUTH_PAYLOAD_LEVEL_7")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_7_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_7_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_7, htmlTemplate = "LEVEL_1/Auth")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level7UsernameEnumeration(
             @RequestParam(required = false) String username,
@@ -190,6 +303,22 @@ public class AuthenticationVulnerability {
             vulnerabilityExposed = VulnerabilityType.WEAK_PASSWORD_HASHING,
             description = "AUTH_LEVEL_8_WEAK_PASSWORD",
             payload = "AUTH_PAYLOAD_LEVEL_8")
+    @ChallengeCard(
+            challengeText = "AUTHENTICATION_VULNERABILITY_LEVEL_8_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_DESCRIPTION",
+                            value = "AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
             htmlTemplate = "LEVEL_8/Auth",

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -416,6 +416,56 @@ AUTH_PAYLOAD_LEVEL_9=This is the secure implementation. Try to enumerate usernam
 AUTH_LEVEL_10_LOW_ITERATION_HASHING=The application utilizes a modern adaptive hashing algorithm (BCrypt) but configures it with a dangerously low work factor/cost parameter (Cost: 4). This significantly reduces the computational cycles required to generate a hash, making the password database highly vulnerable to rapid offline brute-force and dictionary attacks if compromised.
 AUTH_PAYLOAD_LEVEL_10=Submit standard credentials (e.g., admin/admin) to witness the computational speed and exposure of the weak BCrypt hash returned in the metadata payload.
 
+#### Challenge Cards (Challenge Mode)
+AUTHENTICATION_VULNERABILITY_LEVEL_1_CHALLENGE=Log in as admin_sqli without knowing the real password. The login query concatenates your input directly into the SQL string.
+AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_1=The password parameter is dropped straight into the WHERE clause. The username is optional - a known account is admin_sqli.
+AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_2=Make the condition always true. AND binds tighter than OR, so an always-true OR clause overrides the password check.
+AUTHENTICATION_VULNERABILITY_LEVEL_1_HINT_3=Close the open quote, add OR '1'='1, and comment out the rest with -- (the trailing space matters in H2).
+AUTHENTICATION_VULNERABILITY_LEVEL_1_PAYLOAD_DESCRIPTION=SQL injection in the password parameter that bypasses authentication.
+AUTHENTICATION_VULNERABILITY_LEVEL_1_PAYLOAD_VALUE=' OR '1'='1' --
+AUTHENTICATION_VULNERABILITY_LEVEL_2_CHALLENGE=Make a login attempt and confirm that the submitted password is written to the server logs in plaintext, demonstrating a sensitive-data-logging flaw.
+AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_1=Passwords and other sensitive data should never be written to logs; they leak via log files, log aggregators, and backups.
+AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_2=This endpoint logs the submitted password on every attempt. Trigger a login with any password.
+AUTHENTICATION_VULNERABILITY_LEVEL_2_HINT_3=Open the server console or log file and find the line that records the username and password in plaintext.
+AUTHENTICATION_VULNERABILITY_LEVEL_2_PAYLOAD_DESCRIPTION=Trigger a login and inspect the server logs to confirm the password is recorded in plaintext.
+AUTHENTICATION_VULNERABILITY_LEVEL_2_PAYLOAD_VALUE=Submit any login, then read the console/log line beginning "Login attempt for user:" that prints the username and password in plaintext.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_CHALLENGE=Log in as admin_plain. The password is stored in plaintext in the database - retrieve and use it.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_1=Plaintext storage means anyone with database access (SQLi, backup leak, insider) can read passwords instantly.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_2=Open the H2 console at /h2 and query the auth_users table for the admin_plain row.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_3=Read the password column for admin_plain and submit it; on success the app even echoes passwordInDB.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_DESCRIPTION=Read the plaintext password from the database via the H2 console and authenticate.
+AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_VALUE=SELECT username,password FROM auth_users WHERE username='admin_plain' (run in the /h2 console).
+AUTHENTICATION_VULNERABILITY_LEVEL_4_CHALLENGE=Crack the MD5 password hash of admin_md5 (exposed in the response) and log in with the recovered password.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_1=MD5 is cryptographically broken and unfit for passwords; identical inputs always yield the same hash.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_2=The response leaks the stored MD5 hash. Fast, unsalted hashes are reversible via precomputed rainbow tables.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_3=Paste the hash into an online cracker or rainbow-table lookup (CrackStation, hashcat -m 0), then log in.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_DESCRIPTION=Crack the exposed MD5 hash offline using a rainbow table or hash-lookup tool.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_VALUE=Look up MD5 0168b6037606df265be7f1f5d9c0e7fe (CrackStation, hashcat -m 0).
+AUTHENTICATION_VULNERABILITY_LEVEL_5_CHALLENGE=Crack the SHA-1 password hash of admin_sha1 (shown in the response) and log in.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_1=SHA-1 has been deprecated since 2017 and is vulnerable to collisions and rainbow-table lookups.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_2=Like MD5, SHA-1 is fast and unsalted here, so precomputed tables crack common passwords instantly.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_3=Submit the SHA-1 hash to an online cracker or hashcat -m 100, then authenticate.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_DESCRIPTION=Crack the exposed SHA-1 hash offline with a rainbow table or cracking tool.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_VALUE=Look up SHA-1 632e10860bd26278451d3f89d1c46f180e5623e0 (CrackStation, hashcat -m 100).
+AUTHENTICATION_VULNERABILITY_LEVEL_6_CHALLENGE=Crack the unsalted SHA-256 hash of admin_sha256 (in the response) and log in.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_1=SHA-256 is a strong general-purpose hash, but it is fast and here it carries no salt.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_2=No salt means identical passwords give identical hashes, so rainbow and precomputed attacks still work.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_3=Run the hash through a wordlist cracker (hashcat -m 1400, CrackStation), then authenticate.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_DESCRIPTION=Crack the unsalted SHA-256 hash offline with a wordlist or rainbow table.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_VALUE=Crack SHA-256 8b8eca84f7e2b04f531749f999c3bf9e3f045bab78f4c8a451fa70929b3c3946 (hashcat -m 1400).
+AUTHENTICATION_VULNERABILITY_LEVEL_7_CHALLENGE=The login returns different errors for unknown users versus wrong passwords. Use that to discover a valid username.
+AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_1=Compare the messages: a fake user returns "User not found"; a real user with a bad password returns "Invalid password".
+AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_2=This difference confirms which usernames exist without knowing any password - the basis for targeted attacks.
+AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_3=Submit candidate usernames with any password; the one returning "Invalid password" is a valid account.
+AUTHENTICATION_VULNERABILITY_LEVEL_7_PAYLOAD_DESCRIPTION=Distinguish valid usernames by comparing the "User not found" and "Invalid password" responses.
+AUTHENTICATION_VULNERABILITY_LEVEL_7_PAYLOAD_VALUE=Send admin_enum with any password to get "Invalid password"; a fake user returns "User not found".
+AUTHENTICATION_VULNERABILITY_LEVEL_8_CHALLENGE=Log in as admin_weak. BCrypt protects the hash, but the password itself is weak and guessable.
+AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_1=Strong hashing cannot save a weak password - the human-chosen secret is the weak link.
+AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_2=This account uses one of the most common passwords. Try a short list of top passwords.
+AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_3=It is a very common password that starts with "password" - try it via the POST login form.
+AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_DESCRIPTION=Online dictionary or guessing attack against admin_weak using a common-password list.
+AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_VALUE=POST username=admin_weak with a top-10 common password (rockyou-style, "password" plus digits).
+
 # Cache Poisoning Vulnerability
 CACHE_POISONING_VULNERABILITY=Web Cache Poisoning occurs when an attacker manipulates a shared web cache\u2014such as a <b>CDN</b>, <b>Reverse Proxy</b>, or <b>Load Balancer</b>\u2014to store a malicious or unintended response. These systems are designed to optimize performance by serving cached versions of frequently requested resources to reduce latency and backend load. The attack succeeds when there is a discrepancy between the <b>Cache Key</b> (the set of request attributes the cache uses to identify a resource) and the application's processing logic. By manipulating <b>unkeyed inputs</b> (headers, cookies, or parameters that are reflected in the response but not included in the cache key), an attacker can "poison" the cache for a specific resource. Once stored, this poisoned response is served to all subsequent users requesting that resource until the cache entry expires or is cleared.<br/><br/>\
 Important Links:<br/>\

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -435,24 +435,24 @@ AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_2=Open the H2 console at /h2 and query
 AUTHENTICATION_VULNERABILITY_LEVEL_3_HINT_3=Read the password column for admin_plain and submit it; on success the app even echoes passwordInDB.
 AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_DESCRIPTION=Read the plaintext password from the database via the H2 console and authenticate.
 AUTHENTICATION_VULNERABILITY_LEVEL_3_PAYLOAD_VALUE=SELECT username,password FROM auth_users WHERE username='admin_plain' (run in the /h2 console).
-AUTHENTICATION_VULNERABILITY_LEVEL_4_CHALLENGE=Crack the MD5 password hash of admin_md5 (exposed in the response) and log in with the recovered password.
-AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_1=MD5 is cryptographically broken and unfit for passwords; identical inputs always yield the same hash.
-AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_2=The response leaks the stored MD5 hash. Fast, unsalted hashes are reversible via precomputed rainbow tables.
-AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_3=Paste the hash into an online cracker or rainbow-table lookup (CrackStation, hashcat -m 0), then log in.
-AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_DESCRIPTION=Crack the exposed MD5 hash offline using a rainbow table or hash-lookup tool.
-AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_VALUE=Look up MD5 0168b6037606df265be7f1f5d9c0e7fe (CrackStation, hashcat -m 0).
-AUTHENTICATION_VULNERABILITY_LEVEL_5_CHALLENGE=Crack the SHA-1 password hash of admin_sha1 (shown in the response) and log in.
-AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_1=SHA-1 has been deprecated since 2017 and is vulnerable to collisions and rainbow-table lookups.
-AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_2=Like MD5, SHA-1 is fast and unsalted here, so precomputed tables crack common passwords instantly.
-AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_3=Submit the SHA-1 hash to an online cracker or hashcat -m 100, then authenticate.
-AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_DESCRIPTION=Crack the exposed SHA-1 hash offline with a rainbow table or cracking tool.
-AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_VALUE=Look up SHA-1 632e10860bd26278451d3f89d1c46f180e5623e0 (CrackStation, hashcat -m 100).
-AUTHENTICATION_VULNERABILITY_LEVEL_6_CHALLENGE=Crack the unsalted SHA-256 hash of admin_sha256 (in the response) and log in.
-AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_1=SHA-256 is a strong general-purpose hash, but it is fast and here it carries no salt.
-AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_2=No salt means identical passwords give identical hashes, so rainbow and precomputed attacks still work.
-AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_3=Run the hash through a wordlist cracker (hashcat -m 1400, CrackStation), then authenticate.
-AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_DESCRIPTION=Crack the unsalted SHA-256 hash offline with a wordlist or rainbow table.
-AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_VALUE=Crack SHA-256 8b8eca84f7e2b04f531749f999c3bf9e3f045bab78f4c8a451fa70929b3c3946 (hashcat -m 1400).
+AUTHENTICATION_VULNERABILITY_LEVEL_4_CHALLENGE=Inspect how admin_md5's password is stored. Find the stored hash in the database and recognize why MD5 makes this account easy to compromise.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_1=MD5 is cryptographically broken and unfit for passwords; it has no salt and no work factor, and identical inputs always yield the same hash.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_2=Open the H2 console (/h2) and read the stored value for admin_md5 in auth_users; the password is kept as a raw, unsalted MD5 digest.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_HINT_3=Because MD5 is fast and unsalted, anyone who reads this hash could recover a weak password offline in seconds with a wordlist or rainbow table (e.g. hashcat -m 0).
+AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_DESCRIPTION=Read the stored MD5 hash from the database and identify the weak, unsalted hashing scheme that exposes the password to offline cracking.
+AUTHENTICATION_VULNERABILITY_LEVEL_4_PAYLOAD_VALUE=SELECT username,password,algorithm FROM auth_users WHERE username='admin_md5' (run in the /h2 console) - note the raw, unsalted MD5.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_CHALLENGE=Inspect how admin_sha1's password is stored. Locate the stored hash in the database and recognize why SHA-1 is unsafe for passwords.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_1=SHA-1 has been deprecated since 2017; here it is stored fast and unsalted, which is unsuitable for passwords.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_2=Open the H2 console (/h2) and read the stored value for admin_sha1 in auth_users; it is a raw, unsalted SHA-1 digest.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_HINT_3=Like MD5, a fast unsalted SHA-1 lets anyone with the hash recover a weak password offline with a wordlist or rainbow table (e.g. hashcat -m 100).
+AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_DESCRIPTION=Read the stored SHA-1 hash from the database and identify the fast, unsalted scheme that exposes weak passwords to offline cracking.
+AUTHENTICATION_VULNERABILITY_LEVEL_5_PAYLOAD_VALUE=SELECT username,password,algorithm FROM auth_users WHERE username='admin_sha1' (run in the /h2 console) - note the raw, unsalted SHA-1.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_CHALLENGE=Inspect how admin_sha256's password is stored. Find the stored hash and recognize why SHA-256 without a salt is still weak for passwords.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_1=SHA-256 is a strong general-purpose hash, but it is fast and here it is stored with no salt.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_2=Open the H2 console (/h2) and read the stored value for admin_sha256; compare it with other users to confirm there is no per-user salt.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_HINT_3=With no salt and a fast algorithm, identical passwords give identical hashes and weak passwords fall to precomputed or wordlist attacks (e.g. hashcat -m 1400).
+AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_DESCRIPTION=Read the unsalted SHA-256 hash from the database and identify why a missing salt plus a fast hash exposes weak passwords.
+AUTHENTICATION_VULNERABILITY_LEVEL_6_PAYLOAD_VALUE=SELECT username,password,salt,algorithm FROM auth_users WHERE username='admin_sha256' (run in the /h2 console) - note the empty salt.
 AUTHENTICATION_VULNERABILITY_LEVEL_7_CHALLENGE=The login returns different errors for unknown users versus wrong passwords. Use that to discover a valid username.
 AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_1=Compare the messages: a fake user returns "User not found"; a real user with a bad password returns "Invalid password".
 AUTHENTICATION_VULNERABILITY_LEVEL_7_HINT_2=This difference confirms which usernames exist without knowing any password - the basis for targeted attacks.
@@ -465,6 +465,12 @@ AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_2=This account uses one of the most co
 AUTHENTICATION_VULNERABILITY_LEVEL_8_HINT_3=It is a very common password that starts with "password" - try it via the POST login form.
 AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_DESCRIPTION=Online dictionary or guessing attack against admin_weak using a common-password list.
 AUTHENTICATION_VULNERABILITY_LEVEL_8_PAYLOAD_VALUE=POST username=admin_weak with a top-10 common password (rockyou-style, "password" plus digits).
+AUTHENTICATION_VULNERABILITY_LEVEL_10_CHALLENGE=Log in as admin_lowcost. The password is hashed with BCrypt, but its work factor is set far too low - recover the password and authenticate.
+AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_1=BCrypt is only as strong as its cost (work) factor; a low cost makes offline brute-force and wordlist attacks dramatically faster.
+AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_2=Open the H2 console (/h2) and read admin_lowcost's stored hash; the number after $2a$ is the cost factor - here it is 04, far below the recommended 10-12.
+AUTHENTICATION_VULNERABILITY_LEVEL_10_HINT_3=Because the cost is only 4, a common password falls quickly to a wordlist attack (hashcat -m 3200); recover it and log in via the POST form.
+AUTHENTICATION_VULNERABILITY_LEVEL_10_PAYLOAD_DESCRIPTION=Read the low-cost BCrypt hash from the database, crack it offline with a wordlist, and log in.
+AUTHENTICATION_VULNERABILITY_LEVEL_10_PAYLOAD_VALUE=SELECT username,password FROM auth_users WHERE username='admin_lowcost' (run in the /h2 console) - note the $2a$04$ cost factor, then hashcat -m 3200.
 
 # Cache Poisoning Vulnerability
 CACHE_POISONING_VULNERABILITY=Web Cache Poisoning occurs when an attacker manipulates a shared web cache\u2014such as a <b>CDN</b>, <b>Reverse Proxy</b>, or <b>Load Balancer</b>\u2014to store a malicious or unintended response. These systems are designed to optimize performance by serving cached versions of frequently requested resources to reduce latency and backend load. The attack succeeds when there is a discrepancy between the <b>Cache Key</b> (the set of request attributes the cache uses to identify a resource) and the application's processing logic. By manipulating <b>unkeyed inputs</b> (headers, cookies, or parameters that are reflected in the response but not included in the cache key), an attacker can "poison" the cache for a specific resource. Once stored, this poisoned response is served to all subsequent users requesting that resource until the cache entry expires or is cleared.<br/><br/>\

--- a/src/main/resources/scripts/Authentication/db/data.sql
+++ b/src/main/resources/scripts/Authentication/db/data.sql
@@ -29,3 +29,7 @@ INSERT INTO auth_users VALUES (8, 'admin_weak', '$2a$10$gV2vZ5fxhZlwOP.GIqOI1.z7
 -- Level 9: Secure (Bcrypt + Generic Error) (9fG#2hJk*LmN!8qR)
 -- Bcrypt hash for '9fG#2hJk*LmN!8qR'
 INSERT INTO auth_users VALUES (9, 'admin_secure', '$2a$10$1WiFUNqUY/vHTzR2QtuMQuzCLK3aZEdjEUpqS4msXOevaCz7Wobe.', NULL, 'BCRYPT', 9, 'admin_secure@example.com', 'ADMIN');
+
+-- Level 10: Low-iteration BCrypt (cost factor 4)
+-- Bcrypt hash (cost 4) for the common password 'sunshine'
+INSERT INTO auth_users VALUES (10, 'admin_lowcost', '$2a$04$rK/CT/Bz7GjjGLnB3WWjTOpMpNcGJzmoh.bdc7gQJ4DBQnKj9xnHC', NULL, 'BCRYPT_LOW_ITERATION', 10, 'admin_lowcost@example.com', 'ADMIN');

--- a/src/main/resources/scripts/Authentication/db/schema.sql
+++ b/src/main/resources/scripts/Authentication/db/schema.sql
@@ -5,7 +5,7 @@ CREATE TABLE auth_users (
     username VARCHAR(50),
     password VARCHAR(500),
     salt VARCHAR(100),
-    algorithm ENUM('PLAIN', 'MD5', 'SHA1', 'SHA256', 'BCRYPT'),
+    algorithm ENUM('PLAIN', 'MD5', 'SHA1', 'SHA256', 'BCRYPT', 'BCRYPT_LOW_ITERATION'),
     level INT,
     email VARCHAR(100),
     role VARCHAR(20)


### PR DESCRIPTION
### Add Challenge mode to Authentication Vulnerability

This PR brings the Authentication module into Challenge mode by adding `@ChallengeCard`annotations to each unsecure leve. Each card exposes a challenge objective, progressive hints, and a gated payload through new i18n message keys.

### What was implemented

- `@ChallengeCard` per unsecure level (1–8 and 10), each with:
    - The challenge objective (challengeText).
    - A payload describing the attack method, not the literal answer.

- Level 10 made solvable. The endpoint already existed but had no seed user, so it could never be completed. Added the `admin_lowcost` user hashed with BCrypt cost factor 4 and extended the algorithm enum in `schema.sql` with `BCRYPT_LOW_ITERATION`. The card teaches that a low work factor makes offline cracking feasible (e.g., `hashcat -m 3200`).

Closes #569 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Challenge Cards for nine authentication vulnerability levels (1–8, 10), featuring challenge prompts, progressive hints, and pre-configured payload examples for interactive learning.
  * Extended authentication method support to include low-iteration bcrypt credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->