### PR TITLE
Small fix to command injection challenge text

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
@@ -336,7 +336,6 @@ public class PathTraversalVulnerability {
                 fileName);
     }
 
-
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_13,
             variant = Variant.SECURE,

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -205,10 +205,10 @@ COMMAND_INJECTION_LEVEL_1_PAYLOAD_VALUE=127.0.0.1; ls
 
 COMMAND_INJECTION_LEVEL_2_CHALLENGE=Read the contents of a sensitive operating system file (for example, /etc/passwd on Linux or C:\\Windows\\System32\\drivers\\etc\\hosts on Windows).
 COMMAND_INJECTION_LEVEL_2_HINT_1=The validator checks the raw URL string for the characters ;, &, and space using a regex pattern.
-COMMAND_INJECTION_LEVEL_2_HINT_2=The pipe character (|) is not included in the blocklist and can also chain commands.
-COMMAND_INJECTION_LEVEL_2_HINT_3=Use the pipe to chain commands without a space, e.g. 127.0.0.1|ls
-COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION=Pipe-based command injection that reads /etc/passwd, bypassing the semicolon/ampersand/space filter.
-COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE=127.0.0.1|cat%20/etc/passwd
+COMMAND_INJECTION_LEVEL_2_HINT_2=The application decodes URL-encoded characters before using the parameter. Try representing a blocked character using its hexadecimal URL-encoded form.
+COMMAND_INJECTION_LEVEL_2_HINT_3=Encode the command separator and spaces in the URL, for example %26 for & and %20 for a space.
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_DESCRIPTION=URL-encoded command injection that bypasses the raw-character filter by encoding the command separator and spaces.
+COMMAND_INJECTION_LEVEL_2_PAYLOAD_VALUE=127.0.0.1%26cat%20/etc/passwd
 
 COMMAND_INJECTION_LEVEL_3_CHALLENGE=Create a file named "challenge.html" on the server.
 COMMAND_INJECTION_LEVEL_3_HINT_1=The filter now checks for %26 and %3B in the URL, but the comparison is case-sensitive.
@@ -217,9 +217,9 @@ COMMAND_INJECTION_LEVEL_3_HINT_3=Try using lowercase %3b to bypass the case-sens
 COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION=Lowercase URL-encoded semicolon bypassing a case-sensitive filter to create a file on the server.
 COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE=127.0.0.1%3btouch%20challenge.html
 
-COMMAND_INJECTION_LEVEL_4_CHALLENGE=Steal secrets from the web server process environment (for example, database passwords or API keys) by reading /proc/1/environ.
+COMMAND_INJECTION_LEVEL_4_CHALLENGE=find out environment variables for the web server process environment
 COMMAND_INJECTION_LEVEL_4_HINT_1=The filter now blocks %26 and %3B case-insensitively, but the URL-encoded pipe %7C is still not checked.
-COMMAND_INJECTION_LEVEL_4_HINT_2=The Java process stores secrets like database passwords and API keys in its environment. The /proc filesystem exposes the main process's environment at /proc/1/environ.
+COMMAND_INJECTION_LEVEL_4_HINT_2=Applications pass sensitive or other environment variables to the process. The process stores secrets like database passwords and API keys in its environment. The /proc filesystem exposes the main process's environment at /proc/1/environ.
 COMMAND_INJECTION_LEVEL_4_HINT_3=Use the URL-encoded pipe %7C to chain a command that reads the main process environment, e.g. 127.0.0.1%7Ccat%20/proc/1/environ
 COMMAND_INJECTION_LEVEL_4_PAYLOAD_DESCRIPTION=URL-encoded pipe bypassing the case-insensitive filter to read the main process environment and steal secrets.
 COMMAND_INJECTION_LEVEL_4_PAYLOAD_VALUE=127.0.0.1%7Ccat%20/proc/1/environ

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -217,7 +217,7 @@ COMMAND_INJECTION_LEVEL_3_HINT_3=Try using lowercase %3b to bypass the case-sens
 COMMAND_INJECTION_LEVEL_3_PAYLOAD_DESCRIPTION=Lowercase URL-encoded semicolon bypassing a case-sensitive filter to create a file on the server.
 COMMAND_INJECTION_LEVEL_3_PAYLOAD_VALUE=127.0.0.1%3btouch%20challenge.html
 
-COMMAND_INJECTION_LEVEL_4_CHALLENGE=find out environment variables for the web server process environment
+COMMAND_INJECTION_LEVEL_4_CHALLENGE=Discover the environment variables of the web server process
 COMMAND_INJECTION_LEVEL_4_HINT_1=The filter now blocks %26 and %3B case-insensitively, but the URL-encoded pipe %7C is still not checked.
 COMMAND_INJECTION_LEVEL_4_HINT_2=Applications pass sensitive or other environment variables to the process. The process stores secrets like database passwords and API keys in its environment. The /proc filesystem exposes the main process's environment at /proc/1/environ.
 COMMAND_INJECTION_LEVEL_4_HINT_3=Use the URL-encoded pipe %7C to chain a command that reads the main process environment, e.g. 127.0.0.1%7Ccat%20/proc/1/environ


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated command-injection challenge guidance for Level 2 to demonstrate URL-encoded ampersands and spaces.
  * Refined Level 4 instructions to explain how to identify web-server environment variables and access `/proc/1/environ`.
  * Improved challenge wording to provide clearer, more accurate learning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->