### PR TITLE
feat: add challenge mode to LDAP Injection (#568), File Upload (#559), and SSRF (#565)

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -158,17 +158,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL1_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
@@ -193,17 +188,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL2_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
@@ -228,17 +218,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL3_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
@@ -269,17 +254,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL4_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
@@ -311,17 +291,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL5_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
@@ -357,17 +332,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL6_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
@@ -401,20 +371,13 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL7_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2"),
-                @ChallengeCard.Hint(
-                        order = 3,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2"),
+                @ChallengeCard.Hint(order = 3, text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_7,
@@ -447,17 +410,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL8_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
@@ -484,17 +442,12 @@ public class UnrestrictedFileUpload {
     @ChallengeCard(
             challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL9_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_DESCRIPTION",
+                            description = "FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_DESCRIPTION",
                             value = "FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -20,6 +20,7 @@ import org.sasanlabs.internal.utility.FrameworkConstants;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.exception.ServiceApplicationException;
@@ -154,6 +155,21 @@ public class UnrestrictedFileUpload {
             },
             description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -174,6 +190,21 @@ public class UnrestrictedFileUpload {
             },
             description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -194,6 +225,21 @@ public class UnrestrictedFileUpload {
             },
             description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_FILE_EXTENSION",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -220,6 +266,21 @@ public class UnrestrictedFileUpload {
             },
             description = "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -247,6 +308,21 @@ public class UnrestrictedFileUpload {
             description =
                     "UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION_CASE_INSENSITIVE",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_5")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -278,6 +354,21 @@ public class UnrestrictedFileUpload {
             description =
                     "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIVE",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_6")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL6_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -307,6 +398,24 @@ public class UnrestrictedFileUpload {
             description =
                     "UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_7")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL7_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_7,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -335,6 +444,21 @@ public class UnrestrictedFileUpload {
             vulnerabilityExposed = {VulnerabilityType.PATH_TRAVERSAL},
             description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_8")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL8_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
             htmlTemplate = "LEVEL_1/FileUpload",
@@ -357,6 +481,21 @@ public class UnrestrictedFileUpload {
             vulnerabilityExposed = {VulnerabilityType.PATH_TRAVERSAL},
             description = "UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME",
             payload = "UNRESTRICTED_FILE_UPLOAD_PAYLOAD_LEVEL_8")
+    @ChallengeCard(
+            challengeText = "FILE_UPLOAD_VULNERABILITY_LEVEL9_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_DESCRIPTION",
+                            value = "FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,
             htmlTemplate = "LEVEL_1/FileUpload",

--- a/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
@@ -107,17 +107,12 @@ public class LDAPInjectionVulnerability {
     @ChallengeCard(
             challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
                             value = "LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1(
@@ -151,17 +146,12 @@ public class LDAPInjectionVulnerability {
     @ChallengeCard(
             challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
                             value = "LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2(
@@ -195,20 +185,13 @@ public class LDAPInjectionVulnerability {
     @ChallengeCard(
             challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT2"),
-                @ChallengeCard.Hint(
-                        order = 3,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3")
+                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT2"),
+                @ChallengeCard.Hint(order = 3, text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
                             value = "LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3(
@@ -268,17 +251,12 @@ public class LDAPInjectionVulnerability {
     @ChallengeCard(
             challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
                             value = "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4(
@@ -322,20 +300,13 @@ public class LDAPInjectionVulnerability {
     @ChallengeCard(
             challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL5_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2"),
-                @ChallengeCard.Hint(
-                        order = 3,
-                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3")
+                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2"),
+                @ChallengeCard.Hint(order = 3, text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
+                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
                             value = "LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5(

--- a/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
@@ -13,6 +13,7 @@ import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.PasswordHashingUtils;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
@@ -103,6 +104,21 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_1_BASIC_INJECTION",
             payload = "LDAP_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1(
             @RequestParam(required = false) String username) throws Exception {
@@ -132,6 +148,21 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_2_OR_BYPASS",
             payload = "LDAP_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2(
             @RequestParam(required = false) String username) throws Exception {
@@ -161,6 +192,24 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_3_AUTH_BYPASS",
             payload = "LDAP_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3(
             @RequestParam(required = false) String username,
@@ -216,6 +265,21 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_4_INPUT_SANITIZATION",
             payload = "LDAP_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4(
             @RequestParam(required = false) String username) throws Exception {
@@ -255,6 +319,24 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_5_BLIND_INJECTION",
             payload = "LDAP_PAYLOAD_LEVEL_5")
+    @ChallengeCard(
+            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION",
+                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5(
             @RequestParam(required = false) String username,

--- a/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ldapInjection/LDAPInjectionVulnerability.java
@@ -248,16 +248,6 @@ public class LDAPInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.LDAP_INJECTION,
             description = "LDAP_LEVEL_4_INPUT_SANITIZATION",
             payload = "LDAP_PAYLOAD_LEVEL_4")
-    @ChallengeCard(
-            challengeText = "LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE",
-            hints = {
-                @ChallengeCard.Hint(order = 1, text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
-                @ChallengeCard.Hint(order = 2, text = "LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2")
-            },
-            payload =
-                    @ChallengeCard.Payload(
-                            description = "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
-                            value = "LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/LDAP")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4(
             @RequestParam(required = false) String username) throws Exception {

--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -96,17 +96,12 @@ public class SSRFVulnerability {
     @ChallengeCard(
             challengeText = "SSRF_VULNERABILITY_LEVEL1_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "SSRF_VULNERABILITY_LEVEL1_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "SSRF_VULNERABILITY_LEVEL1_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "SSRF_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "SSRF_VULNERABILITY_LEVEL1_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            description = "SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
                             value = "SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel1(
@@ -125,17 +120,12 @@ public class SSRFVulnerability {
     @ChallengeCard(
             challengeText = "SSRF_VULNERABILITY_LEVEL2_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "SSRF_VULNERABILITY_LEVEL2_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "SSRF_VULNERABILITY_LEVEL2_HINT2")
+                @ChallengeCard.Hint(order = 1, text = "SSRF_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "SSRF_VULNERABILITY_LEVEL2_HINT2")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "SSRF_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            description = "SSRF_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
                             value = "SSRF_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel2(
@@ -156,20 +146,13 @@ public class SSRFVulnerability {
     @ChallengeCard(
             challengeText = "SSRF_VULNERABILITY_LEVEL3_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "SSRF_VULNERABILITY_LEVEL3_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "SSRF_VULNERABILITY_LEVEL3_HINT2"),
-                @ChallengeCard.Hint(
-                        order = 3,
-                        text = "SSRF_VULNERABILITY_LEVEL3_HINT3")
+                @ChallengeCard.Hint(order = 1, text = "SSRF_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "SSRF_VULNERABILITY_LEVEL3_HINT2"),
+                @ChallengeCard.Hint(order = 3, text = "SSRF_VULNERABILITY_LEVEL3_HINT3")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            description = "SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
                             value = "SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel3(
@@ -191,20 +174,13 @@ public class SSRFVulnerability {
     @ChallengeCard(
             challengeText = "SSRF_VULNERABILITY_LEVEL4_CHALLENGE",
             hints = {
-                @ChallengeCard.Hint(
-                        order = 1,
-                        text = "SSRF_VULNERABILITY_LEVEL4_HINT1"),
-                @ChallengeCard.Hint(
-                        order = 2,
-                        text = "SSRF_VULNERABILITY_LEVEL4_HINT2"),
-                @ChallengeCard.Hint(
-                        order = 3,
-                        text = "SSRF_VULNERABILITY_LEVEL4_HINT3")
+                @ChallengeCard.Hint(order = 1, text = "SSRF_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "SSRF_VULNERABILITY_LEVEL4_HINT2"),
+                @ChallengeCard.Hint(order = 3, text = "SSRF_VULNERABILITY_LEVEL4_HINT3")
             },
             payload =
                     @ChallengeCard.Payload(
-                            description =
-                                    "SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            description = "SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
                             value = "SSRF_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel4(

--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
@@ -22,7 +23,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 
 /**
  * This class contains vulnerabilities related to SSRF.

--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 
 /**
  * This class contains vulnerabilities related to SSRF.
@@ -92,6 +93,21 @@ public class SSRFVulnerability {
             vulnerabilityExposed = VulnerabilityType.SIMPLE_SSRF,
             description = "SSRF_VULNERABILITY_URL_WITHOUT_CHECK",
             payload = "SSRF_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "SSRF_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "SSRF_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "SSRF_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel1(
             @RequestParam(FILE_URL) String url) throws IOException {
@@ -106,6 +122,21 @@ public class SSRFVulnerability {
             vulnerabilityExposed = VulnerabilityType.SIMPLE_SSRF,
             description = "SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL",
             payload = "SSRF_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "SSRF_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "SSRF_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "SSRF_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "SSRF_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "SSRF_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel2(
             @RequestParam(FILE_URL) String url) throws IOException {
@@ -122,6 +153,24 @@ public class SSRFVulnerability {
             vulnerabilityExposed = VulnerabilityType.SIMPLE_SSRF,
             description = "SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_169.254.169.254",
             payload = "SSRF_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "SSRF_VULNERABILITY_LEVEL3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "SSRF_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "SSRF_VULNERABILITY_LEVEL3_HINT2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "SSRF_VULNERABILITY_LEVEL3_HINT3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            value = "SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel3(
             @RequestParam(FILE_URL) String url) throws IOException {
@@ -139,6 +188,24 @@ public class SSRFVulnerability {
             vulnerabilityExposed = VulnerabilityType.SIMPLE_SSRF,
             description = "SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL",
             payload = "SSRF_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "SSRF_VULNERABILITY_LEVEL4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "SSRF_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "SSRF_VULNERABILITY_LEVEL4_HINT2"),
+                @ChallengeCard.Hint(
+                        order = 3,
+                        text = "SSRF_VULNERABILITY_LEVEL4_HINT3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            value = "SSRF_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/SSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel4(
             @RequestParam(FILE_URL) String url) throws IOException {

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -300,6 +300,122 @@ SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_169.254.169.254=file:// protocol
 SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL=file:// protocol as well as access to internal metadata service is not allowed.
 SSRF_VULNERABILITY_URL_ONLY_IF_IN_THE_WHITELIST=Only Whitelisted URL is allowed.
 
+# LDAP Injection Challenge Mode
+LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Enumerate all users in the directory by injecting a wildcard into the LDAP filter.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input is concatenated directly into the LDAP filter without escaping: (uid=your_input).
+LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2=LDAP filters support wildcard characters. A * matches any sequence of characters, so try inputting * to retrieve all entries.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Wildcard injection that matches all uid values in the directory.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=*
+
+LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Retrieve users from both uid and mail attributes by injecting an OR condition into the LDAP filter.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1=The filter uses an OR condition: (|(uid=your_input)(mail=your_input)).
+LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2=Inject a wildcard to match all entries across both attributes: * as input produces (|(uid=*)(mail=*)).
+LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Wildcard injection that matches all entries across uid and mail attributes.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=*
+
+LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Bypass password verification by injecting a filter that matches all users regardless of the password provided.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT1=The authentication filter is: (&(uid=your_input)(uid=*)). The password is checked separately in application code.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT2=If the filter matches multiple users, the code iterates through all of them and checks passwords. Injecting * returns all users.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3=Combine a valid username with a wildcard to ensure the filter matches, then try known passwords or common defaults.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Wildcard injection that bypasses the LDAP filter to return all users for password checking.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=*
+
+LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the effectiveness of LDAP filter encoding as a defense against injection.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1=This level uses Filter.encodeValue() to escape special LDAP characters before building the filter.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2=Proper encoding prevents injection by treating special characters as literal values rather than filter syntax.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Standard input is safely encoded. Injection attempts are neutralized by the encoder.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=admin
+
+LDAP_INJECTION_VULNERABILITY_LEVEL5_CHALLENGE=Bypass authentication by injecting a filter that matches all users in a blind LDAP injection scenario.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1=The application only reveals success or failure, not the actual user data. But the filter still processes your input.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2=The filter is (&(uid=your_input)). Injecting *) closes the first group and adds a matching condition: (&(uid=*)( )).
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3=Try input: *) to produce (&(uid=*)(*)). This matches any user whose uid attribute exists, bypassing the intended single-user lookup.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION=Filter manipulation that matches all users with a uid attribute, bypassing authentication.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_VALUE=*)
+
+# File Upload Challenge Mode
+FILE_UPLOAD_VULNERABILITY_LEVEL1_CHALLENGE=Upload a malicious file by exploiting the complete lack of filename validation.
+FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT1=The uploaded file is saved with its original name and served from a static directory.
+FILE_UPLOAD_VULNERABILITY_LEVEL1_HINT2=Upload an HTML file containing script tags. The browser will execute the script when the file is accessed.
+FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Upload an HTML file with embedded JavaScript that executes in the victim browser.
+FILE_UPLOAD_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as malicious.html
+
+FILE_UPLOAD_VULNERABILITY_LEVEL2_CHALLENGE=Bypass the random prefix protection by finding how uploaded files are served.
+FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT1=A random number is prepended to the filename, but the full path is returned in the response.
+FILE_UPLOAD_VULNERABILITY_LEVEL2_HINT2=The response contains the exact URL where the file is accessible. Upload an HTML file and visit the returned URL.
+FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Upload an HTML file. The random prefix does not prevent execution when the file is accessed directly.
+FILE_UPLOAD_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=<script>alert('XSS')</script> saved as payload.html
+
+FILE_UPLOAD_VULNERABILITY_LEVEL3_CHALLENGE=Bypass the .html extension block by using an alternative extension that the browser still renders as HTML.
+FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT1=Only .html files are blocked. Other extensions that browsers render as HTML are not filtered.
+FILE_UPLOAD_VULNERABILITY_LEVEL3_HINT2=Try .htm, .svg, or .xhtml extensions. Browsers may still execute embedded scripts in these files.
+FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Upload an HTML file with .htm extension to bypass the .html-only filter.
+FILE_UPLOAD_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as payload.htm
+
+FILE_UPLOAD_VULNERABILITY_LEVEL4_CHALLENGE=Bypass the case-insensitive .html and .htm filter using alternative file extensions.
+FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT1=Both .html and .htm extensions are blocked, but only these two specific extensions.
+FILE_UPLOAD_VULNERABILITY_LEVEL4_HINT2=Try .shtml, .svg, .xhtml, or other extensions that browsers may render as HTML content.
+FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Upload an HTML file with an unblocked extension like .shtml or .svg.
+FILE_UPLOAD_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as payload.svg
+
+FILE_UPLOAD_VULNERABILITY_LEVEL5_CHALLENGE=Bypass the case-insensitive .html/.htm filter using mixed-case or alternative approaches.
+FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT1=The filter converts the filename to lowercase before checking, so .HTML or .HtMl will not bypass it.
+FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT2=The filter only checks the final extension. Try double extensions like payload.html.jpg or alternative extensions like .svg.
+FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION=Upload an HTML file with an extension not covered by the case-insensitive filter.
+FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as payload.xhtml
+
+FILE_UPLOAD_VULNERABILITY_LEVEL6_CHALLENGE=Bypass the .png/.jpeg contains check by embedding the required string in the filename.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT1=The validator checks if the filename contains .png or .jpeg anywhere, not just at the end.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2=A filename like shell.png.php passes the contains check but is executed as PHP by the server.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION=Upload a file with a name that contains .png but ends with an executable extension.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_VALUE=shell.png.php (contains .png, executes as PHP)
+
+FILE_UPLOAD_VULNERABILITY_LEVEL7_CHALLENGE=Bypass the .png/.jpeg ends-with check using a null byte injection.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1=The validator checks if the filename ends with .png or .jpeg after null byte truncation.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2=The code truncates the filename at the null byte before saving. Use payload.php%00.png to save as payload.php.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3=The null byte (%00) terminates the string in C-based systems, so the .png extension check sees the full name but the filesystem saves only the part before the null byte.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION=Null byte injection that causes the filename to be truncated at the null character, saving with an executable extension.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_VALUE=payload.php%00.png (saved as payload.php)
+
+FILE_UPLOAD_VULNERABILITY_LEVEL8_CHALLENGE=Exploit path traversal through the Content-Disposition header to write files outside the intended directory.
+FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT1=This level uses a different upload directory and applies HTML encoding to the filename.
+FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT2=The Content-Disposition header can contain path traversal sequences. Try filenames like ../../../etc/cron.d/shell.
+FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_DESCRIPTION=Upload a file whose name contains directory traversal to write outside the upload directory.
+FILE_UPLOAD_VULNERABILITY_LEVEL8_PAYLOAD_VALUE=../../../tmp/evil.txt with content cron job or webshell
+
+FILE_UPLOAD_VULNERABILITY_LEVEL9_CHALLENGE=Exploit the lack of file size limits to cause denial of service through resource exhaustion.
+FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT1=There is no maximum file size limit on uploads at this level.
+FILE_UPLOAD_VULNERABILITY_LEVEL9_HINT2=Upload an extremely large file to exhaust disk space or memory, causing the application to become unresponsive.
+FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_DESCRIPTION=Upload a very large file to exhaust server resources. No size validation is performed.
+FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_VALUE=Upload a multi-gigabyte file to fill disk space
+
+# SSRF Challenge Mode
+SSRF_VULNERABILITY_LEVEL1_CHALLENGE=Read internal files by providing a file:// URL to the SSRF endpoint.
+SSRF_VULNERABILITY_LEVEL1_HINT1=The endpoint accepts any URL without protocol restrictions.
+SSRF_VULNERABILITY_LEVEL1_HINT2=Use the file:// protocol to read local files from the server filesystem.
+SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Exploit the lack of protocol validation to read local files via the file:// protocol.
+SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=file:///etc/passwd
+
+SSRF_VULNERABILITY_LEVEL2_CHALLENGE=Bypass the file:// protocol block by using an HTTP redirect to access local resources.
+SSRF_VULNERABILITY_LEVEL2_HINT1=The endpoint blocks file:// URLs but still makes HTTP requests to any other URL.
+SSRF_VULNERABILITY_LEVEL2_HINT2=Host a redirect on your server that points to file:///etc/passwd. The application follows the redirect but only checked the initial URL.
+SSRF_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Use an HTTP URL that redirects to a file:// URL to bypass the protocol check.
+SSRF_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=http://your-server/redirect?target=file:///etc/passwd
+
+SSRF_VULNERABILITY_LEVEL3_CHALLENGE=Access cloud metadata services by bypassing the IP address block using DNS rebinding.
+SSRF_VULNERABILITY_LEVEL3_HINT1=The endpoint blocks requests to 169.254.169.254 but does not validate after DNS resolution.
+SSRF_VULNERABILITY_LEVEL3_HINT2=Use a DNS name that first resolves to a safe IP, then after the check resolves to 169.254.169.254 (DNS rebinding).
+SSRF_VULNERABILITY_LEVEL3_HINT3=Alternatively, use decimal or octal IP encoding: 2852039166 for 169.254.169.254, or use IPv6 notation.
+SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Bypass the IP block using DNS rebinding or IP encoding tricks.
+SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=http://169.254.169.254/latest/meta-data/ (via DNS rebinding or encoded IP)
+
+SSRF_VULNERABILITY_LEVEL4_CHALLENGE=Access internal metadata services by bypassing the MetaDataServiceMock check.
+SSRF_VULNERABILITY_LEVEL4_HINT1=The endpoint blocks URLs that the MetaDataServiceMock recognizes as internal metadata endpoints.
+SSRF_VULNERABILITY_LEVEL4_HINT2=Use a redirect from an external URL to an internal metadata endpoint. The check is performed on the initial URL, not the redirect target.
+SSRF_VULNERABILITY_LEVEL4_HINT3=Host a redirect that points to the internal metadata service URL. The application validates the outer URL but follows the redirect to the blocked resource.
+SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Bypass the metadata service check by using an HTTP redirect to an internal endpoint.
+SSRF_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=http://your-server/redirect?target=http://169.254.169.254/latest/meta-data/
+
 # Cryptographic Failures Vulnerability
 CRYPTOGRAPHIC_FAILURES_VULNERABILITY=Cryptographic Failures occur when sensitive data is not properly protected using strong cryptographic algorithms and secure storage mechanisms. \
 This vulnerability can lead to exposure of sensitive information such as passwords, credit card numbers, personal data, and authentication tokens. \

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -301,16 +301,17 @@ SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL=file:// pr
 SSRF_VULNERABILITY_URL_ONLY_IF_IN_THE_WHITELIST=Only Whitelisted URL is allowed.
 
 # LDAP Injection Challenge Mode
-LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Enumerate all users in the directory by injecting a wildcard into the LDAP filter.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Using a blind LDAP injection technique, discover the email addresses of all users in the directory. The application only says whether entries were found - it never shows the actual results directly.
 LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input is concatenated directly into the LDAP filter without escaping: (uid=your_input).
 LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2=LDAP filters support wildcard characters. A * matches any sequence of characters, so try inputting * to retrieve all entries.
-LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Wildcard injection that matches all uid values in the directory.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT3=The application checks (mail=*) within the OR condition even though only uid is shown in the filter. Use this to discover email addresses one character at a time using blind true/false responses.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Blind LDAP wildcard injection that reveals email entries through true/false responses.
 LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=*
 
-LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Retrieve users from both uid and mail attributes by injecting an OR condition into the LDAP filter.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The filter uses an OR condition across uid and mail attributes. Use blind injection to discover passwords stored for users in the directory.
 LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1=The filter uses an OR condition: (|(uid=your_input)(mail=your_input)).
-LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2=Inject a wildcard to match all entries across both attributes: * as input produces (|(uid=*)(mail=*)).
-LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Wildcard injection that matches all entries across uid and mail attributes.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2=The application reveals only whether entries matched, not the values themselves. Use inference - ask yes/no questions one character at a time about what exists in the directory.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Blind LDAP injection that uses inferential questions to discover passwords across uid and mail attributes.
 LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=*
 
 LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Bypass password verification by injecting a filter that matches all users regardless of the password provided.
@@ -320,18 +321,18 @@ LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3=Combine a valid username with a wildca
 LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Wildcard injection that bypasses the LDAP filter to return all users for password checking.
 LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=*
 
-LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the effectiveness of LDAP filter encoding as a defense against injection.
-LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1=This level uses Filter.encodeValue() to escape special LDAP characters before building the filter.
-LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2=Proper encoding prevents injection by treating special characters as literal values rather than filter syntax.
-LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Standard input is safely encoded. Injection attempts are neutralized by the encoder.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the effectiveness of LDAP filter encoding as a defense. This is a SECURE level - no injection is possible here.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT1=This level uses Filter.encodeValue() to escape special LDAP characters before building the filter, making injection impossible.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_HINT2=Proper encoding prevents injection by treating special characters as literal values rather than filter syntax. No amount of wildcards or filter syntax can bypass this.
+LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Standard input is safely encoded. All injection attempts are neutralized by the encoder.
 LDAP_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=admin
 
-LDAP_INJECTION_VULNERABILITY_LEVEL5_CHALLENGE=Bypass authentication by injecting a filter that matches all users in a blind LDAP injection scenario.
-LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1=The application only reveals success or failure, not the actual user data. But the filter still processes your input.
-LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2=The filter is (&(uid=your_input)). Injecting *) closes the first group and adds a matching condition: (&(uid=*)( )).
-LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3=Try input: *) to produce (&(uid=*)(*)). This matches any user whose uid attribute exists, bypassing the intended single-user lookup.
-LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION=Filter manipulation that matches all users with a uid attribute, bypassing authentication.
-LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_VALUE=*)
+LDAP_INJECTION_VULNERABILITY_LEVEL5_CHALLENGE=Bypass authentication in a blind LDAP injection scenario. The filter only checks (uid=your_input) - use injection to match against email attributes instead.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT1=The application only reveals success or failure, not the actual user data. The filter is (&(uid=your_input)).
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT2=Close the (uid= filter with *) and inject an OR condition with (mail=*) to also match by email. Try: *)(mail=*
+LDAP_INJECTION_VULNERABILITY_LEVEL5_HINT3=Input *)(mail=* produces (&(uid=*)(mail=*)). This matches any user with a uid or mail attribute, bypassing the intended single-user lookup.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION=Blind LDAP injection that matches users by both uid and email attributes, bypassing authentication.
+LDAP_INJECTION_VULNERABILITY_LEVEL5_PAYLOAD_VALUE=*)(mail=*
 
 # File Upload Challenge Mode
 FILE_UPLOAD_VULNERABILITY_LEVEL1_CHALLENGE=Upload a malicious file by exploiting the complete lack of filename validation.
@@ -364,18 +365,18 @@ FILE_UPLOAD_VULNERABILITY_LEVEL5_HINT2=The filter only checks the final extensio
 FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_DESCRIPTION=Upload an HTML file with an extension not covered by the case-insensitive filter.
 FILE_UPLOAD_VULNERABILITY_LEVEL5_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as payload.xhtml
 
-FILE_UPLOAD_VULNERABILITY_LEVEL6_CHALLENGE=Bypass the .png/.jpeg contains check by embedding the required string in the filename.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_CHALLENGE=Bypass the .png/.jpeg contains check by embedding the required string in the filename to upload an HTML file with embedded JavaScript.
 FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT1=The validator checks if the filename contains .png or .jpeg anywhere, not just at the end.
-FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2=A filename like shell.png.php passes the contains check but is executed as PHP by the server.
-FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION=Upload a file with a name that contains .png but ends with an executable extension.
-FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_VALUE=shell.png.php (contains .png, executes as PHP)
+FILE_UPLOAD_VULNERABILITY_LEVEL6_HINT2=A filename like xss.png.html passes the contains check. When the browser accesses the uploaded file, it renders the .html extension and executes the JavaScript.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_DESCRIPTION=Upload an HTML file with a name containing .png to bypass the extension filter while maintaining browser execution.
+FILE_UPLOAD_VULNERABILITY_LEVEL6_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as xss.png.html
 
-FILE_UPLOAD_VULNERABILITY_LEVEL7_CHALLENGE=Bypass the .png/.jpeg ends-with check using a null byte injection.
-FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1=The validator checks if the filename ends with .png or .jpeg after null byte truncation.
-FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2=The code truncates the filename at the null byte before saving. Use payload.php%00.png to save as payload.php.
-FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3=The null byte (%00) terminates the string in C-based systems, so the .png extension check sees the full name but the filesystem saves only the part before the null byte.
-FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION=Null byte injection that causes the filename to be truncated at the null character, saving with an executable extension.
-FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_VALUE=payload.php%00.png (saved as payload.php)
+FILE_UPLOAD_VULNERABILITY_LEVEL7_CHALLENGE=Bypass the .png/.jpeg ends-with check using a null byte injection to upload an HTML payload.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT1=The validator checks if the filename ends with .png or .jpeg after null byte truncation. The code truncates at the null byte before saving.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT2=Use a filename like xss.html%00.png. The ends-with check sees the .png extension, but the file is saved as xss.html, which the browser renders as HTML.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_HINT3=The null byte (%00) terminates the string in C-based systems, so the .png suffix is only used for the check while the file retains the .html extension.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_DESCRIPTION=Null byte injection that truncates the filename at the null character, saving as an HTML file rendered by the browser.
+FILE_UPLOAD_VULNERABILITY_LEVEL7_PAYLOAD_VALUE=<img src=x onerror=alert('XSS')> saved as xss.html%00.png (saved as xss.html)
 
 FILE_UPLOAD_VULNERABILITY_LEVEL8_CHALLENGE=Exploit path traversal through the Content-Disposition header to write files outside the intended directory.
 FILE_UPLOAD_VULNERABILITY_LEVEL8_HINT1=This level uses a different upload directory and applies HTML encoding to the filename.
@@ -390,11 +391,11 @@ FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_DESCRIPTION=Upload a very large file to
 FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_VALUE=Upload a multi-gigabyte file to fill disk space
 
 # SSRF Challenge Mode
-SSRF_VULNERABILITY_LEVEL1_CHALLENGE=Read internal files by providing a file:// URL to the SSRF endpoint.
+SSRF_VULNERABILITY_LEVEL1_CHALLENGE=Read internal files by providing a file:// URL to the SSRF endpoint. The payload depends on the operating system.
 SSRF_VULNERABILITY_LEVEL1_HINT1=The endpoint accepts any URL without protocol restrictions.
-SSRF_VULNERABILITY_LEVEL1_HINT2=Use the file:// protocol to read local files from the server filesystem.
+SSRF_VULNERABILITY_LEVEL1_HINT2=Use the file:// protocol to read local files from the server filesystem. On Linux use /etc/passwd, on Windows use C:\Windows\win.ini.
 SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Exploit the lack of protocol validation to read local files via the file:// protocol.
-SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=file:///etc/passwd
+SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=file:///etc/passwd (Linux) or file:///C:/Windows/win.ini (Windows)
 
 SSRF_VULNERABILITY_LEVEL2_CHALLENGE=Bypass the file:// protocol block by using an HTTP redirect to access local resources.
 SSRF_VULNERABILITY_LEVEL2_HINT1=The endpoint blocks file:// URLs but still makes HTTP requests to any other URL.
@@ -402,18 +403,19 @@ SSRF_VULNERABILITY_LEVEL2_HINT2=Host a redirect on your server that points to fi
 SSRF_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Use an HTTP URL that redirects to a file:// URL to bypass the protocol check.
 SSRF_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=http://your-server/redirect?target=file:///etc/passwd
 
-SSRF_VULNERABILITY_LEVEL3_CHALLENGE=Access cloud metadata services by bypassing the IP address block using DNS rebinding.
+SSRF_VULNERABILITY_LEVEL3_CHALLENGE=Access AWS EC2 metadata by bypassing the IP address block. The goal is to reach the instance metadata endpoint at 169.254.169.254.
 SSRF_VULNERABILITY_LEVEL3_HINT1=The endpoint blocks requests to 169.254.169.254 but does not validate after DNS resolution.
-SSRF_VULNERABILITY_LEVEL3_HINT2=Use a DNS name that first resolves to a safe IP, then after the check resolves to 169.254.169.254 (DNS rebinding).
-SSRF_VULNERABILITY_LEVEL3_HINT3=Alternatively, use decimal or octal IP encoding: 2852039166 for 169.254.169.254, or use IPv6 notation.
-SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Bypass the IP block using DNS rebinding or IP encoding tricks.
-SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=http://169.254.169.254/latest/meta-data/ (via DNS rebinding or encoded IP)
+SSRF_VULNERABILITY_LEVEL3_HINT2=AWS metadata endpoints are documented in public gists. Search for AWS metadata endpoints to find the full list of available paths beyond /latest/meta-data/.
+SSRF_VULNERABILITY_LEVEL3_HINT3=Try: https://gist.github.com/jgrimesg/1156291eab8f82b1ce59b8a10ce4dc1c for a comprehensive list of AWS metadata endpoints and paths.
+SSRF_VULNERABILITY_LEVEL3_HINT4=Alternatively, use decimal or octal IP encoding: 2852039166 for 169.254.169.254, or use IPv6 notation to bypass the literal IP check.
+SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Bypass the IP block using DNS rebinding, IP encoding, or alternative representations to reach AWS metadata.
+SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=http://169.254.169.254/latest/meta-data/ (via DNS rebinding, encoded IP, or AWS-specific paths)
 
-SSRF_VULNERABILITY_LEVEL4_CHALLENGE=Access internal metadata services by bypassing the MetaDataServiceMock check.
-SSRF_VULNERABILITY_LEVEL4_HINT1=The endpoint blocks URLs that the MetaDataServiceMock recognizes as internal metadata endpoints.
+SSRF_VULNERABILITY_LEVEL4_CHALLENGE=Access internal metadata services by bypassing the checks in the MetaDataServiceMock class. This mock simulates an internal metadata endpoint.
+SSRF_VULNERABILITY_LEVEL4_HINT1=The endpoint checks URLs against the MetaDataServiceMock class to block known internal metadata endpoints.
 SSRF_VULNERABILITY_LEVEL4_HINT2=Use a redirect from an external URL to an internal metadata endpoint. The check is performed on the initial URL, not the redirect target.
-SSRF_VULNERABILITY_LEVEL4_HINT3=Host a redirect that points to the internal metadata service URL. The application validates the outer URL but follows the redirect to the blocked resource.
-SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Bypass the metadata service check by using an HTTP redirect to an internal endpoint.
+SSRF_VULNERABILITY_LEVEL4_HINT3=Host a redirect that points to the internal metadata service URL. The MetaDataServiceMock only checks the initial URL, so following a redirect bypasses the validation.
+SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Bypass the MetaDataServiceMock check by using an HTTP redirect to an internal metadata endpoint.
 SSRF_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=http://your-server/redirect?target=http://169.254.169.254/latest/meta-data/
 
 # Cryptographic Failures Vulnerability

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -301,24 +301,23 @@ SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL=file:// pr
 SSRF_VULNERABILITY_URL_ONLY_IF_IN_THE_WHITELIST=Only Whitelisted URL is allowed.
 
 # LDAP Injection Challenge Mode
-LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Using a blind LDAP injection technique, discover the email addresses of all users in the directory. The application only says whether entries were found - it never shows the actual results directly.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Use a wildcard injection to retrieve all users from the directory. The filter is (uid=your_input) and returns matching UID values directly.
 LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT1=The input is concatenated directly into the LDAP filter without escaping: (uid=your_input).
-LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2=LDAP filters support wildcard characters. A * matches any sequence of characters, so try inputting * to retrieve all entries.
-LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT3=The application checks (mail=*) within the OR condition even though only uid is shown in the filter. Use this to discover email addresses one character at a time using blind true/false responses.
-LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Blind LDAP wildcard injection that reveals email entries through true/false responses.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_HINT2=LDAP filters support wildcard characters. A * matches any sequence of characters, so inputting * retrieves all entries.
+LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Wildcard injection that reveals all UID entries in the directory.
 LDAP_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=*
 
-LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The filter uses an OR condition across uid and mail attributes. Use blind injection to discover passwords stored for users in the directory.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The filter uses an OR condition across uid and mail attributes. Use a wildcard to retrieve all entries from both attributes.
 LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT1=The filter uses an OR condition: (|(uid=your_input)(mail=your_input)).
-LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2=The application reveals only whether entries matched, not the values themselves. Use inference - ask yes/no questions one character at a time about what exists in the directory.
-LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Blind LDAP injection that uses inferential questions to discover passwords across uid and mail attributes.
+LDAP_INJECTION_VULNERABILITY_LEVEL2_HINT2=Inject * as input to match all entries in both uid and mail attributes: (|(uid=*)(mail=*)).
+LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Wildcard injection across uid and mail attributes returns all matching directory entries.
 LDAP_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=*
 
-LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Bypass password verification by injecting a filter that matches all users regardless of the password provided.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Widen the set of candidate users returned by the LDAP filter so that password verification attempts against multiple users. The password itself is still checked by the application.
 LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT1=The authentication filter is: (&(uid=your_input)(uid=*)). The password is checked separately in application code.
 LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT2=If the filter matches multiple users, the code iterates through all of them and checks passwords. Injecting * returns all users.
-LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3=Combine a valid username with a wildcard to ensure the filter matches, then try known passwords or common defaults.
-LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Wildcard injection that bypasses the LDAP filter to return all users for password checking.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_HINT3=Combine a valid username with a wildcard to ensure the filter matches multiple users, then try known passwords or common defaults.
+LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Wildcard injection that widens the LDAP filter to return all users, increasing the chance of a password match.
 LDAP_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=*
 
 LDAP_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=Analyze the effectiveness of LDAP filter encoding as a defense. This is a SECURE level - no injection is possible here.
@@ -393,7 +392,7 @@ FILE_UPLOAD_VULNERABILITY_LEVEL9_PAYLOAD_VALUE=Upload a multi-gigabyte file to f
 # SSRF Challenge Mode
 SSRF_VULNERABILITY_LEVEL1_CHALLENGE=Read internal files by providing a file:// URL to the SSRF endpoint. The payload depends on the operating system.
 SSRF_VULNERABILITY_LEVEL1_HINT1=The endpoint accepts any URL without protocol restrictions.
-SSRF_VULNERABILITY_LEVEL1_HINT2=Use the file:// protocol to read local files from the server filesystem. On Linux use /etc/passwd, on Windows use C:\Windows\win.ini.
+SSRF_VULNERABILITY_LEVEL1_HINT2=Use the file:// protocol to read local files from the server filesystem. On Linux use /etc/passwd, on Windows use C:\\Windows\\win.ini.
 SSRF_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Exploit the lack of protocol validation to read local files via the file:// protocol.
 SSRF_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=file:///etc/passwd (Linux) or file:///C:/Windows/win.ini (Windows)
 
@@ -407,15 +406,15 @@ SSRF_VULNERABILITY_LEVEL3_CHALLENGE=Access AWS EC2 metadata by bypassing the IP 
 SSRF_VULNERABILITY_LEVEL3_HINT1=The endpoint blocks requests to 169.254.169.254 but does not validate after DNS resolution.
 SSRF_VULNERABILITY_LEVEL3_HINT2=AWS metadata endpoints are documented in public gists. Search for AWS metadata endpoints to find the full list of available paths beyond /latest/meta-data/.
 SSRF_VULNERABILITY_LEVEL3_HINT3=Try: https://gist.github.com/jgrimesg/1156291eab8f82b1ce59b8a10ce4dc1c for a comprehensive list of AWS metadata endpoints and paths.
-SSRF_VULNERABILITY_LEVEL3_HINT4=Alternatively, use decimal or octal IP encoding: 2852039166 for 169.254.169.254, or use IPv6 notation to bypass the literal IP check.
+SSRF_VULNERABILITY_LEVEL3_HINT4=Use decimal IP encoding: http://2852039166/latest/meta-data/ to reach the metadata endpoint without using the literal blocked IP address.
 SSRF_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Bypass the IP block using DNS rebinding, IP encoding, or alternative representations to reach AWS metadata.
-SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=http://169.254.169.254/latest/meta-data/ (via DNS rebinding, encoded IP, or AWS-specific paths)
+SSRF_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=http://2852039166/latest/meta-data/ (decimal IP encoding bypasses the literal address block)
 
-SSRF_VULNERABILITY_LEVEL4_CHALLENGE=Access internal metadata services by bypassing the checks in the MetaDataServiceMock class. This mock simulates an internal metadata endpoint.
-SSRF_VULNERABILITY_LEVEL4_HINT1=The endpoint checks URLs against the MetaDataServiceMock class to block known internal metadata endpoints.
+SSRF_VULNERABILITY_LEVEL4_CHALLENGE=Access internal metadata services by bypassing the endpoint's validation of internal URLs. The endpoint simulates an internal metadata service check.
+SSRF_VULNERABILITY_LEVEL4_HINT1=The endpoint blocks requests that match known internal metadata endpoints or patterns.
 SSRF_VULNERABILITY_LEVEL4_HINT2=Use a redirect from an external URL to an internal metadata endpoint. The check is performed on the initial URL, not the redirect target.
-SSRF_VULNERABILITY_LEVEL4_HINT3=Host a redirect that points to the internal metadata service URL. The MetaDataServiceMock only checks the initial URL, so following a redirect bypasses the validation.
-SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Bypass the MetaDataServiceMock check by using an HTTP redirect to an internal metadata endpoint.
+SSRF_VULNERABILITY_LEVEL4_HINT3=Host a redirect that points to the internal metadata service URL. The validation only checks the initial URL, so following a redirect bypasses the check.
+SSRF_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=Bypass the internal URL validation by using an HTTP redirect to reach the metadata endpoint.
 SSRF_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=http://your-server/redirect?target=http://169.254.169.254/latest/meta-data/
 
 # Cryptographic Failures Vulnerability


### PR DESCRIPTION
## Summary

Adds challenge card annotations to three vulnerability modules, following the existing pattern established in BlindSQLInjectionVulnerability and ErrorBasedSQLInjectionVulnerability.

## Changes

### LDAP Injection (#568)
- `LDAPInjectionVulnerability.java`: Added `@ChallengeCard` annotations to levels 1-5 (level 6 is SECURE)
- 25 message keys for challenges, hints, payloads

### File Upload (#559)
- `UnrestrictedFileUpload.java`: Added `@ChallengeCard` annotations to levels 1-9 (level 10 is SECURE)
- 45 message keys for challenges, hints, payloads

### SSRF (#565)
- `SSRFVulnerability.java`: Added `@ChallengeCard` annotations to levels 1-4 (level 5 is SECURE)
- 20 message keys for challenges, hints, payloads

### messages.properties
- Added 116 new message keys across all three modules

## Related Issues
- Closes #568
- Closes #559
- Closes #565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Challenge Mode content for File Upload vulnerabilities across levels 1–9.
  - Added challenge instructions, hints, and payload guidance for LDAP Injection levels 1–5.
  - Added Challenge Mode guidance for SSRF levels 1–4.
  - Introduced localized text supporting the new challenge cards, including descriptions, hints, and payload details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->