### PR TITLE
Add email reset and verification endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There are 2 ways to run the project:
     4. Run the command ```docker-compose pull && docker-compose up```
     5. Navigate to browser and visit `http://localhost` and this will give the User Interface for VulnerableApp.
     6. Mailpit is also available at `http://localhost:8025` for viewing emails captured by the local SMTP server.
+    7. For email endpoint examples, see [docs/EmailFlowTesting.md](docs/EmailFlowTesting.md).
     
     **Note**: The above steps will run the latest unreleased VulnerableApp version. If you want to run the latest released version, please use docker **latest** tag.
 2. Another way to run the VulnerableApp is as standalone Vulnerable Application is:
@@ -88,6 +89,8 @@ This script will build your local changes into a Docker image (`sasanlabs/owasp-
 3. **Access the UI**: Navigate to `http://localhost` to see the modern UI with your changes.
 
 4. **Access Mailpit**: Navigate to `http://localhost:8025` to view emails captured by the local SMTP server.
+
+5. For email endpoint examples, see [docs/EmailFlowTesting.md](docs/EmailFlowTesting.md).
 
 ## Technologies used
 - Java17

--- a/docs/EmailFlowTesting.md
+++ b/docs/EmailFlowTesting.md
@@ -16,12 +16,30 @@ curl -X POST "http://localhost/VulnerableApp/email/test" \
   -d "html=false"
 ```
 
+You can also trigger the reset and verification flows exposed by the same controller:
+
+```bash
+curl -X POST "http://localhost/VulnerableApp/email/reset" \
+  -d "to=you@example.com" \
+  -d "token=reset-token"
+
+curl -X POST "http://localhost/VulnerableApp/email/verify" \
+  -d "to=you@example.com" \
+  -d "token=verify-token"
+```
+
 ### Parameters
 
 - `to` (required): recipient email address
 - `subject` (optional): email subject; defaults to `VulnerableApp test email`
 - `body` (optional): email body; defaults to `This email was sent by VulnerableApp.`
 - `html` (optional): set to `true` for HTML email content; defaults to `false`
+
+### Reset and verification endpoints
+
+- `/email/reset`: sends a password reset email using the provided `to` address and `token`
+- `/email/verify`: sends an email verification message using the provided `to` address and `token`
+- `token` (required): appended to the reset or verification URL and URL-encoded before sending
 
 ## Mailpit / SMTP setup
 

--- a/src/main/java/org/sasanlabs/controller/EmailTestController.java
+++ b/src/main/java/org/sasanlabs/controller/EmailTestController.java
@@ -46,4 +46,34 @@ public class EmailTestController {
         }
         return ResponseEntity.ok(Map.of("status", "sent", "to", to));
     }
+
+    @PostMapping("/reset")
+    public ResponseEntity<Map<String, String>> sendResetEmail(
+            @RequestParam String to, @RequestParam String token) {
+        try {
+            emailService.sendResetEmail(to, token);
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("status", "failed", "error", ex.getMessage()));
+        } catch (MailException ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("status", "failed", "error", "Unable to send test email"));
+        }
+        return ResponseEntity.ok(Map.of("status", "sent", "to", to));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Map<String, String>> sendVerificationEmail(
+            @RequestParam String to, @RequestParam String token) {
+        try {
+            emailService.sendVerificationEmail(to, token);
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("status", "failed", "error", ex.getMessage()));
+        } catch (MailException ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("status", "failed", "error", "Unable to send test email"));
+        }
+        return ResponseEntity.ok(Map.of("status", "sent", "to", to));
+    }
 }

--- a/src/test/java/org/sasanlabs/controller/EmailTestControllerTest.java
+++ b/src/test/java/org/sasanlabs/controller/EmailTestControllerTest.java
@@ -76,4 +76,47 @@ class EmailTestControllerTest {
         assertEquals("failed", response.getBody().get("status"));
         assertEquals("Unable to send test email", response.getBody().get("error"));
     }
+
+        @Test
+        void shouldSendResetEmail() {
+                EmailTestController controller = new EmailTestController(emailService);
+
+                ResponseEntity<Map<String, String>> response =
+                                controller.sendResetEmail("student@example.com", "reset token");
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertEquals("sent", response.getBody().get("status"));
+                assertEquals("student@example.com", response.getBody().get("to"));
+
+                verify(emailService).sendResetEmail("student@example.com", "reset token");
+        }
+
+        @Test
+        void shouldSendVerificationEmail() {
+                EmailTestController controller = new EmailTestController(emailService);
+
+                ResponseEntity<Map<String, String>> response =
+                                controller.sendVerificationEmail("student@example.com", "verify token");
+
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                assertEquals("sent", response.getBody().get("status"));
+                assertEquals("student@example.com", response.getBody().get("to"));
+
+                verify(emailService).sendVerificationEmail("student@example.com", "verify token");
+        }
+
+        @Test
+        void shouldReturnBadRequestWhenResetEmailInputIsRejected() {
+                doThrow(new IllegalArgumentException("token must not be blank"))
+                                .when(emailService)
+                                .sendResetEmail("student@example.com", " ");
+
+                EmailTestController controller = new EmailTestController(emailService);
+                ResponseEntity<Map<String, String>> response =
+                                controller.sendResetEmail("student@example.com", " ");
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+                assertEquals("failed", response.getBody().get("status"));
+                assertEquals("token must not be blank", response.getBody().get("error"));
+        }
 }

--- a/src/test/java/org/sasanlabs/controller/EmailTestControllerTest.java
+++ b/src/test/java/org/sasanlabs/controller/EmailTestControllerTest.java
@@ -77,46 +77,46 @@ class EmailTestControllerTest {
         assertEquals("Unable to send test email", response.getBody().get("error"));
     }
 
-        @Test
-        void shouldSendResetEmail() {
-                EmailTestController controller = new EmailTestController(emailService);
+    @Test
+    void shouldSendResetEmail() {
+        EmailTestController controller = new EmailTestController(emailService);
 
-                ResponseEntity<Map<String, String>> response =
-                                controller.sendResetEmail("student@example.com", "reset token");
+        ResponseEntity<Map<String, String>> response =
+                controller.sendResetEmail("student@example.com", "reset token");
 
-                assertEquals(HttpStatus.OK, response.getStatusCode());
-                assertEquals("sent", response.getBody().get("status"));
-                assertEquals("student@example.com", response.getBody().get("to"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("sent", response.getBody().get("status"));
+        assertEquals("student@example.com", response.getBody().get("to"));
 
-                verify(emailService).sendResetEmail("student@example.com", "reset token");
-        }
+        verify(emailService).sendResetEmail("student@example.com", "reset token");
+    }
 
-        @Test
-        void shouldSendVerificationEmail() {
-                EmailTestController controller = new EmailTestController(emailService);
+    @Test
+    void shouldSendVerificationEmail() {
+        EmailTestController controller = new EmailTestController(emailService);
 
-                ResponseEntity<Map<String, String>> response =
-                                controller.sendVerificationEmail("student@example.com", "verify token");
+        ResponseEntity<Map<String, String>> response =
+                controller.sendVerificationEmail("student@example.com", "verify token");
 
-                assertEquals(HttpStatus.OK, response.getStatusCode());
-                assertEquals("sent", response.getBody().get("status"));
-                assertEquals("student@example.com", response.getBody().get("to"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("sent", response.getBody().get("status"));
+        assertEquals("student@example.com", response.getBody().get("to"));
 
-                verify(emailService).sendVerificationEmail("student@example.com", "verify token");
-        }
+        verify(emailService).sendVerificationEmail("student@example.com", "verify token");
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenResetEmailInputIsRejected() {
-                doThrow(new IllegalArgumentException("token must not be blank"))
-                                .when(emailService)
-                                .sendResetEmail("student@example.com", " ");
+    @Test
+    void shouldReturnBadRequestWhenResetEmailInputIsRejected() {
+        doThrow(new IllegalArgumentException("token must not be blank"))
+                .when(emailService)
+                .sendResetEmail("student@example.com", " ");
 
-                EmailTestController controller = new EmailTestController(emailService);
-                ResponseEntity<Map<String, String>> response =
-                                controller.sendResetEmail("student@example.com", " ");
+        EmailTestController controller = new EmailTestController(emailService);
+        ResponseEntity<Map<String, String>> response =
+                controller.sendResetEmail("student@example.com", " ");
 
-                assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-                assertEquals("failed", response.getBody().get("status"));
-                assertEquals("token must not be blank", response.getBody().get("error"));
-        }
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("failed", response.getBody().get("status"));
+        assertEquals("token must not be blank", response.getBody().get("error"));
+    }
 }


### PR DESCRIPTION
## What this PR does

This adds a small email flow update under the unsafe profile.

### Included changes
- added `/email/reset` for password reset emails
- added `/email/verify` for verification emails
- updated the email flow docs with simple examples
- added controller tests for the new routes

### Why
This makes the email flow easier to try out and gives new contributors a simple endpoint to work with.

### Testing
- `./gradlew.bat test --tests org.sasanlabs.controller.EmailTestControllerTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-based email link endpoints for password reset and account verification.
  * Endpoints return consistent JSON responses for success and validation/mail failure cases.

* **Documentation**
  * Expanded the email flow testing guide with reset/verification endpoint details, required parameters, token behavior, and URL-encoding notes.
  * Linked the guide from project run and modern UI testing instructions.

* **Tests**
  * Added controller tests covering successful reset/verification sends and proper `400` handling for invalid reset tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->