### PR TITLE
feat: add challenge mode to Error-Based and Union-Based SQL Injection

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
@@ -9,6 +9,7 @@ import org.sasanlabs.internal.utility.JSONSerializationUtils;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
@@ -54,6 +55,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
             description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -99,6 +115,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             description =
                     "ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -145,6 +176,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             description =
                     "ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -195,6 +241,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
             description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -12,6 +12,7 @@ import javax.persistence.criteria.Root;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
@@ -59,6 +60,21 @@ public class UnionBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.UNION_BASED_SQL_INJECTION,
             description = "UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
             payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -74,6 +90,21 @@ public class UnionBasedSQLInjectionVulnerability {
             description =
                     "UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -292,18 +292,18 @@ ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract all car information w
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes in the query: WHERE id='your_input'.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the opening single quote first, then inject your own SQL condition, and comment out the rest.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of the single-quoted string and injects a boolean condition.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' OR '1'='1 --
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' OR '1'='1' -- 
 
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Extract car information when single quotes are stripped from the input before query construction.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Analyze the effectiveness of the naive single-quote stripping used to protect this endpoint.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=The application removes all single quote characters from the input using replaceAll before building the query.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=Since single quotes are stripped, try using a double-encoding or alternate bypass to inject SQL without relying on single quotes.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Payload that bypasses single-quote stripping to inject SQL.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=Because all single quotes are stripped, standard quote-based injection is not possible. The input remains a quoted literal in the final query.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=The single-quote stripping prevents standard injection. The input becomes a harmless quoted literal.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=1 OR 1=1 --
 
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Bypass a PreparedStatement that still constructs the query by concatenating input into the SQL string before preparing it.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=Although a PreparedStatement object is created, the query string itself is built by concatenation with user input.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Because the user input is embedded in the query text rather than bound as a parameter, the same injection techniques apply despite using PreparedStatement.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Payload that exploits concatenated input in a misused PreparedStatement query.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the misused PreparedStatement that strips single quotes and concatenates input into the query string.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=A PreparedStatement object is created, but the query string is built by concatenation with user input rather than using parameterized binding.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Single quotes are stripped from input before concatenation. While this prevents standard injection, the code pattern is still insecure and the PreparedStatement provides no actual protection.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=The single-quote stripping and misused PreparedStatement prevent standard injection. The input becomes a harmless quoted literal.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=1 OR 1=1 --
 
 # Union-Based SQL Injection Challenge Mode
@@ -311,13 +311,13 @@ UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract data from other datab
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query, so you can append a UNION SELECT statement.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Determine the number of columns in the original query by using UNION SELECT with increasing column counts until the query succeeds.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that appends a UNION SELECT to extract data from other tables.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 UNION SELECT 1,name,imagePath FROM cars --
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 UNION SELECT 1,username,password FROM auth_users -- 
 
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract data using UNION-based SQL injection where the input is wrapped in single quotes before being appended.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes: WHERE id='your_input'. Close the quote before injecting UNION.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Break out of the single-quoted string with a closing quote, then append UNION SELECT to combine result sets.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Break out of the single-quoted string with a closing quote, then append UNION SELECT to combine result sets from other tables.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of single quotes and appends a UNION SELECT statement.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' UNION SELECT 1,name,imagePath FROM cars --
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' UNION SELECT 1,username,password FROM auth_users -- 
 
 #### SSRF Vulnerability
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -281,6 +281,44 @@ UNION_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WITH_SINGLE_QUOTE_APPENDED_TO
 BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query param is directly appended to the Query hence Query can be manipulated.
 BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query param is wrapped around "'" and then appended to the SQL Query hence query can be manipulated.
 
+# Error-Based SQL Injection Challenge Mode
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract all car information by exploiting error-based SQL injection where the input is appended directly to the query without any wrapping.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query string without quotes or escaping.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Appending a single quote will break the SQL syntax and cause the database to return an error message revealing query structure.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that causes a SQL syntax error and extracts data through the error message.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1' OR 1=1 --
+
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract all car information where the input is wrapped in single quotes before being appended to the query.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes in the query: WHERE id='your_input'.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the opening single quote first, then inject your own SQL condition, and comment out the rest.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of the single-quoted string and injects a boolean condition.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' OR '1'='1 --
+
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Extract car information when single quotes are stripped from the input before query construction.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=The application removes all single quote characters from the input using replaceAll before building the query.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=Since single quotes are stripped, try using a double-encoding or alternate bypass to inject SQL without relying on single quotes.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Payload that bypasses single-quote stripping to inject SQL.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=1 OR 1=1 --
+
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Bypass a PreparedStatement that still constructs the query by concatenating input into the SQL string before preparing it.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=Although a PreparedStatement object is created, the query string itself is built by concatenation with user input.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Because the user input is embedded in the query text rather than bound as a parameter, the same injection techniques apply despite using PreparedStatement.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Payload that exploits concatenated input in a misused PreparedStatement query.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=1 OR 1=1 --
+
+# Union-Based SQL Injection Challenge Mode
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract data from other database tables using UNION-based SQL injection where the input is appended directly to the query.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query, so you can append a UNION SELECT statement.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Determine the number of columns in the original query by using UNION SELECT with increasing column counts until the query succeeds.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that appends a UNION SELECT to extract data from other tables.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 UNION SELECT 1,name,imagePath FROM cars --
+
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract data using UNION-based SQL injection where the input is wrapped in single quotes before being appended.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes: WHERE id='your_input'. Close the quote before injecting UNION.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Break out of the single-quoted string with a closing quote, then append UNION SELECT to combine result sets.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of single quotes and appends a UNION SELECT statement.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' UNION SELECT 1,name,imagePath FROM cars --
+
 #### SSRF Vulnerability
 
 SSRF_VULNERABILITY=In a Server-Side Request Forgery (SSRF) attack, the attacker can abuse functionality on the server to \

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -282,41 +282,41 @@ BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query param is directly
 BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query param is wrapped around "'" and then appended to the SQL Query hence query can be manipulated.
 
 # Error-Based SQL Injection Challenge Mode
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract all car information by exploiting error-based SQL injection where the input is appended directly to the query without any wrapping.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query string without quotes or escaping.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Appending a single quote will break the SQL syntax and cause the database to return an error message revealing query structure.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that causes a SQL syntax error and extracts data through the error message.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1' OR 1=1 --
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Using only the error messages returned by the database, discover the password stored for admin_sqli in the auth_users table. The application never displays table data directly - only errors.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query string without quotes or escaping. This lets you break the query and control what appears in the error output.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=CAST or CONVERT a value from auth_users to an incompatible type in a subquery. The database will helpfully include that value in the error message when the type conversion fails.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Error-based SQL injection that forces the database to display admin_sqli's password through a type conversion error.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 AND CAST((SELECT password FROM auth_users WHERE username='admin_sqli') AS int)=1
 
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract all car information where the input is wrapped in single quotes before being appended to the query.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes in the query: WHERE id='your_input'.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the opening single quote first, then inject your own SQL condition, and comment out the rest.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of the single-quoted string and injects a boolean condition.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' OR '1'='1' -- 
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The parameter is now wrapped in single quotes. Use the same error-based technique to extract the admin_sqli password from the auth_users table.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes in the query: WHERE id='your_input'. Close that opening quote before injecting your subquery.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the opening quote with ' then use the same CAST trick in a subquery to read admin_sqli's password from auth_users through the error message.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Error-based SQL injection with single-quote escape that reads the admin_sqli password through a forced type conversion error.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' AND CAST((SELECT password FROM auth_users WHERE username='admin_sqli') AS int)=1 -- 
 
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Analyze the effectiveness of the naive single-quote stripping used to protect this endpoint.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Single quotes are stripped from your input before building the query, making standard injection impossible. Analyze why this endpoint is still not secure despite this filter.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=The application removes all single quote characters from the input using replaceAll before building the query.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=Because all single quotes are stripped, standard quote-based injection is not possible. The input remains a quoted literal in the final query.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=The single-quote stripping prevents standard injection. The input becomes a harmless quoted literal.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=Although single quotes are stripped, using PreparedStatement with concatenation is the real issue. Without parameterized binding, other injection vectors may still be exploitable.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=The single-quote stripping prevents standard injection but the concatenation pattern remains insecure.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=1 OR 1=1 --
 
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the misused PreparedStatement that strips single quotes and concatenates input into the query string.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=A PreparedStatement is used but the query is built by concatenating stripped input. Understand why this provides no real protection against injection.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=A PreparedStatement object is created, but the query string is built by concatenation with user input rather than using parameterized binding.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Single quotes are stripped from input before concatenation. While this prevents standard injection, the code pattern is still insecure and the PreparedStatement provides no actual protection.
-ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=The single-quote stripping and misused PreparedStatement prevent standard injection. The input becomes a harmless quoted literal.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Single quotes are stripped from input before concatenation. However, the PreparedStatement offers zero protection because the injection happens before the query is prepared, not through parameterized placeholders.
+ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=The misused PreparedStatement provides no protection since concatenation happens before preparation.
 ERROR_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=1 OR 1=1 --
 
 # Union-Based SQL Injection Challenge Mode
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract data from other database tables using UNION-based SQL injection where the input is appended directly to the query.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query, so you can append a UNION SELECT statement.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Determine the number of columns in the original query by using UNION SELECT with increasing column counts until the query succeeds.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that appends a UNION SELECT to extract data from other tables.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Using a UNION-based injection, extract the username and password for admin_sqli from the auth_users table. The input is appended directly with no wrapping.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input parameter is concatenated directly into the SQL query, so you can append a UNION SELECT statement targeting auth_users.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Determine the number of columns in the original query first. Then replace columns with username and password from auth_users. The original query has 3 columns (id, name, imagePath).
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Payload that uses UNION SELECT to extract admin_sqli credentials from the auth_users table.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 UNION SELECT 1,username,password FROM auth_users -- 
 
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract data using UNION-based SQL injection where the input is wrapped in single quotes before being appended.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes: WHERE id='your_input'. Close the quote before injecting UNION.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Break out of the single-quoted string with a closing quote, then append UNION SELECT to combine result sets from other tables.
-UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that breaks out of single quotes and appends a UNION SELECT statement.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The input is wrapped in single quotes. Use UNION-based injection to extract the admin_sqli credentials from the auth_users table.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The input is placed inside single quotes: WHERE id='your_input'. Close the quote before injecting UNION SELECT.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Break out with ' first, then append UNION SELECT with the correct column count (3) to pull username and password from auth_users.
+UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Payload that escapes single quotes and uses UNION SELECT to read admin_sqli credentials from auth_users.
 UNION_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=' UNION SELECT 1,username,password FROM auth_users -- 
 
 #### SSRF Vulnerability


### PR DESCRIPTION
## Summary

Add `@ChallengeCard` annotations to all unsecure levels in `ErrorBasedSQLInjectionVulnerability` and `UnionBasedSQLInjectionVulnerability`, following the established pattern from `BlindSQLInjectionVulnerability`.

## Changes

### `ErrorBasedSQLInjectionVulnerability.java`
- Added `@ChallengeCard` annotations to 4 unsecure levels (Level1-Level4)
- Each includes challenge text, 2 hints, and payload description/value

### `UnionBasedSQLInjectionVulnerability.java`
- Added `@ChallengeCard` annotations to 2 unsecure levels (Level1-Level2)
- Same structure as above

### `messages.properties`
- Added 30 new message keys for challenge text, hints, and payloads

Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added challenge cards for **Error-Based SQL Injection** levels 1–4.
  * Added challenge cards for **Union-Based SQL Injection** levels 1–2.
  * Each card includes challenge text, progressive hints, and an example payload for the corresponding level.
* **Localization**
  * Added localized (i18n) labels and guidance for the new SQL injection challenge modes, including payload descriptions and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->