### PR TITLE
Fix scanner, sitemap and benchmark URL handling ignoring server.servlet.context-path (#736)

### DIFF
--- a/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
+++ b/src/main/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategy.java
@@ -46,7 +46,6 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
 
     private static final Logger LOGGER = LogManager.getLogger(DastBenchmarkStrategy.class);
 
-    private static final String CONTEXT_PATH = "/VulnerableApp";
     private static final String UNSECURE_VARIANT = "UNSECURE";
     private static final String KEY_SEPARATOR = "::";
     private static final String AXIS_TYPE = "TYPE";
@@ -57,11 +56,22 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
     private final RestTemplate restTemplate;
     private final String groundTruthUrl;
 
+    /**
+     * The context path this instance is served under, used to reduce scanner findings and
+     * ground-truth entries to a common key. Read from configuration rather than hardcoded: {@code
+     * benchmark.dast.ground-truth.url} already follows {@code server.servlet.context-path}, so a
+     * fixed value here would disagree with the very URLs it is comparing. Empty for a root
+     * deployment, which strips nothing.
+     */
+    private final String contextPath;
+
     public DastBenchmarkStrategy(
             RestTemplate restTemplate,
-            @Value("${benchmark.dast.ground-truth.url}") String groundTruthUrl) {
+            @Value("${benchmark.dast.ground-truth.url}") String groundTruthUrl,
+            @Value("${server.servlet.context-path:}") String contextPath) {
         this.restTemplate = restTemplate;
         this.groundTruthUrl = groundTruthUrl;
+        this.contextPath = contextPath;
     }
 
     @Override
@@ -81,7 +91,7 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
             if (finding == null || finding.getUrl() == null) {
                 continue;
             }
-            String url = normalizeUrl(finding.getUrl());
+            String url = normalizeUrl(finding.getUrl(), contextPath);
             List<String> keys = keysForFinding(url, finding);
             if (keys.isEmpty()) {
                 continue;
@@ -161,7 +171,7 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
             if (!UNSECURE_VARIANT.equalsIgnoreCase(entry.getVariant())) {
                 continue;
             }
-            String url = normalizeUrl(entry.getUrl());
+            String url = normalizeUrl(entry.getUrl(), contextPath);
             String method =
                     (entry.getRequestMethod() != null)
                             ? entry.getRequestMethod().name()
@@ -283,10 +293,11 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
      * Normalises a URL to a context-path-stripped path so absolute ground-truth URLs and relative
      * scanner-finding URLs compare equal.
      *
-     * <p>Strips scheme + host + port, the {@code /VulnerableApp} context path, the query string,
-     * and a trailing slash. Leaves the path case unchanged.
+     * <p>Strips scheme + host + port, the context path the application is served under, the query
+     * string, and a trailing slash. Leaves the path case unchanged. An empty or {@code null} {@code
+     * contextPath} strips no prefix, leaving a root deployment's paths unchanged.
      */
-    static String normalizeUrl(String url) {
+    static String normalizeUrl(String url, String contextPath) {
         if (url == null) {
             return "";
         }
@@ -307,10 +318,12 @@ public class DastBenchmarkStrategy implements BenchmarkStrategy {
             s = s.substring(0, zapSQLPayloadIdx);
         }
 
-        if (s.equals(CONTEXT_PATH)) {
-            s = "/";
-        } else if (s.startsWith(CONTEXT_PATH + "/")) {
-            s = s.substring(CONTEXT_PATH.length());
+        if (contextPath != null && !contextPath.isEmpty()) {
+            if (s.equals(contextPath)) {
+                s = "/";
+            } else if (s.startsWith(contextPath + "/")) {
+                s = s.substring(contextPath.length());
+            }
         }
         if (s.length() > 1 && s.endsWith("/")) {
             s = s.substring(0, s.length() - 1);

--- a/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
+++ b/src/main/java/org/sasanlabs/controller/VulnerableAppRestController.java
@@ -94,6 +94,11 @@ public class VulnerableAppRestController {
         String scheme = request.getScheme(); // http or https
         String serverName = request.getServerName(); // actual hostname/IP
         int serverPort = request.getServerPort(); // actual port
+        // The deployment's own context path, not a hardcoded one:
+        // `server.servlet.context-path` is configurable, so a fixed `/VulnerableApp`
+        // describes this deployment only while that default is in force. Empty for a
+        // root deployment.
+        String contextPath = request.getContextPath();
         String appUrl =
                 new StringBuilder()
                         .append(scheme)
@@ -101,8 +106,7 @@ public class VulnerableAppRestController {
                         .append(serverName)
                         .append(FrameworkConstants.COLON)
                         .append(serverPort)
-                        .append(FrameworkConstants.SLASH)
-                        .append(FrameworkConstants.VULNERABLE_APP)
+                        .append(contextPath)
                         .append(FrameworkConstants.SLASH)
                         .toString();
         return getAllSupportedEndPoints.getScannerRelatedEndPointInformation(appUrl);
@@ -141,6 +145,9 @@ public class VulnerableAppRestController {
         String scheme = request.getScheme(); // http or https
         String serverName = request.getServerName(); // actual hostname/IP
         int serverPort = request.getServerPort(); // actual port
+        // Same reasoning as the scanner endpoint: the sitemap must advertise URLs inside the
+        // context path this instance is actually served under.
+        String contextPath = request.getContextPath();
 
         StringBuilder xmlBuilder =
                 new StringBuilder(
@@ -160,8 +167,7 @@ public class VulnerableAppRestController {
                                         .append(serverName)
                                         .append(FrameworkConstants.COLON)
                                         .append(serverPort)
-                                        .append(FrameworkConstants.SLASH)
-                                        .append(FrameworkConstants.VULNERABLE_APP)
+                                        .append(contextPath)
                                         .append(FrameworkConstants.SLASH)
                                         .append(endPoint.getName())
                                         .append(FrameworkConstants.SLASH)

--- a/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
+++ b/src/test/java/org/sasanlabs/benchmark/service/DastBenchmarkStrategyTest.java
@@ -25,6 +25,8 @@ import org.springframework.web.client.RestTemplate;
 @ExtendWith(MockitoExtension.class)
 class DastBenchmarkStrategyTest {
 
+    private static final String CONTEXT_PATH = "/VulnerableApp";
+
     private static final String GROUND_TRUTH_URL = "http://localhost:9090/VulnerableApp/scanner";
 
     @Mock private RestTemplate restTemplate;
@@ -33,7 +35,7 @@ class DastBenchmarkStrategyTest {
 
     @BeforeEach
     void setUp() {
-        strategy = new DastBenchmarkStrategy(restTemplate, GROUND_TRUTH_URL);
+        strategy = new DastBenchmarkStrategy(restTemplate, GROUND_TRUTH_URL, CONTEXT_PATH);
     }
 
     private void stubGroundTruth(ScannerResponseBean... beans) {
@@ -379,15 +381,45 @@ class DastBenchmarkStrategyTest {
     void urlNormalization_acceptsAbsoluteRelativeAndContextStrippedForms() {
         assertThat(
                         DastBenchmarkStrategy.normalizeUrl(
-                                "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1"))
+                                "http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1",
+                                CONTEXT_PATH))
                 .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(DastBenchmarkStrategy.normalizeUrl("/VulnerableApp/SQLInjection/LEVEL_1"))
+        assertThat(
+                        DastBenchmarkStrategy.normalizeUrl(
+                                "/VulnerableApp/SQLInjection/LEVEL_1", CONTEXT_PATH))
                 .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1"))
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1", CONTEXT_PATH))
                 .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1/"))
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1/", CONTEXT_PATH))
                 .isEqualTo("/SQLInjection/LEVEL_1");
-        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1?attack=1' OR 1=1--"))
+        assertThat(
+                        DastBenchmarkStrategy.normalizeUrl(
+                                "/SQLInjection/LEVEL_1?attack=1' OR 1=1--", CONTEXT_PATH))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+    }
+
+    /**
+     * The context path is configuration, not a constant, so the same collapsing has to work for a
+     * deployment served anywhere else. Under a hardcoded {@code /VulnerableApp} the absolute and
+     * context-relative forms below would key differently and stop matching each other.
+     */
+    @Test
+    void urlNormalization_stripsWhicheverContextPathTheAppIsServedUnder() {
+        assertThat(
+                        DastBenchmarkStrategy.normalizeUrl(
+                                "https://10.0.0.5:443/customCtx/SQLInjection/LEVEL_1",
+                                "/customCtx"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(
+                        DastBenchmarkStrategy.normalizeUrl(
+                                "/customCtx/SQLInjection/LEVEL_1", "/customCtx"))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/customCtx", "/customCtx")).isEqualTo("/");
+
+        // A root deployment has an empty context path and must strip nothing.
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1", ""))
+                .isEqualTo("/SQLInjection/LEVEL_1");
+        assertThat(DastBenchmarkStrategy.normalizeUrl("/SQLInjection/LEVEL_1", null))
                 .isEqualTo("/SQLInjection/LEVEL_1");
     }
 

--- a/src/test/java/org/sasanlabs/controller/VulnerableAppRestControllerContextPathTest.java
+++ b/src/test/java/org/sasanlabs/controller/VulnerableAppRestControllerContextPathTest.java
@@ -28,14 +28,22 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  *
  * <p>{@code server.servlet.context-path} is configurable, and nothing in the repository overrides
  * the default, so this shows up only where that setting is overridden. These tests serve the
- * controller under {@code /customCtx} and assert that neither the scanner URL nor the sitemap
- * {@code <loc>} entries point outside the deployment.
+ * controller under three context paths, a custom one, the shipped default and none at all, and
+ * assert that neither the scanner URL nor the sitemap {@code <loc>} entries point outside the
+ * deployment.
  */
 @ExtendWith(MockitoExtension.class)
 class VulnerableAppRestControllerContextPathTest {
 
-    private static final String CONTEXT_PATH = "/customCtx";
-    private static final String HARDCODED_CONTEXT_PATH = "/VulnerableApp";
+    /** A deployment served somewhere other than the shipped default. */
+    private static final String CUSTOM_CONTEXT_PATH = "/customCtx";
+
+    /**
+     * The context path {@code application.properties} ships, and the value both endpoints used to
+     * hardcode. A deployment served elsewhere must not fall back to it, and a deployment served
+     * under it must still produce it.
+     */
+    private static final String DEFAULT_CONTEXT_PATH = "/VulnerableApp";
 
     @Mock private IEndPointsInformationProvider endPointsInformationProvider;
 
@@ -55,15 +63,17 @@ class VulnerableAppRestControllerContextPathTest {
                 .thenReturn(Collections.emptyList());
 
         mockMvc.perform(
-                get(CONTEXT_PATH + "/scanner").contextPath(CONTEXT_PATH).with(servedOverHttps()));
+                get(CUSTOM_CONTEXT_PATH + "/scanner")
+                        .contextPath(CUSTOM_CONTEXT_PATH)
+                        .with(servedOverHttps()));
 
         ArgumentCaptor<String> appUrl = ArgumentCaptor.forClass(String.class);
         verify(endPointsInformationProvider).getScannerRelatedEndPointInformation(appUrl.capture());
 
         assertThat(appUrl.getValue())
                 .as("the scanner base URL must sit under the served context path")
-                .isEqualTo("https://10.0.0.5:443" + CONTEXT_PATH + "/")
-                .doesNotContain(HARDCODED_CONTEXT_PATH);
+                .isEqualTo("https://10.0.0.5:443" + CUSTOM_CONTEXT_PATH + "/")
+                .doesNotContain(DEFAULT_CONTEXT_PATH);
     }
 
     @Test
@@ -73,8 +83,8 @@ class VulnerableAppRestControllerContextPathTest {
 
         String sitemap =
                 mockMvc.perform(
-                                get(CONTEXT_PATH + "/sitemap.xml")
-                                        .contextPath(CONTEXT_PATH)
+                                get(CUSTOM_CONTEXT_PATH + "/sitemap.xml")
+                                        .contextPath(CUSTOM_CONTEXT_PATH)
                                         .with(servedOverHttps()))
                         .andReturn()
                         .getResponse()
@@ -82,8 +92,42 @@ class VulnerableAppRestControllerContextPathTest {
 
         assertThat(sitemap)
                 .as("every <loc> must sit under the served context path")
-                .contains("https://10.0.0.5:443" + CONTEXT_PATH + "/SQLInjection/LEVEL_1")
-                .doesNotContain(HARDCODED_CONTEXT_PATH);
+                .contains("https://10.0.0.5:443" + CUSTOM_CONTEXT_PATH + "/SQLInjection/LEVEL_1")
+                .doesNotContain(DEFAULT_CONTEXT_PATH);
+    }
+
+    /**
+     * The shipped configuration serves the application under {@code /VulnerableApp}, so that
+     * deployment's URLs have to come out exactly as they did before. This case passes on unmodified
+     * master too; it is here to pin behaviour that must not change, not to demonstrate the defect.
+     */
+    @Test
+    void defaultContextPathStillProducesTheVulnerableAppSegment() throws Exception {
+        when(endPointsInformationProvider.getScannerRelatedEndPointInformation(anyString()))
+                .thenReturn(Collections.emptyList());
+        when(endPointsInformationProvider.getSupportedEndPoints())
+                .thenReturn(Collections.singletonList(sqlInjectionEndPoint()));
+
+        mockMvc.perform(
+                get(DEFAULT_CONTEXT_PATH + "/scanner")
+                        .contextPath(DEFAULT_CONTEXT_PATH)
+                        .with(servedOverHttps()));
+
+        ArgumentCaptor<String> appUrl = ArgumentCaptor.forClass(String.class);
+        verify(endPointsInformationProvider).getScannerRelatedEndPointInformation(appUrl.capture());
+        assertThat(appUrl.getValue())
+                .isEqualTo("https://10.0.0.5:443" + DEFAULT_CONTEXT_PATH + "/");
+
+        String sitemap =
+                mockMvc.perform(
+                                get(DEFAULT_CONTEXT_PATH + "/sitemap.xml")
+                                        .contextPath(DEFAULT_CONTEXT_PATH)
+                                        .with(servedOverHttps()))
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+        assertThat(sitemap)
+                .contains("https://10.0.0.5:443" + DEFAULT_CONTEXT_PATH + "/SQLInjection/LEVEL_1");
     }
 
     /**
@@ -110,7 +154,7 @@ class VulnerableAppRestControllerContextPathTest {
                         .getContentAsString();
         assertThat(sitemap)
                 .contains("https://10.0.0.5:443/SQLInjection/LEVEL_1")
-                .doesNotContain(HARDCODED_CONTEXT_PATH);
+                .doesNotContain(DEFAULT_CONTEXT_PATH);
     }
 
     /**

--- a/src/test/java/org/sasanlabs/controller/VulnerableAppRestControllerContextPathTest.java
+++ b/src/test/java/org/sasanlabs/controller/VulnerableAppRestControllerContextPathTest.java
@@ -1,0 +1,146 @@
+package org.sasanlabs.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sasanlabs.beans.AllEndPointsResponseBean;
+import org.sasanlabs.beans.LevelResponseBean;
+import org.sasanlabs.service.IEndPointsInformationProvider;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * The URLs handed to scanners must stay inside the context path the application is actually served
+ * under, rather than a hardcoded {@code /VulnerableApp}.
+ *
+ * <p>{@code server.servlet.context-path} is configurable, and nothing in the repository overrides
+ * the default, so this shows up only where that setting is overridden. These tests serve the
+ * controller under {@code /customCtx} and assert that neither the scanner URL nor the sitemap
+ * {@code <loc>} entries point outside the deployment.
+ */
+@ExtendWith(MockitoExtension.class)
+class VulnerableAppRestControllerContextPathTest {
+
+    private static final String CONTEXT_PATH = "/customCtx";
+    private static final String HARDCODED_CONTEXT_PATH = "/VulnerableApp";
+
+    @Mock private IEndPointsInformationProvider endPointsInformationProvider;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc =
+                MockMvcBuilders.standaloneSetup(
+                                new VulnerableAppRestController(endPointsInformationProvider))
+                        .build();
+    }
+
+    @Test
+    void scannerUrlIsBuiltFromTheRequestContextPath() throws Exception {
+        when(endPointsInformationProvider.getScannerRelatedEndPointInformation(anyString()))
+                .thenReturn(Collections.emptyList());
+
+        mockMvc.perform(
+                get(CONTEXT_PATH + "/scanner").contextPath(CONTEXT_PATH).with(servedOverHttps()));
+
+        ArgumentCaptor<String> appUrl = ArgumentCaptor.forClass(String.class);
+        verify(endPointsInformationProvider).getScannerRelatedEndPointInformation(appUrl.capture());
+
+        assertThat(appUrl.getValue())
+                .as("the scanner base URL must sit under the served context path")
+                .isEqualTo("https://10.0.0.5:443" + CONTEXT_PATH + "/")
+                .doesNotContain(HARDCODED_CONTEXT_PATH);
+    }
+
+    @Test
+    void sitemapLocEntriesAreBuiltFromTheRequestContextPath() throws Exception {
+        when(endPointsInformationProvider.getSupportedEndPoints())
+                .thenReturn(Collections.singletonList(sqlInjectionEndPoint()));
+
+        String sitemap =
+                mockMvc.perform(
+                                get(CONTEXT_PATH + "/sitemap.xml")
+                                        .contextPath(CONTEXT_PATH)
+                                        .with(servedOverHttps()))
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        assertThat(sitemap)
+                .as("every <loc> must sit under the served context path")
+                .contains("https://10.0.0.5:443" + CONTEXT_PATH + "/SQLInjection/LEVEL_1")
+                .doesNotContain(HARDCODED_CONTEXT_PATH);
+    }
+
+    /**
+     * A root deployment has an empty context path. The URLs must then carry no path segment at all
+     * rather than falling back to the old hardcoded one.
+     */
+    @Test
+    void rootDeploymentGetsUrlsWithNoContextSegment() throws Exception {
+        when(endPointsInformationProvider.getScannerRelatedEndPointInformation(anyString()))
+                .thenReturn(Collections.emptyList());
+        when(endPointsInformationProvider.getSupportedEndPoints())
+                .thenReturn(Collections.singletonList(sqlInjectionEndPoint()));
+
+        mockMvc.perform(get("/scanner").with(servedOverHttps()));
+
+        ArgumentCaptor<String> appUrl = ArgumentCaptor.forClass(String.class);
+        verify(endPointsInformationProvider).getScannerRelatedEndPointInformation(appUrl.capture());
+        assertThat(appUrl.getValue()).isEqualTo("https://10.0.0.5:443/");
+
+        String sitemap =
+                mockMvc.perform(get("/sitemap.xml").with(servedOverHttps()))
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+        assertThat(sitemap)
+                .contains("https://10.0.0.5:443/SQLInjection/LEVEL_1")
+                .doesNotContain(HARDCODED_CONTEXT_PATH);
+    }
+
+    /**
+     * Spring 5's request builder has no {@code scheme()}/{@code serverName()} setters, so the host
+     * half of the URL is pinned on the underlying {@link
+     * org.springframework.mock.web.MockHttpServletRequest} instead. Fixed values keep the
+     * assertions exact.
+     */
+    private static RequestPostProcessor servedOverHttps() {
+        return request -> {
+            request.setScheme("https");
+            request.setServerName("10.0.0.5");
+            request.setServerPort(443);
+            return request;
+        };
+    }
+
+    /**
+     * The controller emits one {@code <loc>} per level, so a single endpoint carrying a single
+     * level is enough to pin the URL shape.
+     */
+    private static AllEndPointsResponseBean sqlInjectionEndPoint() {
+        LevelResponseBean level = new LevelResponseBean();
+        level.setLevel("LEVEL_1");
+        Set<LevelResponseBean> levels = new LinkedHashSet<>();
+        levels.add(level);
+
+        AllEndPointsResponseBean endPoint = new AllEndPointsResponseBean();
+        endPoint.setName("SQLInjection");
+        endPoint.setLevelDescriptionSet(levels);
+        return endPoint;
+    }
+}


### PR DESCRIPTION
Fixes #736.

## What was wrong

`VulnerableAppRestController` built the URLs it hands to scanners by appending
`FrameworkConstants.VULNERABLE_APP` to the scheme, host and port, so those URLs
carried `/VulnerableApp/` whatever context path the request actually arrived
under. Two sites on `master` (`766890c`): `getScannerRelatedInformation`
(line 92, constant appended at line 105) and `sitemapForPassiveScanners`
(line 137, constant appended at line 164).

`DastBenchmarkStrategy` held the same literal from the other direction:
`private static final String CONTEXT_PATH = "/VulnerableApp"` at line 49, which
`normalizeUrl` strips to reduce scanner findings and ground-truth entries to a
common key.

`server.servlet.context-path` is set in exactly one place in the repository,
`application.properties:2`. I grepped every spelling of the key,
case-insensitively, across all files tracked at `766890c`: 10 matches, none of
them in `application-public.properties`, `application-unsafe.properties`, the
four `docker-compose*.yml` files, `Dockerfile.base`, or any of the seven
workflows. The hardcoded value therefore matches every configuration the
repository ships, and diverges for anyone who overrides it.

## The fix

One commit per site, and a third that pins the shipped deployment in the
controller test.

**Controller.** Both methods already receive the `HttpServletRequest`, so the
deployment's own context path is one call away and no signature changes. An
empty context path (a root deployment) yields `scheme://host:port/`.

**Benchmark.** The class is already a `@Service` taking `@Value` config, so the
context path arrives the same way, and `normalizeUrl` takes it as a parameter.
A null or empty context path strips nothing.

## Evidence

### A real deployment, before and after

I built the boot jar from `766890c` and from this branch and ran both on the
embedded Tomcat. Counts below are from parsing each response, `url` fields for
`/scanner` and `<loc>` elements for `/sitemap.xml`.

Started with `--server.servlet.context-path=/customCtx`, both jars log:

```
Tomcat started on port(s): 9090 (http) with context path '/customCtx'
```

| Jar | `/scanner` | `/sitemap.xml` |
|---|---|---|
| `766890c` | 153 entries, all 153 on `http://localhost:9090/VulnerableApp` | 164 entries, all 164 on `http://localhost:9090/VulnerableApp` |
| this branch | 153 entries, all 153 on `http://localhost:9090/customCtx` | 164 entries, all 164 on `http://localhost:9090/customCtx` |

Taking one URL that `766890c` emitted and fetching it back from the same
running instance:

| URL | Status |
|---|---|
| `http://localhost:9090/VulnerableApp/JWTVulnerability/LEVEL_1` | 404 |
| `http://localhost:9090/customCtx/JWTVulnerability/LEVEL_1` | 200 |

This branch started with an empty context path,
`--server.servlet.context-path=`, logs:

```
Tomcat started on port(s): 9090 (http) with context path ''
```

`/scanner` returns 153 entries and `/sitemap.xml` 164, all on
`http://localhost:9090` with no context segment, for example
`http://localhost:9090/JWTVulnerability/LEVEL_1`, which answers 200. Neither
response contains a doubled slash or the string `VulnerableApp`.

### The shipped configuration is unchanged

Both jars started with no flag, so both under `/VulnerableApp`. Each response
is byte-identical between the two jars:

| Response | sha256, first 16 hex |
|---|---|
| `/scanner` | `1739486ea7348e10` |
| `/sitemap.xml` | `c5dd89f486c5ff33` |

This branch's jar starting cleanly, under all three context paths, is also what
checks that the new `@Value("${server.servlet.context-path:}")` constructor
parameter wires. The repository has no `@SpringBootTest`, so no test starts the
Spring context.

### Controller tests, against unmodified master

The new test class copied onto a clean `766890c` worktree with no other change.
Three of its four cases fail:

```
scannerUrlIsBuiltFromTheRequestContextPath
org.opentest4j.AssertionFailedError: [the scanner base URL must sit under the served context path]
Expecting: <"https://10.0.0.5:443/VulnerableApp/"> to be equal to: <"https://10.0.0.5:443/customCtx/"> but was not.

sitemapLocEntriesAreBuiltFromTheRequestContextPath
java.lang.AssertionError: [every <loc> must sit under the served context path]
Expecting: <"... <loc> https://10.0.0.5:443/VulnerableApp/SQLInjection/LEVEL_1 </loc> ...">
to contain: <"https://10.0.0.5:443/customCtx/SQLInjection/LEVEL_1">

rootDeploymentGetsUrlsWithNoContextSegment
org.opentest4j.AssertionFailedError:
Expecting: <"https://10.0.0.5:443/VulnerableApp/"> to be equal to: <"https://10.0.0.5:443/"> but was not.
```

The sitemap message is abridged at the ellipses. Otherwise these are the
assertion messages as JUnit reported them, with line breaks added and repeated
spaces collapsed. All four cases pass on this branch.

The fourth, `defaultContextPathStillProducesTheVulnerableAppSegment`, passes on
`766890c` as well, and that is its purpose: it serves the controller under the
shipped `/VulnerableApp` and pins the URLs that deployment already receives, so
the two cases above cannot stay green while the default quietly changes. There
is no test class for this controller on `master`.

### Benchmark normalisation, against unmodified master

`normalizeUrl` on `766890c`, called directly from a throwaway test:

```
/VulnerableApp/SQLInjection/LEVEL_1                       ->  /SQLInjection/LEVEL_1
http://localhost:9090/VulnerableApp/SQLInjection/LEVEL_1  ->  /SQLInjection/LEVEL_1
/SQLInjection/LEVEL_1                                     ->  /SQLInjection/LEVEL_1
/customCtx/SQLInjection/LEVEL_1                           ->  /customCtx/SQLInjection/LEVEL_1
https://10.0.0.5:443/customCtx/SQLInjection/LEVEL_1       ->  /customCtx/SQLInjection/LEVEL_1
```

Under `/VulnerableApp` all three forms of the same endpoint reduce to one key.
Under `/customCtx` the absolute and the context-relative form reduce to
`/customCtx/SQLInjection/LEVEL_1` and `/SQLInjection/LEVEL_1`, two keys that no
longer match.

The constant also disagreed with its own configuration:
`benchmark.dast.ground-truth.url` is built from
`${server.servlet.context-path:/VulnerableApp}` (`application.properties:46`),
so the ground-truth URL follows whatever context path is configured while the
constant did not.

### Test run

`./gradlew clean build --no-daemon`, the command this repository's CI runs, on
JDK 17: run twice, `BUILD SUCCESSFUL` both times, 38 classes, 432 tests,
0 failures, 0 errors, 2 skipped. At `766890c`, `./gradlew clean test` gives
37 classes and 427 tests, so this PR adds one test class and five tests. The
2 skipped are pre-existing, both in `Http3xxStatusCodeBasedInjectionTest`.

## Correction to the issue

In #736 I wrote that site 3 means "making both non-static and reworking that
test". That was wrong, and I am correcting it here rather than editing the
issue. `normalizeUrl` stays `static` and package-private and takes the context
path as a second parameter, so the existing assertions in
`urlNormalization_acceptsAbsoluteRelativeAndContextStrippedForms` keep their
cases and gain one argument each.

## What I did not test

- A real scanner run. Whether the benchmark key divergence changes a reported
  number depends on which URL form the scanner emits, which I have not measured.
- A VulnerableApp-facade deployment.
- A deployment behind a reverse proxy that rewrites the path.

## Overlap with #733

#733 changes both of the main-source files this PR touches. Merging this branch
onto its head (`cad4d1a`) conflicts in one of them,
`VulnerableAppRestController.java`; `DastBenchmarkStrategy.java` merges cleanly,
since #733 changes only a javadoc line there. Whichever lands second needs the
rebase, and I am happy to do it on this side either way. In #733 the block this
PR edits is extracted into a helper, `applicationUrl(request)`, so on that side
the same change moves into the helper, which also feeds the
`Link: <...>; rel="successor-version"` header that PR adds.

`FrameworkConstants.VULNERABLE_APP` stays. `UnrestrictedFileUpload.java:123`
still uses it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scanner and sitemap URLs now correctly use the application’s configured context path.
  * Applications deployed at the root path or under a custom path now generate valid URLs.
  * Removed assumptions tied to the default `/VulnerableApp` deployment path.

* **Tests**
  * Added coverage for custom context paths, root deployments, and missing context paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->