### PR TITLE
Fix mojibake in Swedish and Spanish i18n bundles (#722)

### DIFF
--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -229,7 +229,7 @@ COOKIE_BASED_FOR_JWK_HEADER_BASED_JWT_VULNERABILITY=Validador de token JWT basad
 COOKIE_BASED_EMPTY_TOKEN_JWT_VULNERABILITY=Token JWT basado en cookies, vulnerable por el ataque de token vac√≠o.
 
 # JWT Injection Header
-HEADER_INJECTION_VULNERABILITY=Prueba cÛmo un encabezado JWT puede ser manipulado para alterar la verificaciÛn de la firma.
+HEADER_INJECTION_VULNERABILITY=Prueba c√≥mo un encabezado JWT puede ser manipulado para alterar la verificaci√≥n de la firma.
 
 
 # SQL Injection Vulnerability

--- a/src/main/resources/i18n/messages_sv.properties
+++ b/src/main/resources/i18n/messages_sv.properties
@@ -1,134 +1,134 @@
 # Exception Code Labels
-INVALID_END_POINT=Fˆljande {0} endpoint ‰r inte tillg‰nglig. Kontrollera namnet fˆr endpoint frÂn allEndPoint-anropet och prova igen.
-INVALID_LEVEL=Fˆljande {0} nivÂ ‰r inte ett giltigt nivÂv‰rde. Kontrollera vilken nivÂ och endpoint som stˆds frÂn allEndPoint-anropet och fˆrsˆk igen.
-UNAVAILABLE_LEVEL=Fˆljande {0} nivÂ i {1} endpoint ‰r inte tillg‰nglig. Kontrollera vilken nivÂ och endpoint som stˆds frÂn allEndPoint-anropet och fˆrsˆk igen.
-INVALID_ACCESS=Fˆljande {0} metod ‰r inte tillg‰nglig. Orsakerna kan vara felaktig synlighet eller felaktig metoddefinition. Kontrollera loggarna.
-INVALID_AGRUMENTS=Fˆljande {0} metod tilldelas inte r‰tt upps‰ttning argument. Kontrollera loggarna.
+INVALID_END_POINT=F√∂ljande {0} endpoint √§r inte tillg√§nglig. Kontrollera namnet f√∂r endpoint fr√•n allEndPoint-anropet och prova igen.
+INVALID_LEVEL=F√∂ljande {0} niv√• √§r inte ett giltigt niv√•v√§rde. Kontrollera vilken niv√• och endpoint som st√∂ds fr√•n allEndPoint-anropet och f√∂rs√∂k igen.
+UNAVAILABLE_LEVEL=F√∂ljande {0} niv√• i {1} endpoint √§r inte tillg√§nglig. Kontrollera vilken niv√• och endpoint som st√∂ds fr√•n allEndPoint-anropet och f√∂rs√∂k igen.
+INVALID_ACCESS=F√∂ljande {0} metod √§r inte tillg√§nglig. Orsakerna kan vara felaktig synlighet eller felaktig metoddefinition. Kontrollera loggarna.
+INVALID_AGRUMENTS=F√∂ljande {0} metod tilldelas inte r√§tt upps√§ttning argument. Kontrollera loggarna.
 SYSTEM_ERROR=Ett systemfel uppstod. Kontrollera loggarna.
 
 # XSS based Injections
-XSS_VULNERABILITY=Cross-Site Scripting (XSS) attacker ‰r en typ av injektion, i vilken skadliga skript ‰r injicerade i \
-annars ofarliga och pÂlitliga hemsidor. XSS attacker uppstÂr n‰r en angripare anv‰nder en webbapplikation fˆr att skicka skadlig kod, \
- vanligtvis i form av skript frÂn webbl‰sarsidan, till en annan slutanv‰ndare. Brister som tillÂter denna typ av attacker att lyckas \
-  ‰r ganska utbredda och uppstÂr ˆverallt d‰r en webbapplikation anv‰nder indata frÂn en anv‰ndare i utdatan \
-  den genereras utan validering eller att kodas. <br/> <br/> En angripare kan anv‰nda XSS fˆr att skicka skadliga skript till en intet ont anande anv‰ndare. \
-  Slutanv‰ndaren\u2019s webbl‰sare har inget s‰tt att veta att skriptet inte ‰r pÂlitligt, och kommer kˆra skriptet. \
-   PÂ grund utav att det trot att skriptet kommer frÂn en pÂlitlig k‰lla, kan det skadliga skriptet komma Ât alla kakor, session tokens, \
-    eller annan k‰nslig information som lagras av webbl‰saren och anv‰nds pÂ webbplatsen. Dessa skript kan till och med skriva om innehÂllet \
-     pÂ HTML sidan. <br/><br/> Fˆr mer information om XSS: <ol><li><a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Owasp XSS</a> \
-     <li><a href="https://www.google.com/about/appsecurity/learning/xss/" target="_blank">Google Applikation S‰kerhet</a></ol>
+XSS_VULNERABILITY=Cross-Site Scripting (XSS) attacker √§r en typ av injektion, i vilken skadliga skript √§r injicerade i \
+annars ofarliga och p√•litliga hemsidor. XSS attacker uppst√•r n√§r en angripare anv√§nder en webbapplikation f√∂r att skicka skadlig kod, \
+ vanligtvis i form av skript fr√•n webbl√§sarsidan, till en annan slutanv√§ndare. Brister som till√•ter denna typ av attacker att lyckas \
+  √§r ganska utbredda och uppst√•r √∂verallt d√§r en webbapplikation anv√§nder indata fr√•n en anv√§ndare i utdatan \
+  den genereras utan validering eller att kodas. <br/> <br/> En angripare kan anv√§nda XSS f√∂r att skicka skadliga skript till en intet ont anande anv√§ndare. \
+  Slutanv√§ndaren\u2019s webbl√§sare har inget s√§tt att veta att skriptet inte √§r p√•litligt, och kommer k√∂ra skriptet. \
+   P√• grund utav att det trot att skriptet kommer fr√•n en p√•litlig k√§lla, kan det skadliga skriptet komma √•t alla kakor, session tokens, \
+    eller annan k√§nslig information som lagras av webbl√§saren och anv√§nds p√• webbplatsen. Dessa skript kan till och med skriva om inneh√•llet \
+     p√• HTML sidan. <br/><br/> F√∂r mer information om XSS: <ol><li><a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Owasp XSS</a> \
+     <li><a href="https://www.google.com/about/appsecurity/learning/xss/" target="_blank">Google Applikation S√§kerhet</a></ol>
 
 #### AttackVector description
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG="comment" query-parameterv‰rdet l‰ggs till direkt i "div" taggen.
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG="comment" query-parameterv‰rdet l‰ggs till direkt i "div" taggen efter att "<img" och "<input" taggarna ersatts.
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_CASE_INSENSITIVE="comment" query-parameterv‰rdet l‰ggs till direkt i "div" taggen efter att skiftl‰gesok‰nsliga "<img" och "<input" taggar har ersatts.
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_IF_TAGS_ARE_PRESENT_BEFORE_NULL_BYTE="comment" query-parameterv‰rdet l‰ggs till direkt i "div" taggen efter att "<img" och "<input" taggar ersatts om dessa finns fˆre Null Byte.
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_CASE_INSENSITIVEIF_TAGS_ARE_PRESENT_BEFORE_NULL_BYTE="comment" query parameterv‰rdet l‰ggs till direkt i "div" taggen efter att skiftl‰gesok‰nsliga "<img" och "<input" taggar ersatts om dessa finns fˆre Null Byte.
-PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_AFTER_HTML_ESCAPING_POST_CONTENT_BEFORE_NULL_BYTE="comment" query-parameterv‰rdet l‰ggs till direkt i "div" taggen efter genomfˆrd HTML escape frÂn innehÂllet fˆre Null Byte medan den andra delen l‰mnas som den ‰r.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG="comment" query-parameterv√§rdet l√§ggs till direkt i "div" taggen.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG="comment" query-parameterv√§rdet l√§ggs till direkt i "div" taggen efter att "<img" och "<input" taggarna ersatts.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_CASE_INSENSITIVE="comment" query-parameterv√§rdet l√§ggs till direkt i "div" taggen efter att skiftl√§gesok√§nsliga "<img" och "<input" taggar har ersatts.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_IF_TAGS_ARE_PRESENT_BEFORE_NULL_BYTE="comment" query-parameterv√§rdet l√§ggs till direkt i "div" taggen efter att "<img" och "<input" taggar ersatts om dessa finns f√∂re Null Byte.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_REPLACING_IMG_AND_INPUT_TAG_CASE_INSENSITIVEIF_TAGS_ARE_PRESENT_BEFORE_NULL_BYTE="comment" query parameterv√§rdet l√§ggs till direkt i "div" taggen efter att skiftl√§gesok√§nsliga "<img" och "<input" taggar ersatts om dessa finns f√∂re Null Byte.
+PERSISTENT_XSS_HTML_TAG_URL_PARAM_DIRECTLY_INJECTED_IN_DIV_TAG_AFTER_HTML_ESCAPING_POST_CONTENT_BEFORE_NULL_BYTE="comment" query-parameterv√§rdet l√§ggs till direkt i "div" taggen efter genomf√∂rd HTML escape fr√•n inneh√•llet f√∂re Null Byte medan den andra delen l√§mnas som den √§r.
 
      
 ## Image Tag Injections
-XSS_IMAGE_TAG_INJECTION=$XSS_VULNERABILITY <br> Denna sÂrbarhet ‰r relaterad till XSS-attacker via Image-taggen. Om ..
+XSS_IMAGE_TAG_INJECTION=$XSS_VULNERABILITY <br> Denna s√•rbarhet √§r relaterad till XSS-attacker via Image-taggen. Om ..
 #### Attack Vector Description
-XSS_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG=URL-parametrar l‰ggs till direkt i src-attributet fˆr Image-taggen.\
+XSS_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG=URL-parametrar l√§ggs till direkt i src-attributet f√∂r Image-taggen.\
 
-XSS_QUOTES_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=Citaten l‰ggs till URL-parametrarna och l‰ggs sen direkt till src-attributet fˆr Image-taggen
-XSS_HTML_ESCAPE_ON_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG=HTML escaping gˆrs pÂ URL-parametrarna och l‰ggs sen direkt till src-attributet fˆr Image-taggen
-XSS_HTML_ESCAPE_ON_DIRECT_INPUT_AND_REMOVAL_OF_VALUES_WITH_PARENTHESIS_SRC_ATTRIBUTE_IMG_TAG=HTML escaping tillsammans med borttagande av v‰rden innehÂllandes parantes gˆrs pÂ URL-parametrar och l‰ggs sen direkt till src-attributet av Image-taggen.
-XSS_QUOTES_AND_WITH_HTML_ESCAPE_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=HTML escaping gˆrs pÂ URL-parametrar och infogas sen i citattecken in i src-attributet fˆr Image-taggen.
-XSS_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG_BUT_NULL_BYTE_VULNERABLE=URL-parametrar ‰r HTML escaped, validerade mot en whitelist fˆr filnamn och infogade i src-attributet fˆr Image-taggen, validator fˆr validering av filnamn ‰r dock sÂrbar fˆr Null Byte injektion.
-XSS_QUOTES_AND_WITH_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=URL-parametrar ‰r HTML escaped, validerade mot en whitelist fˆr filnamn och infogade i citattecken in i src-attributet fˆr Image-taggen.
+XSS_QUOTES_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=Citaten l√§ggs till URL-parametrarna och l√§ggs sen direkt till src-attributet f√∂r Image-taggen
+XSS_HTML_ESCAPE_ON_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG=HTML escaping g√∂rs p√• URL-parametrarna och l√§ggs sen direkt till src-attributet f√∂r Image-taggen
+XSS_HTML_ESCAPE_ON_DIRECT_INPUT_AND_REMOVAL_OF_VALUES_WITH_PARENTHESIS_SRC_ATTRIBUTE_IMG_TAG=HTML escaping tillsammans med borttagande av v√§rden inneh√•llandes parantes g√∂rs p√• URL-parametrar och l√§ggs sen direkt till src-attributet av Image-taggen.
+XSS_QUOTES_AND_WITH_HTML_ESCAPE_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=HTML escaping g√∂rs p√• URL-parametrar och infogas sen i citattecken in i src-attributet f√∂r Image-taggen.
+XSS_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG_BUT_NULL_BYTE_VULNERABLE=URL-parametrar √§r HTML escaped, validerade mot en whitelist f√∂r filnamn och infogade i src-attributet f√∂r Image-taggen, validator f√∂r validering av filnamn √§r dock s√•rbar f√∂r Null Byte injektion.
+XSS_QUOTES_AND_WITH_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG=URL-parametrar √§r HTML escaped, validerade mot en whitelist f√∂r filnamn och infogade i citattecken in i src-attributet f√∂r Image-taggen.
 
 ## Html Tag Injection
-XSS_HTML_TAG_INJECTION=XSS-attack baserad pÂ HTML-taggar.
+XSS_HTML_TAG_INJECTION=XSS-attack baserad p√• HTML-taggar.
 XSS_DIRECT_INPUT_DIV_TAG=HTML-taggen injiceras direkt in i div-taggen.
 
 ### Attack vectors
-XSS_DIRECT_INPUT_DIV_TAG=URL-parametrar l‰ggs till direkt i div taggen.
-XSS_DIRECT_INPUT_DIV_TAG_AFTER_REMOVING_VALUES_CONTAINING_ANCHOR_SCRIPT_AND_IMG_TAG=URL-parametrar l‰ggs till direkt i div-taggen om de inte har Script/Image och Anchor-tagg.
-XSS_DIRECT_INPUT_DIV_TAG_AFTER_REMOVING_VALUES_CONTAINING_ANCHOR_SCRIPT_IMG_TAG_AND_ALERT_KEYWORD=URL-parametrar l‰ggs till direkt i div-taggen om de inte har Script/Image/Anchor tagg och Javascript och Alert nyckelord.
+XSS_DIRECT_INPUT_DIV_TAG=URL-parametrar l√§ggs till direkt i div taggen.
+XSS_DIRECT_INPUT_DIV_TAG_AFTER_REMOVING_VALUES_CONTAINING_ANCHOR_SCRIPT_AND_IMG_TAG=URL-parametrar l√§ggs till direkt i div-taggen om de inte har Script/Image och Anchor-tagg.
+XSS_DIRECT_INPUT_DIV_TAG_AFTER_REMOVING_VALUES_CONTAINING_ANCHOR_SCRIPT_IMG_TAG_AND_ALERT_KEYWORD=URL-parametrar l√§ggs till direkt i div-taggen om de inte har Script/Image/Anchor tagg och Javascript och Alert nyckelord.
 
 # URL Redirection
 ## Location Header Injection
-OPEN_REDIRECTION_VULNERABILITY_3XX_BASED=÷ppen omdirigeringssÂrbarhet uppstÂr n‰r en applikation innehÂller anv‰ndarkontrollerbar \
-data till mÂlet fˆr en omdirigering pÂ ett os‰kert s‰tt.<br/> En angripare kan konstruera en URL innifrÂn applikationen som \
-orsakar en omdirigering till en godtycklig extern dom‰n. Detta beteende kan utnyttjas fˆr att underl‰tta phishing attacker mot anv‰ndare av applikationen.<br/>\
-Mˆjligheten att anv‰nda en autentisk applikations-URL, rikta in sig pÂ r‰tt dom‰n och med ett giltigt SSL certifikat (om SSL anv‰nds), ger trov‰rdighet till\
-phishing attacken eftersom mÂnga anv‰ndare, ‰ven om de verifierar dessa funktioner, inte kommer att m‰rka den efterfˆljande omdirigeringen till en annan dom‰n. \
+OPEN_REDIRECTION_VULNERABILITY_3XX_BASED=√ñppen omdirigeringss√•rbarhet uppst√•r n√§r en applikation inneh√•ller anv√§ndarkontrollerbar \
+data till m√•let f√∂r en omdirigering p√• ett os√§kert s√§tt.<br/> En angripare kan konstruera en URL innifr√•n applikationen som \
+orsakar en omdirigering till en godtycklig extern dom√§n. Detta beteende kan utnyttjas f√∂r att underl√§tta phishing attacker mot anv√§ndare av applikationen.<br/>\
+M√∂jligheten att anv√§nda en autentisk applikations-URL, rikta in sig p√• r√§tt dom√§n och med ett giltigt SSL certifikat (om SSL anv√§nds), ger trov√§rdighet till\
+phishing attacken eftersom m√•nga anv√§ndare, √§ven om de verifierar dessa funktioner, inte kommer att m√§rka den efterf√∂ljande omdirigeringen till en annan dom√§n. \
 <br/><br/> <a href="https://www.w3.org/Protocols/rfc2616/rfc2616.html">RFC 2616 - "Hypertext Transfer Protocol - HTTP/1.1" target="_blank"</a> definierar en rad \
- olika 3xx status koder som kommer fÂ en webbl‰sare att omdirigeras till en specificerad plats och dess implementering ‰r baserad pÂ 3xx status koder <br/><br/>\
- Viktiga l‰nkar:<ol>\
+ olika 3xx status koder som kommer f√• en webbl√§sare att omdirigeras till en specificerad plats och dess implementering √§r baserad p√• 3xx status koder <br/><br/>\
+ Viktiga l√§nkar:<ol>\
  <li><a href="http://projects.webappsec.org/w/page/13246981/URL%20Redirector%20Abuse" target="_blank">WASC-38</a><br/></li>\
  <li><a href="https://cwe.mitre.org/data/definitions/601.html" target="_blank">CWE-601</a><br/></li>\
- <li><a href="https://portswigger.net/kb/issues/00500100_open-redirection-reflected" target="_blank">Port Swigger's sÂrbarhetsdokumentation</a><br/></li>\
- <li><a href="https://en.wikipedia.org/wiki/URL_redirection" target="_blank">Wiki l‰nk for som beskriver syftet med URL omdirigering</a></li>\
- <li><a href="https://github.com/payloadbox/open-redirect-payload-list" target="_blank">÷ppen lista fˆr omdirigering payloads</a></li>\
- <li><a href="https://appsec-labs.com/portal/case-study-open-redirect/" target="_blank">L‰gg till dom‰n som prefix - fallstudie</a></li>\
+ <li><a href="https://portswigger.net/kb/issues/00500100_open-redirection-reflected" target="_blank">Port Swigger's s√•rbarhetsdokumentation</a><br/></li>\
+ <li><a href="https://en.wikipedia.org/wiki/URL_redirection" target="_blank">Wiki l√§nk for som beskriver syftet med URL omdirigering</a></li>\
+ <li><a href="https://github.com/payloadbox/open-redirect-payload-list" target="_blank">√ñppen lista f√∂r omdirigering payloads</a></li>\
+ <li><a href="https://appsec-labs.com/portal/case-study-open-redirect/" target="_blank">L√§gg till dom√§n som prefix - fallstudie</a></li>\
  </ol>\
- NÂgra myter: <a href="https://security.stackexchange.com/questions/59517/are-url-shorteners-vulnerable-due-to-open-redirects" target="_blank">ƒr URL fˆrkortare \u201CsÂrbara\u201D pÂ grund utav ˆppna omdirigeringar?</a><br/>
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern.
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern om den inte startar med "http", "www" och "https" eller om dom‰nen ‰r densamma som applikationens.
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_//_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern om den inte startar med "http", "www", "https" och "//" eller om dom‰nen ‰r densamma som applikationens.
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_WWW_HTTPS_//_NULL_BYTE_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern om den inte startar med "http", "www", "https", "//" och Null Byte eller om dom‰nen ‰r densamma som applikationens.
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_//_WWW_%_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern om den inte startar med "http", "www", "https", "//" och tecknet mindre ‰n ascii v‰rdet 33 eller om dom‰nen ‰r densamma som applikationens.
-OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADDED_TO_LOCATION_HEADER_BY_ADDING_DOMAIN_AS_PREFIX="returnTo" query-parameterns v‰rde l‰ggs till direkt i "Location" headern om den har prefixet med applikationens dom‰nnamn.
+ N√•gra myter: <a href="https://security.stackexchange.com/questions/59517/are-url-shorteners-vulnerable-due-to-open-redirects" target="_blank">√Ñr URL f√∂rkortare \u201Cs√•rbara\u201D p√• grund utav √∂ppna omdirigeringar?</a><br/>
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern.
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern om den inte startar med "http", "www" och "https" eller om dom√§nen √§r densamma som applikationens.
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_WWW_//_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern om den inte startar med "http", "www", "https" och "//" eller om dom√§nen √§r densamma som applikationens.
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_WWW_HTTPS_//_NULL_BYTE_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern om den inte startar med "http", "www", "https", "//" och Null Byte eller om dom√§nen √§r densamma som applikationens.
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADD_TO_LOCATION_HEADER_IF_NOT_HTTP_HTTPS_//_WWW_%_OR_DOMAIN_IS_SAME="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern om den inte startar med "http", "www", "https", "//" och tecknet mindre √§n ascii v√§rdet 33 eller om dom√§nen √§r densamma som applikationens.
+OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADDED_TO_LOCATION_HEADER_BY_ADDING_DOMAIN_AS_PREFIX="returnTo" query-parameterns v√§rde l√§ggs till direkt i "Location" headern om den har prefixet med applikationens dom√§nnamn.
 
 
 ## Meta Tag based URL Redirection
-OPEN_REDIRECTION_VULNERABILITY_META_TAG_BASED=÷ppen omdirigeringssÂrbarhet uppstÂr n‰r en applikation innehÂller anv‰ndarkontrollerbar \
-data till mÂlet fˆr en omdirigering pÂ ett os‰kert s‰tt.<br/> En angripare kan konstruera en URL innifrÂn applikationen som \
-orsakar en omdirigering till en godtycklig extern dom‰n. Detta beteende kan utnyttjas fˆr att underl‰tta phishing attacker mot anv‰ndare av applikationen.<br/>\
-Mˆjligheten att anv‰nda en autentisk applikations-URL, rikta in sig pÂ r‰tt dom‰n och med ett giltigt SSL certifikat (om SSL anv‰nds), ger trov‰rdighet till\
-phishing attacken eftersom mÂnga anv‰ndare, ‰ven om de verifierar dessa funktioner, inte kommer att m‰rka den efterfˆljande omdirigeringen till en annan dom‰n.  \
-<br/><br/> Ett HTML meta-element som specificerar tiden i sekunder fˆre webbl‰saren ska uppdatera sidan. \
-Genom att tillhandahÂlla en alternativ URI kan elementet anv‰ndas som en tidsinst‰lld URL omdirigering.\
+OPEN_REDIRECTION_VULNERABILITY_META_TAG_BASED=√ñppen omdirigeringss√•rbarhet uppst√•r n√§r en applikation inneh√•ller anv√§ndarkontrollerbar \
+data till m√•let f√∂r en omdirigering p√• ett os√§kert s√§tt.<br/> En angripare kan konstruera en URL innifr√•n applikationen som \
+orsakar en omdirigering till en godtycklig extern dom√§n. Detta beteende kan utnyttjas f√∂r att underl√§tta phishing attacker mot anv√§ndare av applikationen.<br/>\
+M√∂jligheten att anv√§nda en autentisk applikations-URL, rikta in sig p√• r√§tt dom√§n och med ett giltigt SSL certifikat (om SSL anv√§nds), ger trov√§rdighet till\
+phishing attacken eftersom m√•nga anv√§ndare, √§ven om de verifierar dessa funktioner, inte kommer att m√§rka den efterf√∂ljande omdirigeringen till en annan dom√§n.  \
+<br/><br/> Ett HTML meta-element som specificerar tiden i sekunder f√∂re webbl√§saren ska uppdatera sidan. \
+Genom att tillhandah√•lla en alternativ URI kan elementet anv√§ndas som en tidsinst√§lld URL omdirigering.\
  \
-Till exempel, i fˆljande exempel kommer webbl‰saren omdirigeras till example.com efter 5 sekunder: <br/> \
+Till exempel, i f√∂ljande exempel kommer webbl√§saren omdirigeras till example.com efter 5 sekunder: <br/> \
           &lt;meta http-equiv=&quot;refresh&quot; content=&quot;5;url=http://example.com&quot;&gt; <br/><br/>\
- Viktiga l‰nkar:<ol>\
+ Viktiga l√§nkar:<ol>\
  <li><a href="http://projects.webappsec.org/w/page/13246981/URL%20Redirector%20Abuse" target="_blank">WASC-38</a><br/></li>\
  <li><a href="https://cwe.mitre.org/data/definitions/601.html" target="_blank">CWE-601</a><br/></li>\
- <li><a href="https://portswigger.net/kb/issues/00500100_open-redirection-reflected" target="_blank">Port Swigger's sÂrbarhetsdokumentation</a><br/></li>\
- <li><a href="https://en.wikipedia.org/wiki/URL_redirection" target="_blank">Wiki l‰nk for som beskriver syftet med URL omdirigering</a></li>\
- <li><a href="https://github.com/payloadbox/open-redirect-payload-list" target="_blank">÷ppen lista fˆr omdirigering payloads</a></li>\
- <li><a href="https://appsec-labs.com/portal/case-study-open-redirect/" target="_blank">L‰gg till dom‰n som prefix - fallstudie</a></li>\
+ <li><a href="https://portswigger.net/kb/issues/00500100_open-redirection-reflected" target="_blank">Port Swigger's s√•rbarhetsdokumentation</a><br/></li>\
+ <li><a href="https://en.wikipedia.org/wiki/URL_redirection" target="_blank">Wiki l√§nk for som beskriver syftet med URL omdirigering</a></li>\
+ <li><a href="https://github.com/payloadbox/open-redirect-payload-list" target="_blank">√ñppen lista f√∂r omdirigering payloads</a></li>\
+ <li><a href="https://appsec-labs.com/portal/case-study-open-redirect/" target="_blank">L√§gg till dom√§n som prefix - fallstudie</a></li>\
  </ol>\
- NÂgra myter: <a href="https://security.stackexchange.com/questions/59517/are-url-shorteners-vulnerable-due-to-open-redirects" target="_blank">ƒr URL fˆrkortare \u201CsÂrbara\u201D pÂ grund utav ˆppna omdirigeringar?</a><br/>
-URL_REDIRECTION_META_TAG_BASED_INJECTION=URL-omdirigering baserad pÂ metatagg.
-URL_REDIRECTION_URL_PARAMETER_INJECTION_INTO_META_TAG=URL-parametern l‰ggs till direkt i metataggen.
+ N√•gra myter: <a href="https://security.stackexchange.com/questions/59517/are-url-shorteners-vulnerable-due-to-open-redirects" target="_blank">√Ñr URL f√∂rkortare \u201Cs√•rbara\u201D p√• grund utav √∂ppna omdirigeringar?</a><br/>
+URL_REDIRECTION_META_TAG_BASED_INJECTION=URL-omdirigering baserad p√• metatagg.
+URL_REDIRECTION_URL_PARAMETER_INJECTION_INTO_META_TAG=URL-parametern l√§ggs till direkt i metataggen.
 
 
 
 # UNRESTRICTED_FILE_UPLOAD_VULNERABILITY
-UNRESTRICTED_FILE_UPLOAD_VULNERABILITY=Uppladdade filer utgˆr en betydande risk fˆr applikationer. Det fˆrsta steget i mÂnga attacker ‰r att fÂ kod till systemet som ska attackeras. Sen behˆver attacken bara hitta ett s‰tt att exekvera koden.\
-<br/>Konsekvenserna av obegr‰nsad filuppladdning kan variera, inklusive fullst‰ndig systemkapning, ett ˆverbelastat filsystem eller databas, vidarebefodra attacker till back-end system, attacker pÂ klientsidan, eller helt enkelt fˆr‰ndring av utseendet. Det beror helt pÂ vad applikationen gˆr med uppladdade filer och speciellt var de lagras.\
+UNRESTRICTED_FILE_UPLOAD_VULNERABILITY=Uppladdade filer utg√∂r en betydande risk f√∂r applikationer. Det f√∂rsta steget i m√•nga attacker √§r att f√• kod till systemet som ska attackeras. Sen beh√∂ver attacken bara hitta ett s√§tt att exekvera koden.\
+<br/>Konsekvenserna av obegr√§nsad filuppladdning kan variera, inklusive fullst√§ndig systemkapning, ett √∂verbelastat filsystem eller databas, vidarebefodra attacker till back-end system, attacker p√• klientsidan, eller helt enkelt f√∂r√§ndring av utseendet. Det beror helt p√• vad applikationen g√∂r med uppladdade filer och speciellt var de lagras.\
 <br/><br/>\
-Viktiga l‰nkar:<br/>\
-<ol> <li> <a href="https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload" target="_blank">Owasp Wiki L‰nk</a>  \
- <li> <a href="https://www.youtube.com/watch?v=CmF9sEyKZNo" target="_blank">Ebrahim Hegazy prata om obegr‰nsad filuppladdning</a> \
- <li> <a href="https://www.sans.org/blog/8-basic-rules-to-implement-secure-file-uploads/" target="_blank">Sans regler fˆr att implementera s‰ker filuppladdning</a> \
+Viktiga l√§nkar:<br/>\
+<ol> <li> <a href="https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload" target="_blank">Owasp Wiki L√§nk</a>  \
+ <li> <a href="https://www.youtube.com/watch?v=CmF9sEyKZNo" target="_blank">Ebrahim Hegazy prata om obegr√§nsad filuppladdning</a> \
+ <li> <a href="https://www.sans.org/blog/8-basic-rules-to-implement-secure-file-uploads/" target="_blank">Sans regler f√∂r att implementera s√§ker filuppladdning</a> \
 </ol>
 
 #### Attack Vector Description
 UNRESTRICTED_FILE_UPLOAD_NO_VALIDATION_FILE_NAME=Det finns ingen validering av den uppladdade filens namn.
-UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_FILE_EXTENSION=Alla filtill‰gg ‰r tillÂtna utom .html till‰gg.
-UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION=Alla filtill‰gg ‰r tillÂtna utom .html och .htm till‰gg.
-UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION_CASE_INSENSITIVE=Alla filtill‰gg ‰r tillÂtna utom skiftl‰gesok‰nsliga .html och .htm till‰gg.
-UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIVE=Endast filnamn ‰r tillÂtet om det innehÂller skiftl‰gesok‰nsligt .jpeg eller .png.
-UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE=Endast filnamn ‰r tillÂtet om det slutar med skiftl‰gesok‰nsligt .jpeg eller .png och som endast beaktas fˆre Nyll Byte.
-UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE=Endast filnamn ‰r tillÂtet om det slutar med skiftl‰gesok‰nsligt .jpeg eller .png.
+UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_FILE_EXTENSION=Alla filtill√§gg √§r till√•tna utom .html till√§gg.
+UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION=Alla filtill√§gg √§r till√•tna utom .html och .htm till√§gg.
+UNRESTRICTED_FILE_UPLOAD_IF_NOT_HTML_NOT_HTM_FILE_EXTENSION_CASE_INSENSITIVE=Alla filtill√§gg √§r till√•tna utom skiftl√§gesok√§nsliga .html och .htm till√§gg.
+UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIVE=Endast filnamn √§r till√•tet om det inneh√•ller skiftl√§gesok√§nsligt .jpeg eller .png.
+UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE=Endast filnamn √§r till√•tet om det slutar med skiftl√§gesok√§nsligt .jpeg eller .png och som endast beaktas f√∂re Nyll Byte.
+UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE=Endast filnamn √§r till√•tet om det slutar med skiftl√§gesok√§nsligt .jpeg eller .png.
 
 
 # XXE Vulnerability
-XXE_VULNERABILITY=En XML External Entity attack ‰r en typ av attack mot en \
-applikation som analyserar XML input. Denna attack uppstÂr n‰r XML input innehÂller \
+XXE_VULNERABILITY=En XML External Entity attack √§r en typ av attack mot en \
+applikation som analyserar XML input. Denna attack uppst√•r n√§r XML input inneh√•ller \
 en referens till en extern enhet bearbetas av en svagt konfigurerad XML parser.\
-Denna attack kan leda till avslˆjande av konfidentiell data, denial of service, \
-fˆrfalskning av beg‰ran pÂ serversidan, port skanning frÂn perspektivet av maskinen d‰r \
-parsern ‰r lokaliserad, och annan systempÂverkan.\
+Denna attack kan leda till avsl√∂jande av konfidentiell data, denial of service, \
+f√∂rfalskning av beg√§ran p√• serversidan, port skanning fr√•n perspektivet av maskinen d√§r \
+parsern √§r lokaliserad, och annan systemp√•verkan.\
 <br/><br/>\
-Viktiga L‰nkar:<br/>\
-<ol> <li> <a href="https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing" target="_blank">Owasp Wiki L‰nk</a>  \
+Viktiga L√§nkar:<br/>\
+<ol> <li> <a href="https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing" target="_blank">Owasp Wiki L√§nk</a>  \
  <li> <a href="https://www.youtube.com/watch?v=DREgLWZqMWg" target="_blank">HackHappys video tutorial</a> \
  <li> <a href="https://medium.com/@onehackman/exploiting-xml-external-entity-xxe-injections-b0e3eac388f9" target="_blank">Medium artikel av OneHackMan</a>\
  <li> <a href="https://portswigger.net/web-security/xxe" target="_blank">Portswigger XXE dokumentation</a> \
@@ -136,49 +136,49 @@ Viktiga L‰nkar:<br/>\
 </ol>
 #### Attack Vector Description
 XXE_NO_VALIDATION=Det finns ingen validering av XML som skickas i request-bodyn.
-XXE_DISABLE_GENERAL_ENTITY=Parsern ‰r inaktiverad frÂn att behandla allm‰nna externa enheter.
-XXE_DISABLE_GENERAL_AND_PARAMETER_ENTITY=Parsern ‰r inaktiverad frÂn att behandla allm‰nna enheter och parameterenheter.
+XXE_DISABLE_GENERAL_ENTITY=Parsern √§r inaktiverad fr√•n att behandla allm√§nna externa enheter.
+XXE_DISABLE_GENERAL_AND_PARAMETER_ENTITY=Parsern √§r inaktiverad fr√•n att behandla allm√§nna enheter och parameterenheter.
 
 # Path Traversal Attack
-PATH_TRAVERSAL_VULNERABILITY=En katalogˆvergÂng (eller sˆkv‰gsˆvergÂng) bestÂr i att utnyttja otillr‰cklig s‰kerhetsvalidering/sanering av input filnamn som anv‰ndaren bistÂtt,\
-sÂ att tecken som representerar "gÂ till ˆverordnad katalog" gÂr genom filens APIer.\
+PATH_TRAVERSAL_VULNERABILITY=En katalog√∂verg√•ng (eller s√∂kv√§gs√∂verg√•ng) best√•r i att utnyttja otillr√§cklig s√§kerhetsvalidering/sanering av input filnamn som anv√§ndaren bist√•tt,\
+s√• att tecken som representerar "g√• till √∂verordnad katalog" g√•r genom filens APIer.\
 <br/><br/>\
-MÂlet med denna attack ‰r att anv‰nda en pÂverkad applikation fˆr att fÂ obehˆrig Âtkomst till filsystemet. <br/><br/> \
-Viktiga L‰nkar:<br/>\
-<ol> <li> <a href="https://en.wikipedia.org/wiki/Directory_traversal_attack" target="_blank">Wiki L‰nk</a>  \
- <li> <a href="https://owasp.org/www-community/attacks/Path_Traversal" target="_blank">Owasp Wiki L‰nk</a> \
+M√•let med denna attack √§r att anv√§nda en p√•verkad applikation f√∂r att f√• obeh√∂rig √•tkomst till filsystemet. <br/><br/> \
+Viktiga L√§nkar:<br/>\
+<ol> <li> <a href="https://en.wikipedia.org/wiki/Directory_traversal_attack" target="_blank">Wiki L√§nk</a>  \
+ <li> <a href="https://owasp.org/www-community/attacks/Path_Traversal" target="_blank">Owasp Wiki L√§nk</a> \
 </ol>
 
 #### AttackVector description
-PATH_TRAVERSAL_URL_PARAM_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde l‰ggs direkt till i sˆkv‰gen fˆr att l‰sa filen.
-PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde l‰ggs direkt till om det inte innehÂller "..".
-PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_OR_%2F_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde l‰ggs direkt till om det inte innehÂller ".." eller "%2f" vilket ‰r URL-kodningen fˆr "/".
-PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_OR_%2F_CASE_INSENSITIVE_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query parameterns v‰rde l‰ggs direkt till om det inte innehÂller ".." eller "%2f" eller "%2F" vilket ‰r URL-kodningen fˆr "/".
-PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_WITH_OR_WITHOUT_URL_ENCODING_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query parameterns v‰rde l‰ggs direkt till om det inte innehÂller "..", tar ‰ven hand om URL-kodningen.
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt i sˆkv‰gen fˆr att l‰sa filen.
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_PARENT_DIRECTORY_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt om det inte innehÂller "../".
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt om det inte innehÂller "..".
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_OR_%2F_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt om det inte innehÂller ".." eller "%2f" vilket ‰r URL-kodningen fˆr "/".
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_OR_%2F_CASE_INSENSITIVE_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt om det inte innehÂller ".." eller "%2f" eller "%2F" vilket ‰r URL-kodningen fˆr "/".
-PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_WITH_OR_WITHOUT_URL_ENCODING_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v‰rde fˆre Null Byte l‰ggs till direkt om det inte innehÂller "..", tar ‰ven hand om URL-kodningen.
+PATH_TRAVERSAL_URL_PARAM_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde l√§ggs direkt till i s√∂kv√§gen f√∂r att l√§sa filen.
+PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde l√§ggs direkt till om det inte inneh√•ller "..".
+PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_OR_%2F_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde l√§ggs direkt till om det inte inneh√•ller ".." eller "%2f" vilket √§r URL-kodningen f√∂r "/".
+PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_OR_%2F_CASE_INSENSITIVE_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query parameterns v√§rde l√§ggs direkt till om det inte inneh√•ller ".." eller "%2f" eller "%2F" vilket √§r URL-kodningen f√∂r "/".
+PATH_TRAVERSAL_URL_PARAM_IF_DOT_DOT_PATH_WITH_OR_WITHOUT_URL_ENCODING_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query parameterns v√§rde l√§ggs direkt till om det inte inneh√•ller "..", tar √§ven hand om URL-kodningen.
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt i s√∂kv√§gen f√∂r att l√§sa filen.
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_PARENT_DIRECTORY_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt om det inte inneh√•ller "../".
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt om det inte inneh√•ller "..".
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_OR_%2F_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt om det inte inneh√•ller ".." eller "%2f" vilket √§r URL-kodningen f√∂r "/".
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_OR_%2F_CASE_INSENSITIVE_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt om det inte inneh√•ller ".." eller "%2f" eller "%2F" vilket √§r URL-kodningen f√∂r "/".
+PATH_TRAVERSAL_URL_PARAM_BEFORE_NULL_BYTE_IF_DOT_DOT_PATH_WITH_OR_WITHOUT_URL_ENCODING_NOT_PRESENT_DIRECTLY_INJECTED="fileName" query-parameterns v√§rde f√∂re Null Byte l√§ggs till direkt om det inte inneh√•ller "..", tar √§ven hand om URL-kodningen.
 
 
 # Command Injection Attack
-COMMAND_INJECTION_VULNERABILITY=Kommandoinjektion ‰r en attack d‰r mÂlet ‰r exekvering av godtyckliga kommandon pÂ v‰rdens operativsystem\
-via en sÂrbar applikation. Kommandoinjektionsattacker ‰r mˆjliga n‰r en applikation skickar os‰ker data frÂn anv‰ndaren (formul‰r, cookies, HTTP headers etc.)\
-till ett systemskal. I den h‰r attacken exekveras vanligtvis kommandon frÂn angriparens operativsystem med samma privilegier som det sÂrbara programmet har.\
-Kommandoinjektionsattacker ‰r till stor del mˆjliga pÂ grund utav otillr‰cklig input validering. <br/><br/>\
-Viktiga l‰nkar om sÂrbarheter fˆr kommandoinjektion :<br/>\
+COMMAND_INJECTION_VULNERABILITY=Kommandoinjektion √§r en attack d√§r m√•let √§r exekvering av godtyckliga kommandon p√• v√§rdens operativsystem\
+via en s√•rbar applikation. Kommandoinjektionsattacker √§r m√∂jliga n√§r en applikation skickar os√§ker data fr√•n anv√§ndaren (formul√§r, cookies, HTTP headers etc.)\
+till ett systemskal. I den h√§r attacken exekveras vanligtvis kommandon fr√•n angriparens operativsystem med samma privilegier som det s√•rbara programmet har.\
+Kommandoinjektionsattacker √§r till stor del m√∂jliga p√• grund utav otillr√§cklig input validering. <br/><br/>\
+Viktiga l√§nkar om s√•rbarheter f√∂r kommandoinjektion :<br/>\
 <ol> <li> <a href="https://cwe.mitre.org/data/definitions/77.html" target="_blank">CWE-77</a>  \
- <li> <a href="https://owasp.org/www-community/attacks/Command_Injection" target="_blank">Owasp Wiki L‰nk</a> \
+ <li> <a href="https://owasp.org/www-community/attacks/Command_Injection" target="_blank">Owasp Wiki L√§nk</a> \
 </ol>
 
 #### Attack vectors
-COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED="ipaddress" query-parameterns v‰rde exekveras direkt.
-COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_NOT_PRESENT="ipaddress" query-parameterns v‰rde exekveras direkt om ";", "&" eller blanksteg inte finns med.
-COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_NOT_PRESENT="ipaddress" query-parameterns v‰rde exekveras direkt om ";", "&", "%26", "%3B" eller blanksteg inte finns med.
-COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_CASE_INSENSITIVE_NOT_PRESENT="ipaddress" query-parameterns v‰rde exekveras direkt om ";", "&", "%26", "%3B", "%3b" eller blanksteg inte finns med.
-COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_%7C_CASE_INSENSITIVE_NOT_PRESENT="ipaddress" query-parameterns v‰rde exekveras direkt om ";", "&", "%26", "%3B", "%3b", "%7C", "%7c" eller blanksteg inte finns med.
+COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED="ipaddress" query-parameterns v√§rde exekveras direkt.
+COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_NOT_PRESENT="ipaddress" query-parameterns v√§rde exekveras direkt om ";", "&" eller blanksteg inte finns med.
+COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_NOT_PRESENT="ipaddress" query-parameterns v√§rde exekveras direkt om ";", "&", "%26", "%3B" eller blanksteg inte finns med.
+COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_CASE_INSENSITIVE_NOT_PRESENT="ipaddress" query-parameterns v√§rde exekveras direkt om ";", "&", "%26", "%3B", "%3b" eller blanksteg inte finns med.
+COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_%7C_CASE_INSENSITIVE_NOT_PRESENT="ipaddress" query-parameterns v√§rde exekveras direkt om ";", "&", "%26", "%3B", "%3b", "%7C", "%7c" eller blanksteg inte finns med.
 
 
 # Local File Injection
@@ -195,47 +195,47 @@ COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26
 URL_BASED_RFI_INJECTION=Lokal URL-baserad filinjektionsattack
 
 # JWT Injection
-JWT_INJECTION_VULNERABILITY=JSON Web Token (JWT) ‰r en ˆppen standard (RFC 7519) som definierar ett kompakt och fristÂende s‰tt fˆr att\
-s‰kert skicka information mellan parter i form av ett JSON objekt. Denna information kan verifieras och ses som tillfˆrlitlig eftersom\
-den ‰r digitalt signerad. Det kan finnas flera saker som kan gÂ fel med implementeringen av JWT och som kan pÂverka autentiseringen eller auktoriseringen  \
-av applikationen och resultera i fullst‰ndig kompromiss av systemet. <br/><br/> Viktiga l‰nkar om JWT : \
-<ol> <li> <a href="https://en.wikipedia.org/wiki/JSON_Web_Token" target="_blank">Wiki L‰nk</a>  \
+JWT_INJECTION_VULNERABILITY=JSON Web Token (JWT) √§r en √∂ppen standard (RFC 7519) som definierar ett kompakt och frist√•ende s√§tt f√∂r att\
+s√§kert skicka information mellan parter i form av ett JSON objekt. Denna information kan verifieras och ses som tillf√∂rlitlig eftersom\
+den √§r digitalt signerad. Det kan finnas flera saker som kan g√• fel med implementeringen av JWT och som kan p√•verka autentiseringen eller auktoriseringen  \
+av applikationen och resultera i fullst√§ndig kompromiss av systemet. <br/><br/> Viktiga l√§nkar om JWT : \
+<ol> <li> <a href="https://en.wikipedia.org/wiki/JSON_Web_Token" target="_blank">Wiki L√§nk</a>  \
  <li> <a href="https://jwt.io/introduction/" target="_blank">Jwt.io</a> \
- </ol> Viktiga l‰nkar om sÂrbara implementeringar i JWT : \
- <ol>  <li><a href="https://tools.ietf.org/html/draft-ietf-oauth-jwt-bcp-06" target="_blank">JSON Web Token b‰st \
+ </ol> Viktiga l√§nkar om s√•rbara implementeringar i JWT : \
+ <ol>  <li><a href="https://tools.ietf.org/html/draft-ietf-oauth-jwt-bcp-06" target="_blank">JSON Web Token b√§st \
       aktuell praxis(ieft dokument)</a> \
    <li><a \
        href="https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.html" target="_blank"> \
-       OWASP cheatsheet fˆr sÂrbarheter i JWT implementering </a> \
-   <li><a href="https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries" target="_blank">Fˆr \
-       sÂrbarheter pÂ serversidan i JWT implementeringar</a> \
+       OWASP cheatsheet f√∂r s√•rbarheter i JWT implementering </a> \
+   <li><a href="https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries" target="_blank">F√∂r \
+       s√•rbarheter p√• serversidan i JWT implementeringar</a> \
  </ol>
 
 #### AttackVector description
-JWT_URL_EXPOSING_SECURE_INFORMATION=FˆrfrÂgan innehÂller en JWT-token som ‰r synlig i URL:en. Detta kan bryta mot PCI och de flesta organisatoriska efterlevnadspolicyer.
-COOKIE_CONTAINING_JWT_TOKEN_SECURITY_ATTRIBUTES_MISSING=Cookiebaserad JWT-token men utan Secure/HttpOnly flaggor och ‰ven utan cookie-prefix.
-COOKIE_WITH_HTTPONLY_WITHOUT_SECURE_FLAG_BASED_JWT_VULNERABILITY=Cookiebaserad JWT-token men med HttpOnly flagga mem itam Secure flagga och ‰ven utan cookie-prefix.
-COOKIE_BASED_LOW_KEY_STRENGTH_JWT_VULNERABILITY=Cookiebaserad JWT-token, sÂrbar pÂ grund av svag nyckelsignatur.
-COOKIE_BASED_NULL_BYTE_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator, sÂrbar pÂ grund av Null Byte.
-COOKIE_BASED_NONE_ALGORITHM_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator, sÂrbar pÂ grund av None-algoritmen.
-COOKIE_BASED_KEY_CONFUSION_JWT_VULNERABILITY=Cookiebaserad JWT-token, sÂrbar pÂ grund av nyckelfˆrvirring.
-COOKIE_BASED_FOR_JWK_HEADER_BASED_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator som ‰r sÂrbar fˆr att lita pÂ JWK-f‰ltet utan att kontrollera om den tillhandahÂllna offentliga nyckeln finns i truststore eller inte.
-COOKIE_BASED_EMPTY_TOKEN_JWT_VULNERABILITY=Cookiebaserad JWT-token, sÂrbar fˆr attack med tom token.
+JWT_URL_EXPOSING_SECURE_INFORMATION=F√∂rfr√•gan inneh√•ller en JWT-token som √§r synlig i URL:en. Detta kan bryta mot PCI och de flesta organisatoriska efterlevnadspolicyer.
+COOKIE_CONTAINING_JWT_TOKEN_SECURITY_ATTRIBUTES_MISSING=Cookiebaserad JWT-token men utan Secure/HttpOnly flaggor och √§ven utan cookie-prefix.
+COOKIE_WITH_HTTPONLY_WITHOUT_SECURE_FLAG_BASED_JWT_VULNERABILITY=Cookiebaserad JWT-token men med HttpOnly flagga mem itam Secure flagga och √§ven utan cookie-prefix.
+COOKIE_BASED_LOW_KEY_STRENGTH_JWT_VULNERABILITY=Cookiebaserad JWT-token, s√•rbar p√• grund av svag nyckelsignatur.
+COOKIE_BASED_NULL_BYTE_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator, s√•rbar p√• grund av Null Byte.
+COOKIE_BASED_NONE_ALGORITHM_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator, s√•rbar p√• grund av None-algoritmen.
+COOKIE_BASED_KEY_CONFUSION_JWT_VULNERABILITY=Cookiebaserad JWT-token, s√•rbar p√• grund av nyckelf√∂rvirring.
+COOKIE_BASED_FOR_JWK_HEADER_BASED_JWT_VULNERABILITY=Cookiebaserad JWT-tokenvalidator som √§r s√•rbar f√∂r att lita p√• JWK-f√§ltet utan att kontrollera om den tillhandah√•llna offentliga nyckeln finns i truststore eller inte.
+COOKIE_BASED_EMPTY_TOKEN_JWT_VULNERABILITY=Cookiebaserad JWT-token, s√•rbar f√∂r attack med tom token.
 
 
 
 # SQL Injection Vulnerability
-SQL_INJECTION_VULNERABILITY=En SQL injection attack bestÂr av infogande eller "injektion" av SQL-querys via input datan \
-frÂn klienten till applikationen. En framgÂngsrik SQL injektion kan l‰sa k‰nslig data frÂn databasen, modifiera databasdata (Insert/Update/Delete), \
-exekvera administrationsoperationer pÂ databasen (som att st‰nga av DBMS), Âterst‰lla innehÂllet i en given fil \
-pÂ DBMS-filsystemet och i vissa fall utf‰rda kommandon till operativsystemet. SQL injektioner ‰r en typ av injektionsattacker,\
-d‰r SQL-kommandon injiceras in i datainmatningen fˆr att pÂverka exekveringen av fˆrdefinierade SQL-kommandon. <br>\
-Viktiga l‰nkar om SQLInjection : \
-<ol> <li> <a href="https://en.wikipedia.org/wiki/SQL_injection" target="_blank">Wiki L‰nk</a>  \
+SQL_INJECTION_VULNERABILITY=En SQL injection attack best√•r av infogande eller "injektion" av SQL-querys via input datan \
+fr√•n klienten till applikationen. En framg√•ngsrik SQL injektion kan l√§sa k√§nslig data fr√•n databasen, modifiera databasdata (Insert/Update/Delete), \
+exekvera administrationsoperationer p√• databasen (som att st√§nga av DBMS), √•terst√§lla inneh√•llet i en given fil \
+p√• DBMS-filsystemet och i vissa fall utf√§rda kommandon till operativsystemet. SQL injektioner √§r en typ av injektionsattacker,\
+d√§r SQL-kommandon injiceras in i datainmatningen f√∂r att p√•verka exekveringen av f√∂rdefinierade SQL-kommandon. <br>\
+Viktiga l√§nkar om SQLInjection : \
+<ol> <li> <a href="https://en.wikipedia.org/wiki/SQL_injection" target="_blank">Wiki L√§nk</a>  \
  <li> <a href="https://owasp.org/www-community/attacks/SQL_Injection" target="_blank">Owasp SQLInjection</a> \
  <li> <a href="https://www.youtube.com/watch?v=WkHkryIoLD0" target="_blank">Joe McCray pratar om SQLInjection</a>\
  <li> <a href="https://www.netsparker.com/blog/web-security/sql-injection-cheat-sheet/" target="_blank">SQL Injection cheat sheet av netsparker</a>\
- </ol> <br/><br/> Viktiga l‰nkar om fˆrebyggande tekniker : \
+ </ol> <br/><br/> Viktiga l√§nkar om f√∂rebyggande tekniker : \
  <ol>  <li><a href="https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html" target="_blank">Owasp Prevention cheatsheet</a> \
    <li><a \
        href="https://www.websec.ca/kb/sql_injection" target="_blank"> \
@@ -243,39 +243,39 @@ Viktiga l‰nkar om SQLInjection : \
  </ol>
 
 #### AttackVector description
-ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l‰ggs direkt till i SQL-Query vilket orsakar undantag i vissa scenarion\
- och exponerar d‰rfˆr applikationsinformation.
-ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l‰ggs sen till i SQL-Query vilket orsakar undantag i vissa scenarion \
- och exponerar d‰rfˆr applikationsinformation.
-ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Det enda citatet tas bort frÂn Query-parametern och l‰ggs sen till i SQL-Query genom att omslutas\
+ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l√§ggs direkt till i SQL-Query vilket orsakar undantag i vissa scenarion\
+ och exponerar d√§rf√∂r applikationsinformation.
+ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l√§ggs sen till i SQL-Query vilket orsakar undantag i vissa scenarion \
+ och exponerar d√§rf√∂r applikationsinformation.
+ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Det enda citatet tas bort fr√•n Query-parametern och l√§ggs sen till i SQL-Query genom att omslutas\
  med "'".
-ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY=Query-parametern l‰ggs till direkt i SQL-Query och sedan bildas en parametrerad query. Detta fˆr att visa att\
- korrekt anv‰ndning av PreparedStatement ‰r viktigt. 
-UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l‰ggs direkt till Query och d‰rfˆr kan nyckelordet "Union" anv‰ndas fˆr att gruppera resultaten och\
-extrahera information frÂn applikationen.
-UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l‰ggs sen till Query och d‰rfˆr kan nyckelordet "Union" anv‰ndas fˆr att gruppera resultaten och\
-extrahera information frÂn applikationen.
-UNION_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Det enda citatet tas bort frÂn Query-parametern och l‰ggs sen till i SQL-Query genom att omslutas med "'"\
-och d‰rfˆr kan nyckelordet "Union" anv‰ndas fˆr att gruppera resultaten och extrahera information frÂn applikationen.\
+ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY=Query-parametern l√§ggs till direkt i SQL-Query och sedan bildas en parametrerad query. Detta f√∂r att visa att\
+ korrekt anv√§ndning av PreparedStatement √§r viktigt. 
+UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l√§ggs direkt till Query och d√§rf√∂r kan nyckelordet "Union" anv√§ndas f√∂r att gruppera resultaten och\
+extrahera information fr√•n applikationen.
+UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l√§ggs sen till Query och d√§rf√∂r kan nyckelordet "Union" anv√§ndas f√∂r att gruppera resultaten och\
+extrahera information fr√•n applikationen.
+UNION_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Det enda citatet tas bort fr√•n Query-parametern och l√§ggs sen till i SQL-Query genom att omslutas med "'"\
+och d√§rf√∂r kan nyckelordet "Union" anv√§ndas f√∂r att gruppera resultaten och extrahera information fr√•n applikationen.\
 
-BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l‰ggs direkt till Query d‰rfˆr kan Query manipuleras.
-BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l‰ggs sen till SQL-Query d‰rfˆr kan Query manipuleras.
+BLIND_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY=Query-parametern l√§ggs direkt till Query d√§rf√∂r kan Query manipuleras.
+BLIND_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY=Query-parametern omsluts med "'" och l√§ggs sen till SQL-Query d√§rf√∂r kan Query manipuleras.
 
 
 #### SSRF Vulnerability
-SSRF_VULNERABILITY=I en fˆrfalskning av beg‰ran pÂ serversidan (Server-Side Request Forgery, SSRF) attack kan angriparen missbruka funktionalitet pÂ servern fˆr att \
-l‰sa eller uppdatera interna resurser. Angriparen kan tillhandahÂlla eller ‰ndra en <strong>URL</strong> som koden som kˆrs pÂ servern kommer l‰sa   \
-eller skicka data till, och genom att noggrant v‰lja URL:er, <strong>kan angriparen eventuellt l‰sa serverns </strong>\
-konfigurationer sÂsom AWS metadata, ansluta till interna tj‰nster sÂsom http-aktiverade databaser eller gˆra POST-fˆrfrÂgningar\
-till interna tj‰nster som inte ‰r menade att exponeras. \
-Viktiga l‰nkar om SSRF : \
+SSRF_VULNERABILITY=I en f√∂rfalskning av beg√§ran p√• serversidan (Server-Side Request Forgery, SSRF) attack kan angriparen missbruka funktionalitet p√• servern f√∂r att \
+l√§sa eller uppdatera interna resurser. Angriparen kan tillhandah√•lla eller √§ndra en <strong>URL</strong> som koden som k√∂rs p√• servern kommer l√§sa   \
+eller skicka data till, och genom att noggrant v√§lja URL:er, <strong>kan angriparen eventuellt l√§sa serverns </strong>\
+konfigurationer s√•som AWS metadata, ansluta till interna tj√§nster s√•som http-aktiverade databaser eller g√∂ra POST-f√∂rfr√•gningar\
+till interna tj√§nster som inte √§r menade att exponeras. \
+Viktiga l√§nkar om SSRF : \
 <ol> \
- <li> <a href="https://en.wikipedia.org/wiki/Server-side_request_forgery" target="_blank">Wiki L‰nk</a>  \
+ <li> <a href="https://en.wikipedia.org/wiki/Server-side_request_forgery" target="_blank">Wiki L√§nk</a>  \
  <li> <a href="https://owasp.org/www-community/attacks/Server_Side_Request_Forgery" target="_blank">Owasp SSRF</a> \
  <li> <a href="https://www.youtube.com/watch?v=AsPpxqIlTDU" target="_blank">SSRF (Server Side Request Forgery) av Musab Khan</a>\
  </ol>
-SSRF_VULNERABILITY_URL_WITHOUT_CHECK=Ingen validering pÂ den angivna URL:en.
-SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL=file:// protokollet ‰r inte tillÂtet fˆr den angivna URL:en.
-SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_169.254.169.254=file:// protokollet samt Âtkomst till den interna metadatatj‰nsten IP 169.254.169.254 ‰r inte tillÂtet.
-SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL=file:// protokollet samt Âtkomst till den interna metadatatj‰nsten ‰r inte tillÂtet.
-SSRF_VULNERABILITY_URL_ONLY_IF_IN_THE_WHITELIST=Bara vitlistade URL:er ‰r tillÂtna.
+SSRF_VULNERABILITY_URL_WITHOUT_CHECK=Ingen validering p√• den angivna URL:en.
+SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL=file:// protokollet √§r inte till√•tet f√∂r den angivna URL:en.
+SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_169.254.169.254=file:// protokollet samt √•tkomst till den interna metadatatj√§nsten IP 169.254.169.254 √§r inte till√•tet.
+SSRF_VULNERABILITY_URL_IF_NOT_FILE_PROTOCOL_AND_INTERNAL_METADATA_URL=file:// protokollet samt √•tkomst till den interna metadatatj√§nsten √§r inte till√•tet.
+SSRF_VULNERABILITY_URL_ONLY_IF_IN_THE_WHITELIST=Bara vitlistade URL:er √§r till√•tna.


### PR DESCRIPTION
Closes #722.

`VulnerableAppConfiguration.messageSource()` sets `setDefaultEncoding("UTF-8")`, but two bundles stored their non-ASCII text as ISO-8859-1 bytes. Read as UTF-8, those bytes decoded to U+FFFD and reached the client as `�`.

This converts the affected lines to UTF-8. No code or configuration changes.

**What changed**

| File | Lines converted |
|---|---:|
| `messages_sv.properties` | 170 |
| `messages_es.properties` | 1 |

Diff is `+171 / -171`. Lines that were already valid UTF-8 are byte-identical to `master`.

**Result over HTTP**

`GET /VulnerableApp/VulnerabilityDefinitions`, counting U+FFFD in the response:

| `Accept-Language` | before | after |
|---|---:|---:|
| `sv` | 623 | 0 |
| `es` | 2 | 0 |
| `it` | 0 | 0 |
| `en` | 0 | 0 |

`INVALID_END_POINT` now reads `Följande {0} endpoint är inte tillgänglig...`, and `HEADER_INJECTION_VULNERABILITY` reads `Prueba cómo un encabezado JWT puede ser manipulado para alterar la verificación de la firma.`

**How the conversion was done**

Per line, not per file. `messages_es.properties` is mostly valid UTF-8 already, so decoding the whole file as ISO-8859-1 would have corrupted the parts that were correct. Each line was checked first: if it already decoded as UTF-8 it was copied through untouched, otherwise it was decoded as ISO-8859-1 and re-encoded as UTF-8.

**Checks**

- Loaded both files through `java.util.Properties` and compared against `master`: the key sets are identical and in the same order, 92 keys for Swedish and 96 for Spanish. Keys holding U+FFFD went from 88 to 0 and from 1 to 0.
- Every line that was already valid UTF-8 is byte-identical, and every converted line satisfies `latin1(before) == utf8(after)`, so no text was altered.
- All eleven bundles under `src/main/resources/i18n/` are now valid UTF-8.
- `./gradlew build` passes on JDK 17: 426 tests, 0 failures, `spotlessCheck` clean.
- `./gradlew processResources` copies both files byte for byte; the SHA-256 of the built resource matches the source.

**Note on the open PR #537**

That PR also rewrites these two files, but replaces the affected characters with literal U+FFFD rather than converting them. If it merges after this one, the Swedish text would be lost again and would need retranslating. Worth restoring those two files from `master` on that branch before it lands. Its other five i18n bundles are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected character encoding in Spanish localization text.
  * Fixed Swedish translations so accented and special characters display correctly across security-related messages.
  * Preserved all existing message keys and content structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->