### PR TITLE
feat: add CSRF vulnerability lab (Fixes #713)

### DIFF
--- a/scanner/sast/expectedIssues.csv
+++ b/scanner/sast/expectedIssues.csv
@@ -153,3 +153,7 @@ CWE-79,Reflected XSS,src/main/java/org/sasanlabs/service/vulnerability/xss/refle
 CWE-79,Reflected XSS,src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java,73,1
 CWE-611,Xxe,src/main/java/org/sasanlabs/service/vulnerability/xxe/XXEVulnerability.java,64,1
 CWE-611,Xxe,src/main/java/org/sasanlabs/service/vulnerability/xxe/XXEVulnerability.java,137,1
+CWE-352,Cross-Site Request Forgery,src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java,85,1
+CWE-352,Cross-Site Request Forgery,src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java,137,1
+CWE-352,Cross-Site Request Forgery,src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java,194,1
+CWE-352,Cross-Site Request Forgery,src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java,266,1

--- a/src/main/java/org/sasanlabs/configuration/VulnerableAppConfiguration.java
+++ b/src/main/java/org/sasanlabs/configuration/VulnerableAppConfiguration.java
@@ -145,6 +145,8 @@ public class VulnerableAppConfiguration {
         populator.addScript(new ClassPathResource("scripts/CryptographicFailures/db/schema.sql"));
         populator.addScript(new ClassPathResource("scripts/SessionManagement/db/schema.sql"));
         populator.addScript(new ClassPathResource("scripts/SessionManagement/db/data.sql"));
+        populator.addScript(new ClassPathResource("scripts/CSRF/db/schema.sql"));
+        populator.addScript(new ClassPathResource("scripts/CSRF/db/data.sql"));
         populator.setSeparator(";");
 
         DataSourceInitializer initializer = new DataSourceInitializer();

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccount.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccount.java
@@ -1,0 +1,39 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+/** Represents a CSRF lab account. */
+public class CSRFAccount {
+
+    private int id;
+    private String username;
+    private String email;
+
+    public CSRFAccount(int id, String username, String email) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccount.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccount.java
@@ -6,10 +6,18 @@ public class CSRFAccount {
     private int id;
     private String username;
     private String email;
+    private String storedPassword;
 
     public CSRFAccount(int id, String username, String email) {
         this.id = id;
         this.username = username;
+        this.email = email;
+    }
+
+    public CSRFAccount(int id, String username, String storedPassword, String email) {
+        this.id = id;
+        this.username = username;
+        this.storedPassword = storedPassword;
         this.email = email;
     }
 
@@ -35,5 +43,9 @@ public class CSRFAccount {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getStoredPassword() {
+        return storedPassword;
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
@@ -1,5 +1,7 @@
 package org.sasanlabs.service.vulnerability.csrf;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,7 +24,7 @@ public class CSRFSessionService {
     private static final String INVALID_TOKEN = "Invalid or missing CSRF token";
     private static final String INVALID_SESSION = "Invalid session";
 
-    private static final int TOKEN_HEADER_VALUE_DURATION_SECONDS = 120;
+    private static final long SESSION_TTL_MILLIS = 3600_000L;
 
     private final JdbcTemplate jdbcTemplate;
     private final SecureRandom secureRandom = new SecureRandom();
@@ -41,29 +43,44 @@ public class CSRFSessionService {
                                 + level
                                 + " WHERE username=?",
                         new Object[] {username},
-                        (rs, rowNum) -> {
-                            String stored = rs.getString("password");
-                            if (stored != null
-                                    && stored.contains(":")
-                                    && PasswordHashingUtils.isValidSaltedSha256(password, stored)) {
-                                return new CSRFAccount(
+                        (rs, rowNum) ->
+                                new CSRFAccount(
                                         rs.getInt("id"),
                                         rs.getString("username"),
-                                        rs.getString("email"));
-                            }
-                            return null;
-                        });
+                                        rs.getString("password"),
+                                        rs.getString("email")));
 
-        return accounts.stream().filter(account -> account != null).findFirst().orElse(null);
+        return accounts.stream()
+                .filter(
+                        account ->
+                                account.getStoredPassword() != null
+                                        && account.getStoredPassword().contains(":")
+                                        && PasswordHashingUtils.isValidSaltedSha256(
+                                                password, account.getStoredPassword()))
+                .map(
+                        account ->
+                                new CSRFAccount(
+                                        account.getId(),
+                                        account.getUsername(),
+                                        account.getEmail()))
+                .findFirst()
+                .orElse(null);
     }
 
     /** Creates a new session for the account and returns the opaque session token. */
     public String createSession(int level, CSRFAccount account) {
         String sessionToken = randomHex(32);
+        evictExpiredSessions();
         sessions.put(
                 sessionKey(level, sessionToken),
                 new CSRFLoginSession(account.getUsername(), account.getEmail()));
         return sessionToken;
+    }
+
+    private void evictExpiredSessions() {
+        long now = System.currentTimeMillis();
+        sessions.entrySet()
+                .removeIf(entry -> now - entry.getValue().getCreatedAt() > SESSION_TTL_MILLIS);
     }
 
     /** Returns a securely generated CSRF token stored with the session. */
@@ -87,9 +104,9 @@ public class CSRFSessionService {
     }
 
     /**
-     * Validates a weak (predictable) token of the form {@code username:epochSeconds}. The check
-     * passes for any token whose timestamp is within the allowed window, which makes the token
-     * guessable.
+     * Validates a weak (predictable) token of the form {@code username:epochSeconds}. The token
+     * remains valid for the entire session lifetime because the format itself is the weakness —
+     * any attacker who knows the username can forge a token with the current timestamp.
      */
     public boolean isValidWeakToken(CSRFLoginSession session, String tokenHeaderValue) {
         if (session == null || tokenHeaderValue == null) {
@@ -100,19 +117,21 @@ public class CSRFSessionService {
             return false;
         }
         try {
-            long tokenTime = Long.parseLong(parts[1]);
-            return Math.abs(System.currentTimeMillis() / 1000 - tokenTime)
-                    <= TOKEN_HEADER_VALUE_DURATION_SECONDS;
+            Long.parseLong(parts[1]);
+            return true;
         } catch (NumberFormatException e) {
             return false;
         }
     }
 
-    /** Strict comparison against the token stored with the session. */
+    /** Constant-time comparison against the token stored with the session. */
     public boolean isValidSecureToken(CSRFLoginSession session, String tokenHeaderValue) {
-        return session != null
-                && session.getCsrfToken() != null
-                && session.getCsrfToken().equals(tokenHeaderValue);
+        if (session == null || session.getCsrfToken() == null || tokenHeaderValue == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                session.getCsrfToken().getBytes(StandardCharsets.UTF_8),
+                tokenHeaderValue.getBytes(StandardCharsets.UTF_8));
     }
 
     /** Updates the email for the given account id in the level's table. */
@@ -169,8 +188,9 @@ public class CSRFSessionService {
     public static class CSRFLoginSession {
 
         private final String username;
-        private String email;
-        private String csrfToken;
+        private volatile String email;
+        private volatile String csrfToken;
+        private final long createdAt = System.currentTimeMillis();
 
         public CSRFLoginSession(String username, String email) {
             this.username = username;
@@ -195,6 +215,10 @@ public class CSRFSessionService {
 
         public void setCsrfToken(String csrfToken) {
             this.csrfToken = csrfToken;
+        }
+
+        public long getCreatedAt() {
+            return createdAt;
         }
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
@@ -60,9 +60,7 @@ public class CSRFSessionService {
                 .map(
                         account ->
                                 new CSRFAccount(
-                                        account.getId(),
-                                        account.getUsername(),
-                                        account.getEmail()))
+                                        account.getId(), account.getUsername(), account.getEmail()))
                 .findFirst()
                 .orElse(null);
     }
@@ -105,8 +103,8 @@ public class CSRFSessionService {
 
     /**
      * Validates a weak (predictable) token of the form {@code username:epochSeconds}. The token
-     * remains valid for the entire session lifetime because the format itself is the weakness -- any
-     * attacker who knows the username can forge a token with the current timestamp.
+     * remains valid for the entire session lifetime because the format itself is the weakness --
+     * any attacker who knows the username can forge a token with the current timestamp.
      */
     public boolean isValidWeakToken(CSRFLoginSession session, String tokenHeaderValue) {
         if (session == null || tokenHeaderValue == null) {

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
@@ -1,0 +1,200 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.sasanlabs.internal.utility.PasswordHashingUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Manages CSRF lab sessions and CSRF tokens.
+ *
+ * <p>Each level uses its own table, cookie and session namespace so that a state change in one
+ * level never affects the others.
+ */
+@Service
+public class CSRFSessionService {
+
+    private static final String INVALID_CREDENTIALS = "Invalid credentials";
+    private static final String NOT_LOGGED_IN = "Please login first";
+    private static final String INVALID_TOKEN = "Invalid or missing CSRF token";
+    private static final String INVALID_SESSION = "Invalid session";
+
+    private static final int TOKEN_HEADER_VALUE_DURATION_SECONDS = 120;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    private final ConcurrentMap<String, CSRFLoginSession> sessions = new ConcurrentHashMap<>();
+
+    public CSRFSessionService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /** Returns the account if credentials are valid, null otherwise. */
+    public CSRFAccount authenticate(int level, String username, String password) {
+        List<CSRFAccount> accounts =
+                jdbcTemplate.query(
+                        "SELECT id, username, password, email FROM csrf_accounts_l"
+                                + level
+                                + " WHERE username=?",
+                        new Object[] {username},
+                        (rs, rowNum) -> {
+                            String stored = rs.getString("password");
+                            if (stored != null
+                                    && stored.contains(":")
+                                    && PasswordHashingUtils.isValidSaltedSha256(password, stored)) {
+                                return new CSRFAccount(
+                                        rs.getInt("id"),
+                                        rs.getString("username"),
+                                        rs.getString("email"));
+                            }
+                            return null;
+                        });
+
+        return accounts.stream().filter(account -> account != null).findFirst().orElse(null);
+    }
+
+    /** Creates a new session for the account and returns the opaque session token. */
+    public String createSession(int level, CSRFAccount account) {
+        String sessionToken = randomHex(32);
+        sessions.put(
+                sessionKey(level, sessionToken),
+                new CSRFLoginSession(account.getUsername(), account.getEmail()));
+        return sessionToken;
+    }
+
+    /** Returns a securely generated CSRF token stored with the session. */
+    public String createSecureCsrfToken(int level, String sessionToken) {
+        String token = randomHex(32);
+        CSRFLoginSession session = getSession(level, sessionToken);
+        if (session == null) {
+            throw new IllegalArgumentException(INVALID_SESSION);
+        }
+        session.setCsrfToken(token);
+        return token;
+    }
+
+    /** Returns a predictably generated CSRF token (timestamp based, weak by design). */
+    public String createWeakCsrfToken(CSRFAccount account) {
+        return account.getUsername() + ":" + (System.currentTimeMillis() / 1000);
+    }
+
+    public CSRFLoginSession getSession(int level, String sessionToken) {
+        return sessions.get(sessionKey(level, sessionToken));
+    }
+
+    /**
+     * Validates a weak (predictable) token of the form {@code username:epochSeconds}. The check
+     * passes for any token whose timestamp is within the allowed window, which makes the token
+     * guessable.
+     */
+    public boolean isValidWeakToken(CSRFLoginSession session, String tokenHeaderValue) {
+        if (session == null || tokenHeaderValue == null) {
+            return false;
+        }
+        String[] parts = tokenHeaderValue.split(":", 2);
+        if (parts.length != 2 || !parts[0].equals(session.getUsername())) {
+            return false;
+        }
+        try {
+            long tokenTime = Long.parseLong(parts[1]);
+            return Math.abs(System.currentTimeMillis() / 1000 - tokenTime)
+                    <= TOKEN_HEADER_VALUE_DURATION_SECONDS;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /** Strict comparison against the token stored with the session. */
+    public boolean isValidSecureToken(CSRFLoginSession session, String tokenHeaderValue) {
+        return session != null
+                && session.getCsrfToken() != null
+                && session.getCsrfToken().equals(tokenHeaderValue);
+    }
+
+    /** Updates the email for the given account id in the level's table. */
+    public void updateEmail(int level, int accountId, String newEmail) {
+        jdbcTemplate.update(
+                "UPDATE csrf_accounts_l" + level + " SET email=? WHERE id=?", newEmail, accountId);
+    }
+
+    public String emailOf(int level, String sessionToken) {
+        CSRFLoginSession session = getSession(level, sessionToken);
+        return session == null ? null : session.getEmail();
+    }
+
+    public CSRFAccount accountByUsername(int level, String username) {
+        List<CSRFAccount> accounts =
+                jdbcTemplate.query(
+                        "SELECT id, username, email FROM csrf_accounts_l"
+                                + level
+                                + " WHERE username=?",
+                        new Object[] {username},
+                        (rs, rowNum) ->
+                                new CSRFAccount(
+                                        rs.getInt("id"),
+                                        rs.getString("username"),
+                                        rs.getString("email")));
+        return accounts.isEmpty() ? null : accounts.get(0);
+    }
+
+    public void refreshSessionEmail(int level, String sessionToken) {
+        CSRFLoginSession session = getSession(level, sessionToken);
+        if (session != null) {
+            CSRFAccount account = accountByUsername(level, session.getUsername());
+            if (account != null) {
+                session.setEmail(account.getEmail());
+            }
+        }
+    }
+
+    private String randomHex(int numBytes) {
+        byte[] bytes = new byte[numBytes];
+        secureRandom.nextBytes(bytes);
+        StringBuilder sb = new StringBuilder(numBytes * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private String sessionKey(int level, String sessionToken) {
+        return "L" + level + ":" + sessionToken;
+    }
+
+    /** Simple in-memory session holding the logged in account and optional CSRF token. */
+    public static class CSRFLoginSession {
+
+        private final String username;
+        private String email;
+        private String csrfToken;
+
+        public CSRFLoginSession(String username, String email) {
+            this.username = username;
+            this.email = email;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getCsrfToken() {
+            return csrfToken;
+        }
+
+        public void setCsrfToken(String csrfToken) {
+            this.csrfToken = csrfToken;
+        }
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
@@ -105,8 +105,8 @@ public class CSRFSessionService {
 
     /**
      * Validates a weak (predictable) token of the form {@code username:epochSeconds}. The token
-     * remains valid for the entire session lifetime because the format itself is the weakness —
-     * any attacker who knows the username can forge a token with the current timestamp.
+     * remains valid for the entire session lifetime because the format itself is the weakness -- any
+     * attacker who knows the username can forge a token with the current timestamp.
      */
     public boolean isValidWeakToken(CSRFLoginSession session, String tokenHeaderValue) {
         if (session == null || tokenHeaderValue == null) {

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionService.java
@@ -98,7 +98,16 @@ public class CSRFSessionService {
     }
 
     public CSRFLoginSession getSession(int level, String sessionToken) {
-        return sessions.get(sessionKey(level, sessionToken));
+        String key = sessionKey(level, sessionToken);
+        CSRFLoginSession session = sessions.get(key);
+        if (session != null) {
+            long now = System.currentTimeMillis();
+            if (now - session.getCreatedAt() > SESSION_TTL_MILLIS) {
+                sessions.remove(key);
+                return null;
+            }
+        }
+        return session;
     }
 
     /**

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
@@ -1,5 +1,6 @@
 package org.sasanlabs.service.vulnerability.csrf;
 
+import java.util.function.BiFunction;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -12,8 +13,10 @@ import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -82,7 +85,7 @@ public class CSRFVulnerability {
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1ChangeEmail(
             @CookieValue(value = "csrf_session_l1", required = false) String sessionToken,
             @RequestParam String email) {
-        return changeEmail(1, sessionToken, email, null, true);
+        return changeEmail(1, sessionToken, email, null, null);
     }
 
     @VulnerableAppRequestMapping(
@@ -134,7 +137,7 @@ public class CSRFVulnerability {
             @RequestParam String email) {
         // The token is read from the request but its value is never compared
         // against anything - the state change succeeds with any (or no) token.
-        return changeEmail(2, sessionToken, email, csrfToken, true);
+        return changeEmail(2, sessionToken, email, csrfToken, null);
     }
 
     @VulnerableAppRequestMapping(
@@ -184,23 +187,12 @@ public class CSRFVulnerability {
             @CookieValue(value = "csrf_session_l3", required = false) String sessionToken,
             @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
             @RequestParam String email) {
-        CSRFSessionService.CSRFLoginSession session =
-                csrfSessionService.getSession(3, sessionToken);
-        if (session == null) {
-            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
-        }
-        // The token format is username:epochSeconds, so an attacker who knows
-        // the victim's username can forge a valid token for the current window.
-        if (!csrfSessionService.isValidWeakToken(session, csrfToken)) {
-            return response(INVALID_TOKEN, false, HttpStatus.FORBIDDEN);
-        }
-        CSRFAccount account = csrfSessionService.accountByUsername(3, session.getUsername());
-        if (account == null) {
-            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
-        }
-        csrfSessionService.updateEmail(3, account.getId(), email);
-        csrfSessionService.refreshSessionEmail(3, sessionToken);
-        return response(EMAIL_UPDATED, true);
+        return changeEmail(
+                3,
+                sessionToken,
+                email,
+                csrfToken,
+                (session, token) -> csrfSessionService.isValidWeakToken(session, token));
     }
 
     @VulnerableAppRequestMapping(
@@ -250,7 +242,12 @@ public class CSRFVulnerability {
             @CookieValue(value = "csrf_session_l4", required = false) String sessionToken,
             @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
             @RequestParam String email) {
-        return changeEmail(4, sessionToken, email, csrfToken, false);
+        return changeEmail(
+                4,
+                sessionToken,
+                email,
+                csrfToken,
+                csrfSessionService::isValidSecureToken);
     }
 
     // The state-changing operation is also exposed over GET without any CSRF
@@ -263,7 +260,7 @@ public class CSRFVulnerability {
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4ChangeEmailViaGet(
             @CookieValue(value = "csrf_session_l4", required = false) String sessionToken,
             @RequestParam String email) {
-        return changeEmail(4, sessionToken, email, null, true);
+        return changeEmail(4, sessionToken, email, null, null);
     }
 
     @VulnerableAppRequestMapping(
@@ -315,7 +312,12 @@ public class CSRFVulnerability {
             @CookieValue(value = "csrf_session_l5", required = false) String sessionToken,
             @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
             @RequestParam String email) {
-        return changeEmail(5, sessionToken, email, csrfToken, false);
+        return changeEmail(
+                5,
+                sessionToken,
+                email,
+                csrfToken,
+                csrfSessionService::isValidSecureToken);
     }
 
     @VulnerableAppRequestMapping(
@@ -346,17 +348,17 @@ public class CSRFVulnerability {
 
         String sessionToken = csrfSessionService.createSession(level, account);
         if (level == 5) {
-            // javax.servlet 4.0 (Tomcat 9) has no Cookie#setAttribute, so the
-            // SameSite=Lax attribute is appended to the raw Set-Cookie header.
-            StringBuilder cookieHeader =
-                    new StringBuilder(cookieName)
-                            .append('=')
-                            .append(sessionToken)
-                            .append("; HttpOnly; Path=/; Max-Age=3600; SameSite=Lax");
+            ResponseCookie.ResponseCookieBuilder cookieBuilder =
+                    ResponseCookie.from(cookieName, sessionToken)
+                            .httpOnly(true)
+                            .path("/")
+                            .maxAge(3600)
+                            .sameSite("Lax");
             if (request.isSecure()) {
-                cookieHeader.append("; Secure");
+                cookieBuilder.secure(true);
             }
-            response.setHeader("Set-Cookie", cookieHeader.toString());
+            response.addHeader(
+                    HttpHeaders.SET_COOKIE, cookieBuilder.build().toString());
         } else {
             Cookie sessionCookie = new Cookie(cookieName, sessionToken);
             sessionCookie.setHttpOnly(true);
@@ -385,14 +387,14 @@ public class CSRFVulnerability {
             String sessionToken,
             String email,
             String csrfToken,
-            boolean ignoreTokenCheck) {
+            BiFunction<CSRFSessionService.CSRFLoginSession, String, Boolean> tokenValidator) {
         CSRFSessionService.CSRFLoginSession session =
                 csrfSessionService.getSession(level, sessionToken);
         if (session == null) {
             return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
         }
 
-        if (!ignoreTokenCheck && !csrfSessionService.isValidSecureToken(session, csrfToken)) {
+        if (tokenValidator != null && !tokenValidator.apply(session, csrfToken)) {
             return response(INVALID_TOKEN, false, HttpStatus.FORBIDDEN);
         }
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
@@ -185,8 +185,10 @@ public class CSRFVulnerability {
             htmlTemplate = "LEVEL_3/CSRF")
     public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3ChangeEmail(
             @CookieValue(value = "csrf_session_l3", required = false) String sessionToken,
-            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
+            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfTokenHeader,
+            @RequestParam(value = "csrfToken", required = false) String csrfTokenParam,
             @RequestParam String email) {
+        String csrfToken = csrfTokenHeader != null ? csrfTokenHeader : csrfTokenParam;
         return changeEmail(
                 3,
                 sessionToken,

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
@@ -1,0 +1,453 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * CSRF (Cross-Site Request Forgery) vulnerability lab.
+ *
+ * <p>Demonstrates how CSRF works against a modern REST API where authenticated users perform
+ * state-changing actions. The victim's session is carried in a cookie; depending on the level the
+ * backend either performs no CSRF protection at all, accepts a token without validating it,
+ * validates a predictable token, exposes the state change over GET, or enforces proper protection.
+ *
+ * @author mmustafasenoglu
+ */
+@Profile("public")
+@VulnerableAppRestController(descriptionLabel = "CSRF_VULNERABILITY", value = "CSRFVulnerability")
+public class CSRFVulnerability {
+
+    private static final String CSRF_TOKEN_HEADER = "X-CSRF-Token";
+    private static final String NOT_LOGGED_IN = "Please login first";
+    private static final String INVALID_CREDENTIALS = "Invalid credentials";
+    private static final String INVALID_TOKEN = "Invalid or missing CSRF token";
+    private static final String EMAIL_UPDATED = "Email updated successfully";
+
+    private final CSRFSessionService csrfSessionService;
+
+    public CSRFVulnerability(CSRFSessionService csrfSessionService) {
+        this.csrfSessionService = csrfSessionService;
+    }
+
+    // ------------------------------------------------------------------
+    // LEVEL 1 - No CSRF protection: session cookie alone is accepted
+    // ------------------------------------------------------------------
+
+    @ChallengeCard(
+            challengeText = "CSRF_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CSRF_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CSRF_LEVEL_1_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "CSRF_LEVEL_1_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CSRF_LEVEL_1_PAYLOAD_DESCRIPTION",
+                            value = "CSRF_PAYLOAD_LEVEL_1"))
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.CROSS_SITE_REQUEST_FORGERY,
+            description = "CSRF_LEVEL_1_NO_CSRF_PROTECTION")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_1,
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_1/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1Login(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return login(1, username, password, "csrf_session_l1", request, response);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_1/changeEmail",
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_1/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1ChangeEmail(
+            @CookieValue(value = "csrf_session_l1", required = false) String sessionToken,
+            @RequestParam String email) {
+        return changeEmail(1, sessionToken, email, null, true);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_1/account",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_1/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level1Account(
+            @CookieValue(value = "csrf_session_l1", required = false) String sessionToken) {
+        return accountResponse(1, sessionToken);
+    }
+
+    // ------------------------------------------------------------------
+    // LEVEL 2 - Token is sent but never validated
+    // ------------------------------------------------------------------
+
+    @ChallengeCard(
+            challengeText = "CSRF_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CSRF_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CSRF_LEVEL_2_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "CSRF_LEVEL_2_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CSRF_LEVEL_2_PAYLOAD_DESCRIPTION",
+                            value = "CSRF_PAYLOAD_LEVEL_2"))
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.CROSS_SITE_REQUEST_FORGERY,
+            description = "CSRF_LEVEL_2_TOKEN_NOT_VALIDATED")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_2,
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_2/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2Login(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return login(2, username, password, "csrf_session_l2", request, response);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_2/changeEmail",
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_2/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2ChangeEmail(
+            @CookieValue(value = "csrf_session_l2", required = false) String sessionToken,
+            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
+            @RequestParam String email) {
+        // The token is read from the request but its value is never compared
+        // against anything - the state change succeeds with any (or no) token.
+        return changeEmail(2, sessionToken, email, csrfToken, true);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_2/account",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_2/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level2Account(
+            @CookieValue(value = "csrf_session_l2", required = false) String sessionToken) {
+        return accountResponse(2, sessionToken);
+    }
+
+    // ------------------------------------------------------------------
+    // LEVEL 3 - Token is validated but generated predictably
+    // ------------------------------------------------------------------
+
+    @ChallengeCard(
+            challengeText = "CSRF_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CSRF_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CSRF_LEVEL_3_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "CSRF_LEVEL_3_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CSRF_LEVEL_3_PAYLOAD_DESCRIPTION",
+                            value = "CSRF_PAYLOAD_LEVEL_3"))
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.CROSS_SITE_REQUEST_FORGERY,
+            description = "CSRF_LEVEL_3_WEAK_TOKEN_GENERATION")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_3,
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_3/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3Login(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return login(3, username, password, "csrf_session_l3", request, response);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_3/changeEmail",
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_3/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3ChangeEmail(
+            @CookieValue(value = "csrf_session_l3", required = false) String sessionToken,
+            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
+            @RequestParam String email) {
+        CSRFSessionService.CSRFLoginSession session =
+                csrfSessionService.getSession(3, sessionToken);
+        if (session == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+        // The token format is username:epochSeconds, so an attacker who knows
+        // the victim's username can forge a valid token for the current window.
+        if (!csrfSessionService.isValidWeakToken(session, csrfToken)) {
+            return response(INVALID_TOKEN, false, HttpStatus.FORBIDDEN);
+        }
+        CSRFAccount account = csrfSessionService.accountByUsername(3, session.getUsername());
+        if (account == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+        csrfSessionService.updateEmail(3, account.getId(), email);
+        csrfSessionService.refreshSessionEmail(3, sessionToken);
+        return response(EMAIL_UPDATED, true);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_3/account",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_3/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level3Account(
+            @CookieValue(value = "csrf_session_l3", required = false) String sessionToken) {
+        return accountResponse(3, sessionToken);
+    }
+
+    // ------------------------------------------------------------------
+    // LEVEL 4 - POST is protected, but GET performs the state change
+    // ------------------------------------------------------------------
+
+    @ChallengeCard(
+            challengeText = "CSRF_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CSRF_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CSRF_LEVEL_4_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "CSRF_LEVEL_4_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CSRF_LEVEL_4_PAYLOAD_DESCRIPTION",
+                            value = "CSRF_PAYLOAD_LEVEL_4"))
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.CROSS_SITE_REQUEST_FORGERY,
+            description = "CSRF_LEVEL_4_STATE_CHANGING_GET")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_4,
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_4/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4Login(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return login(4, username, password, "csrf_session_l4", request, response);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_4/changeEmail",
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_4/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4ChangeEmail(
+            @CookieValue(value = "csrf_session_l4", required = false) String sessionToken,
+            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
+            @RequestParam String email) {
+        return changeEmail(4, sessionToken, email, csrfToken, false);
+    }
+
+    // The state-changing operation is also exposed over GET without any CSRF
+    // check - a top-level navigation (e.g. a link in a phishing email) carries
+    // the victim's session cookie and triggers the change.
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_4/changeEmail",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_4/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4ChangeEmailViaGet(
+            @CookieValue(value = "csrf_session_l4", required = false) String sessionToken,
+            @RequestParam String email) {
+        return changeEmail(4, sessionToken, email, null, true);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_4/account",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_4/CSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level4Account(
+            @CookieValue(value = "csrf_session_l4", required = false) String sessionToken) {
+        return accountResponse(4, sessionToken);
+    }
+
+    // ------------------------------------------------------------------
+    // LEVEL 5 - Secure CSRF protection
+    // ------------------------------------------------------------------
+
+    @ChallengeCard(
+            challengeText = "CSRF_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CSRF_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CSRF_LEVEL_5_HINT_2"),
+                @ChallengeCard.Hint(order = 3, text = "CSRF_LEVEL_5_HINT_3")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CSRF_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "CSRF_PAYLOAD_LEVEL_5"))
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.CROSS_SITE_REQUEST_FORGERY,
+            description = "CSRF_LEVEL_5_SECURE_PROTECTION")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_5,
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_5/CSRF",
+            variant = Variant.SECURE)
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5Login(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return login(5, username, password, "csrf_session_l5", request, response);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_5/changeEmail",
+            requestMethod = RequestMethod.POST,
+            htmlTemplate = "LEVEL_5/CSRF",
+            variant = Variant.SECURE)
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5ChangeEmail(
+            @CookieValue(value = "csrf_session_l5", required = false) String sessionToken,
+            @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
+            @RequestParam String email) {
+        return changeEmail(5, sessionToken, email, csrfToken, false);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = "LEVEL_5/account",
+            requestMethod = RequestMethod.GET,
+            htmlTemplate = "LEVEL_5/CSRF",
+            variant = Variant.SECURE)
+    public ResponseEntity<GenericVulnerabilityResponseBean<Object>> level5Account(
+            @CookieValue(value = "csrf_session_l5", required = false) String sessionToken) {
+        return accountResponse(5, sessionToken);
+    }
+
+    // ------------------------------------------------------------------
+    // Shared helpers
+    // ------------------------------------------------------------------
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<Object>> login(
+            int level,
+            String username,
+            String password,
+            String cookieName,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        CSRFAccount account = csrfSessionService.authenticate(level, username, password);
+        if (account == null) {
+            return response(INVALID_CREDENTIALS, false);
+        }
+
+        String sessionToken = csrfSessionService.createSession(level, account);
+        if (level == 5) {
+            // javax.servlet 4.0 (Tomcat 9) has no Cookie#setAttribute, so the
+            // SameSite=Lax attribute is appended to the raw Set-Cookie header.
+            StringBuilder cookieHeader =
+                    new StringBuilder(cookieName)
+                            .append('=')
+                            .append(sessionToken)
+                            .append("; HttpOnly; Path=/; Max-Age=3600; SameSite=Lax");
+            if (request.isSecure()) {
+                cookieHeader.append("; Secure");
+            }
+            response.setHeader("Set-Cookie", cookieHeader.toString());
+        } else {
+            Cookie sessionCookie = new Cookie(cookieName, sessionToken);
+            sessionCookie.setHttpOnly(true);
+            sessionCookie.setPath("/");
+            sessionCookie.setMaxAge(3600);
+            sessionCookie.setSecure(request.isSecure());
+            response.addCookie(sessionCookie);
+        }
+
+        // The CSRF token is delivered during login and kept in the page
+        // (React-like runtime memory) rather than in a cookie.
+        if (level == 2 || level == 4 || level == 5) {
+            String csrfToken = csrfSessionService.createSecureCsrfToken(level, sessionToken);
+            return response(new CSRFLoginResponse(account, csrfToken), true);
+        }
+        if (level == 3) {
+            return response(
+                    new CSRFLoginResponse(account, csrfSessionService.createWeakCsrfToken(account)),
+                    true);
+        }
+        return response(account, true);
+    }
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<Object>> changeEmail(
+            int level,
+            String sessionToken,
+            String email,
+            String csrfToken,
+            boolean ignoreTokenCheck) {
+        CSRFSessionService.CSRFLoginSession session =
+                csrfSessionService.getSession(level, sessionToken);
+        if (session == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+
+        if (!ignoreTokenCheck && !csrfSessionService.isValidSecureToken(session, csrfToken)) {
+            return response(INVALID_TOKEN, false, HttpStatus.FORBIDDEN);
+        }
+
+        CSRFAccount account = csrfSessionService.accountByUsername(level, session.getUsername());
+        if (account == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+        csrfSessionService.updateEmail(level, account.getId(), email);
+        csrfSessionService.refreshSessionEmail(level, sessionToken);
+        return response(EMAIL_UPDATED, true);
+    }
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<Object>> accountResponse(
+            int level, String sessionToken) {
+        CSRFSessionService.CSRFLoginSession session =
+                csrfSessionService.getSession(level, sessionToken);
+        if (session == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+        CSRFAccount account = csrfSessionService.accountByUsername(level, session.getUsername());
+        if (account == null) {
+            return response(NOT_LOGGED_IN, false, HttpStatus.UNAUTHORIZED);
+        }
+        return response(account, true);
+    }
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<Object>> response(
+            Object content, boolean isValid) {
+        return new ResponseEntity<>(
+                new GenericVulnerabilityResponseBean<>(content, isValid), HttpStatus.OK);
+    }
+
+    private ResponseEntity<GenericVulnerabilityResponseBean<Object>> response(
+            Object content, boolean isValid, HttpStatus status) {
+        return new ResponseEntity<>(
+                new GenericVulnerabilityResponseBean<>(content, isValid), status);
+    }
+
+    /** Response bean carrying the logged in account and (when applicable) the CSRF token. */
+    public static class CSRFLoginResponse {
+
+        private final CSRFAccount account;
+        private final String csrfToken;
+
+        public CSRFLoginResponse(CSRFAccount account, String csrfToken) {
+            this.account = account;
+            this.csrfToken = csrfToken;
+        }
+
+        public CSRFAccount getAccount() {
+            return account;
+        }
+
+        public String getCsrfToken() {
+            return csrfToken;
+        }
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
@@ -15,8 +15,8 @@ import org.sasanlabs.vulnerability.types.VulnerabilityType;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -243,11 +243,7 @@ public class CSRFVulnerability {
             @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
             @RequestParam String email) {
         return changeEmail(
-                4,
-                sessionToken,
-                email,
-                csrfToken,
-                csrfSessionService::isValidSecureToken);
+                4, sessionToken, email, csrfToken, csrfSessionService::isValidSecureToken);
     }
 
     // The state-changing operation is also exposed over GET without any CSRF
@@ -313,11 +309,7 @@ public class CSRFVulnerability {
             @RequestHeader(value = CSRF_TOKEN_HEADER, required = false) String csrfToken,
             @RequestParam String email) {
         return changeEmail(
-                5,
-                sessionToken,
-                email,
-                csrfToken,
-                csrfSessionService::isValidSecureToken);
+                5, sessionToken, email, csrfToken, csrfSessionService::isValidSecureToken);
     }
 
     @VulnerableAppRequestMapping(

--- a/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerability.java
@@ -349,8 +349,7 @@ public class CSRFVulnerability {
             if (request.isSecure()) {
                 cookieBuilder.secure(true);
             }
-            response.addHeader(
-                    HttpHeaders.SET_COOKIE, cookieBuilder.build().toString());
+            response.addHeader(HttpHeaders.SET_COOKIE, cookieBuilder.build().toString());
         } else {
             Cookie sessionCookie = new Cookie(cookieName, sessionToken);
             sessionCookie.setHttpOnly(true);

--- a/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java
+++ b/src/main/java/org/sasanlabs/vulnerability/types/VulnerabilityType.java
@@ -49,6 +49,9 @@ public enum VulnerabilityType {
     // IDOR - Broken Access Control
     INSECURE_DIRECT_OBJECT_REFERENCE(639, 13),
 
+    // CSRF - Cross-Site Request Forgery
+    CROSS_SITE_REQUEST_FORGERY(352, 9),
+
     // Clickjacking
     CLICKJACKING(1021, null),
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1098,12 +1098,12 @@ CSRF_PAYLOAD_LEVEL_2=curl -X POST -H "X-CSRF-Token: 1234" -b "csrf_session_l2=VI
 
 CSRF_LEVEL_3_WEAK_TOKEN_GENERATION=The token is validated server side, but it is generated from the username and the current timestamp, so an attacker can forge a valid token without knowing the victim's password.
 
-CSRF_LEVEL_3_CHALLENGE=The server validates the X-CSRF-Token header, but the token is generated from the username and the current timestamp. Forge a valid token for the victim and change the victim's email.
+CSRF_LEVEL_3_CHALLENGE=The server validates the CSRF token, but the token is generated from the username and the current timestamp. Forge a valid token for the victim and change the victim's email via a cross-site form submission.
 CSRF_LEVEL_3_HINT_1=Login as the attacker (attacker / Attacker@123) and inspect the token returned after login.
-CSRF_LEVEL_3_HINT_2=The token format is username:epochSeconds. Tokens are accepted within a two minute window.
-CSRF_LEVEL_3_HINT_3=Build a token as victim:<current epoch seconds> and send it with the victim's session cookie: curl -X POST -H "X-CSRF-Token: victim:$(date +%s)" -b "csrf_session_l3=<cookie>" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail
-CSRF_LEVEL_3_PAYLOAD_DESCRIPTION=Cross-site request that changes the victim's email using a forged predictable token
-CSRF_PAYLOAD_LEVEL_3=curl -X POST -H "X-CSRF-Token: victim:$(date +%s)" -b "csrf_session_l3=VICTIM_SESSION" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail
+CSRF_LEVEL_3_HINT_2=The token format is username:epochSeconds. Any numeric timestamp is accepted.
+CSRF_LEVEL_3_HINT_3=Build a token as victim:<current epoch seconds> and submit a cross-site form with the token in a hidden field: <form action=".../LEVEL_3/changeEmail" method="POST"><input name="csrfToken" value="victim:$(date +%s)" /><input name="email" value="attacker@example.com" /></form>
+CSRF_LEVEL_3_PAYLOAD_DESCRIPTION=Cross-site form submission that changes the victim's email using a forged predictable token
+CSRF_PAYLOAD_LEVEL_3=<form action="/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail" method="POST"><input type="hidden" name="csrfToken" value="victim:1700000000" /><input type="hidden" name="email" value="attacker@example.com" /></form><script>document.forms[0].submit()</script>
 
 CSRF_LEVEL_4_STATE_CHANGING_GET=The POST endpoint is properly protected with a validated token, but the same state-changing operation is also exposed over GET without any CSRF check.
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1064,3 +1064,61 @@ PERSISTENT_XSS_LEVEL7_HINT2=Even the null-byte-prefix trick that worked on level
 PERSISTENT_XSS_LEVEL7_PAYLOAD_DESCRIPTION=The same null-byte-prefixed script payload that broke level 6 is now fully escaped and rendered as inert text.
 PERSISTENT_XSS_LEVEL7_PAYLOAD_VALUE=%00<script>alert(1)</script>
 BLIND_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE2_PAYLOAD_VALUE=1 AND (SELECT SUBSTRING(password,1,1) FROM auth_users WHERE username='admin_sqli')='n'
+
+# -------------------------------------------
+# CSRF Vulnerability Lab
+# -------------------------------------------
+CSRF_VULNERABILITY=<b>Cross-Site Request Forgery (CSRF)</b> is an attack that forces an authenticated user to execute unwanted state-changing actions in a web application. \
+The browser automatically attaches the victim's authentication cookies to requests, so a malicious site can submit a forged request that the server cannot distinguish from a legitimate one. \
+CSRF is commonly discussed in the Broken Access Control category in the OWASP security framework and the OWASP Top 10.\<br/><br/>\
+This lab demonstrates the classic CSRF progression against a REST API: no protection, a token that is not validated, a predictable token, a state-changing GET request, and finally a properly protected implementation.\<br/><br/>\
+Important Links:<br/>\
+<ol> \
+<li> <a href="https://owasp.org/www-community/attacks/csrf" target="_blank">OWASP CSRF</a></li> \
+<li> <a href="https://cwe.mitre.org/data/definitions/352.html" target="_blank">CWE-352: Cross-Site Request Forgery</a></li> \
+</ol>
+
+CSRF_LEVEL_1_NO_CSRF_PROTECTION=The change email endpoint relies only on the session cookie. No CSRF token is generated or validated.
+
+CSRF_LEVEL_1_CHALLENGE=You are the attacker. The victim (victim / Victim@123) is already logged in. Change the victim's account email to attacker@example.com without knowing the victim's password.
+CSRF_LEVEL_1_HINT_1=Login as the victim in this page to obtain the session cookie.
+CSRF_LEVEL_1_HINT_2=The change email endpoint only checks the session cookie. Create a request that includes the victim's session cookie but is sent from an external origin.
+CSRF_LEVEL_1_HINT_3=For example with curl: curl -X POST -b "csrf_session_l1=<cookie>" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_1/changeEmail
+CSRF_LEVEL_1_PAYLOAD_DESCRIPTION=Cross-site request that changes the victim's email using only the session cookie
+CSRF_PAYLOAD_LEVEL_1=curl -X POST -b "csrf_session_l1=VICTIM_SESSION" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_1/changeEmail
+
+CSRF_LEVEL_2_TOKEN_NOT_VALIDATED=The application generates a CSRF token and returns it after login, but the change email endpoint reads the X-CSRF-Token header and never validates it.
+
+CSRF_LEVEL_2_CHALLENGE=The victim's email change endpoint requires an X-CSRF-Token header. Send any value (or none) in that header and still change the victim's email.
+CSRF_LEVEL_2_HINT_1=Login as the victim and note that the page receives a CSRF token after login.
+CSRF_LEVEL_2_HINT_2=The server reads the X-CSRF-Token header but ignores its value - there is no comparison anywhere.
+CSRF_LEVEL_2_HINT_3=Send the change request with a random header value: curl -X POST -H "X-CSRF-Token: anything" -b "csrf_session_l2=<cookie>" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_2/changeEmail
+CSRF_LEVEL_2_PAYLOAD_DESCRIPTION=Cross-site request that changes the victim's email with an unvalidated token header
+CSRF_PAYLOAD_LEVEL_2=curl -X POST -H "X-CSRF-Token: 1234" -b "csrf_session_l2=VICTIM_SESSION" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_2/changeEmail
+
+CSRF_LEVEL_3_WEAK_TOKEN_GENERATION=The token is validated server side, but it is generated from the username and the current timestamp, so an attacker can forge a valid token without knowing the victim's password.
+
+CSRF_LEVEL_3_CHALLENGE=The server validates the X-CSRF-Token header, but the token is generated from the username and the current timestamp. Forge a valid token for the victim and change the victim's email.
+CSRF_LEVEL_3_HINT_1=Login as the attacker (attacker / Attacker@123) and inspect the token returned after login.
+CSRF_LEVEL_3_HINT_2=The token format is username:epochSeconds. Tokens are accepted within a two minute window.
+CSRF_LEVEL_3_HINT_3=Build a token as victim:<current epoch seconds> and send it with the victim's session cookie: curl -X POST -H "X-CSRF-Token: victim:$(date +%s)" -b "csrf_session_l3=<cookie>" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail
+CSRF_LEVEL_3_PAYLOAD_DESCRIPTION=Cross-site request that changes the victim's email using a forged predictable token
+CSRF_PAYLOAD_LEVEL_3=curl -X POST -H "X-CSRF-Token: victim:$(date +%s)" -b "csrf_session_l3=VICTIM_SESSION" -d "email=attacker@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail
+
+CSRF_LEVEL_4_STATE_CHANGING_GET=The POST endpoint is properly protected with a validated token, but the same state-changing operation is also exposed over GET without any CSRF check.
+
+CSRF_LEVEL_4_CHALLENGE=The POST change email request is protected by a valid CSRF token. Find another way to trigger the email change without knowing the token.
+CSRF_LEVEL_4_HINT_1=Login as the victim and use the page normally to change the email - the POST endpoint validates the token.
+CSRF_LEVEL_4_HINT_2=Check whether the same operation is also available over GET. GET requests cannot carry custom headers.
+CSRF_LEVEL_4_HINT_3=A top-level navigation carries the session cookie. Open this link while logged in: /VulnerableApp/CSRFVulnerability/LEVEL_4/changeEmail?email=attacker@example.com
+CSRF_LEVEL_4_PAYLOAD_DESCRIPTION=Cross-site request that changes the victim's email via a state-changing GET request
+CSRF_PAYLOAD_LEVEL_4=<a href="/VulnerableApp/CSRFVulnerability/LEVEL_4/changeEmail?email=attacker@example.com">Click to change victim's email</a>
+
+CSRF_LEVEL_5_SECURE_PROTECTION=The application uses an unpredictable server-side token, validates the X-CSRF-Token header on every state change, marks the session cookie with SameSite=Lax and never exposes the operation over GET.
+
+CSRF_LEVEL_5_CHALLENGE=All previous attacks now fail. Understand why the request is rejected without a valid token, and confirm that the legitimate flow still works.
+CSRF_LEVEL_5_HINT_1=Login as the victim and change the email through the page - the flow carries the token received at login.
+CSRF_LEVEL_5_HINT_2=Now repeat the same request without the X-CSRF-Token header (or with the wrong value) and observe the rejection.
+CSRF_LEVEL_5_HINT_3=The session cookie is also SameSite=Lax, so browsers do not even attach it to cross-site POST requests.
+CSRF_LEVEL_5_PAYLOAD_DESCRIPTION=Legitimate request that includes the server-issued CSRF token
+CSRF_PAYLOAD_LEVEL_5=curl -X POST -H "X-CSRF-Token: <token from login response>" -b "csrf_session_l5=<cookie>" -d "email=victim@example.com" http://localhost:9090/VulnerableApp/CSRFVulnerability/LEVEL_5/changeEmail

--- a/src/main/resources/scripts/CSRF/db/data.sql
+++ b/src/main/resources/scripts/CSRF/db/data.sql
@@ -1,0 +1,10 @@
+INSERT INTO csrf_accounts_l1 VALUES (1, 'victim', 'CSRF_SALT_L1:f5e2a35c9dac8a96fbe2ddf38a7694cf5177ed293bc6e600236ae8aefb677407', 'victim@example.com');
+INSERT INTO csrf_accounts_l1 VALUES (2, 'attacker', 'CSRF_SALT_L1:d6f84008e9cbadae9ed05181db30fd185ab79266574e388ccda0aaa30f6f525f', 'attacker@example.com');
+INSERT INTO csrf_accounts_l2 VALUES (1, 'victim', 'CSRF_SALT_L2:d49608978e2ed53cf73f57fdba1fc49c77149a237bb52b5db45be28267d4d3d8', 'victim@example.com');
+INSERT INTO csrf_accounts_l2 VALUES (2, 'attacker', 'CSRF_SALT_L2:5aee8e1fc08a785ba8c506ec08afbced0689f20a4b5f6c4c41d4bdd0a08215e5', 'attacker@example.com');
+INSERT INTO csrf_accounts_l3 VALUES (1, 'victim', 'CSRF_SALT_L3:ecad93df0a7647c1ec08c295f48b3a6e7805b936616571b86c67a36c4aa2dd41', 'victim@example.com');
+INSERT INTO csrf_accounts_l3 VALUES (2, 'attacker', 'CSRF_SALT_L3:4e46dc613de300bb4d38a2b291f5e9fa4e4791be1cdacb87876889b7dd24f062', 'attacker@example.com');
+INSERT INTO csrf_accounts_l4 VALUES (1, 'victim', 'CSRF_SALT_L4:188f5110e871f562a71c5ac61415560d2f445a1e2cab733a761703bc155e7a73', 'victim@example.com');
+INSERT INTO csrf_accounts_l4 VALUES (2, 'attacker', 'CSRF_SALT_L4:1d452cb5d992f0481aa9d24b1c5c108fe0a8857132088b3c755a8e9ce2d5e2ee', 'attacker@example.com');
+INSERT INTO csrf_accounts_l5 VALUES (1, 'victim', 'CSRF_SALT_L5:c5896a95c341d90a254c6ce4cbf6b897ef8e94c832035159e2e4ec9e705ce0ed', 'victim@example.com');
+INSERT INTO csrf_accounts_l5 VALUES (2, 'attacker', 'CSRF_SALT_L5:ac33445e397fe2a17338816998d9835da6c85480b96f4e98dba87ca2d6f8b34b', 'attacker@example.com');

--- a/src/main/resources/scripts/CSRF/db/schema.sql
+++ b/src/main/resources/scripts/CSRF/db/schema.sql
@@ -1,0 +1,46 @@
+DROP TABLE IF EXISTS csrf_accounts_l1;
+DROP TABLE IF EXISTS csrf_accounts_l2;
+DROP TABLE IF EXISTS csrf_accounts_l3;
+DROP TABLE IF EXISTS csrf_accounts_l4;
+DROP TABLE IF EXISTS csrf_accounts_l5;
+
+CREATE TABLE csrf_accounts_l1 (
+    id INT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(500),
+    email VARCHAR(100)
+);
+
+CREATE TABLE csrf_accounts_l2 (
+    id INT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(500),
+    email VARCHAR(100)
+);
+
+CREATE TABLE csrf_accounts_l3 (
+    id INT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(500),
+    email VARCHAR(100)
+);
+
+CREATE TABLE csrf_accounts_l4 (
+    id INT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(500),
+    email VARCHAR(100)
+);
+
+CREATE TABLE csrf_accounts_l5 (
+    id INT PRIMARY KEY,
+    username VARCHAR(50),
+    password VARCHAR(500),
+    email VARCHAR(100)
+);
+
+GRANT SELECT, UPDATE ON csrf_accounts_l1 TO application;
+GRANT SELECT, UPDATE ON csrf_accounts_l2 TO application;
+GRANT SELECT, UPDATE ON csrf_accounts_l3 TO application;
+GRANT SELECT, UPDATE ON csrf_accounts_l4 TO application;
+GRANT SELECT, UPDATE ON csrf_accounts_l5 TO application;

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.css
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.css
@@ -1,0 +1,123 @@
+.csrf-shell {
+    width: 100%;
+    max-width: 600px;
+    margin: 12px auto;
+    padding: 6px;
+    box-sizing: border-box;
+    text-align: center;
+    color: black;
+}
+
+.csrf-title {
+    margin: 0 0 6px;
+    font-size: 22px;
+}
+
+.csrf-subtitle {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+
+.csrf-card {
+    border: 1px solid black;
+    border-radius: 4px;
+    border-left: 6px solid burlywood;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.csrf-card + .csrf-card {
+    margin-top: 16px;
+}
+
+.csrf-card h5 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.csrf-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.csrf-field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.csrf-field label {
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.csrf-field input,
+.csrf-field select {
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-size: 13px;
+    min-width: 150px;
+}
+
+.csrf-card button {
+    padding: 5px 14px;
+    border: 1px solid black;
+    border-radius: 3px;
+    background: burlywood;
+    color: black;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.csrf-card button:hover {
+    background: #d2a55c;
+}
+
+.status-message {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.login-pill {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: #d4edda;
+    border: 1px solid #28a745;
+    font-size: 13px;
+}
+
+.token-box {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #f8f9fa;
+    border: 1px dashed #888;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    text-align: left;
+}
+
+.csrf-attack-note {
+    margin-top: 8px;
+    padding: 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: left;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.html
@@ -1,0 +1,46 @@
+<div id="csrf_ui" class="csrf-shell">
+    <h3 class="csrf-title">CSRF Vulnerability - Level 1</h3>
+    <p class="csrf-subtitle">
+        No CSRF protection: the email change endpoint only checks the session
+        cookie.
+    </p>
+
+    <div class="csrf-card">
+        <h5>Login</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l1_username">Username</label>
+                <select id="csrf_l1_username">
+                    <option value="victim">victim</option>
+                    <option value="attacker">attacker</option>
+                </select>
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l1_password">Password</label>
+                <input type="password" id="csrf_l1_password" value="Victim@123" />
+            </div>
+            <button id="csrf_l1_login_btn">Login</button>
+        </div>
+        <div class="hidden" id="csrf_l1_login_state"></div>
+        <div class="status-message" id="csrf_l1_login_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l1_new_email">New email</label>
+                <input type="text" id="csrf_l1_new_email" value="attacker@example.com" />
+            </div>
+            <button id="csrf_l1_change_btn">Change Email</button>
+        </div>
+        <div class="status-message" id="csrf_l1_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Account</h5>
+        <div class="status-message" id="csrf_l1_account_msg"></div>
+        <button id="csrf_l1_account_btn">Show Current Email</button>
+    </div>
+</div>
+<script src="/VulnerableApp/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js"></script>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.html
@@ -18,6 +18,12 @@
             <div class="csrf-field">
                 <label for="csrf_l1_password">Password</label>
                 <input type="password" id="csrf_l1_password" value="Victim@123" />
+                <script>
+                document.getElementById("csrf_l1_username").addEventListener("change", function() {
+                    document.getElementById("csrf_l1_password").value =
+                        this.value === "attacker" ? "Attacker@123" : "Victim@123";
+                });
+                </script>
             </div>
             <button id="csrf_l1_login_btn">Login</button>
         </div>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
@@ -17,7 +17,7 @@
     b.textContent = account.username;
     pill.appendChild(b);
     pill.appendChild(
-        document.createTextNode(" (email: " + account.email + ")")
+      document.createTextNode(" (email: " + account.email + ")"),
     );
     loginState.appendChild(pill);
   }
@@ -44,7 +44,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data
+        data,
       );
     });
 
@@ -65,7 +65,7 @@
         },
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
-        data
+        data,
       );
     });
 
@@ -90,7 +90,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true
+        true,
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
@@ -16,7 +16,9 @@
     var b = document.createElement("b");
     b.textContent = account.username;
     pill.appendChild(b);
-    pill.appendChild(document.createTextNode(" (email: " + account.email + ")"));
+    pill.appendChild(
+        document.createTextNode(" (email: " + account.email + ")")
+    );
     loginState.appendChild(pill);
   }
 

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
@@ -9,12 +9,15 @@
 
   function showLoginState(account) {
     loginState.classList.remove("hidden");
-    loginState.innerHTML =
-      '<div class="login-pill">Logged in as <b>' +
-      account.username +
-      "</b> (email: " +
-      account.email +
-      ")</div>";
+    loginState.textContent = "";
+    var pill = document.createElement("div");
+    pill.className = "login-pill";
+    pill.appendChild(document.createTextNode("Logged in as "));
+    var b = document.createElement("b");
+    b.textContent = account.username;
+    pill.appendChild(b);
+    pill.appendChild(document.createTextNode(" (email: " + account.email + ")"));
+    loginState.appendChild(pill);
   }
 
   document
@@ -71,13 +74,17 @@
       doGetAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            accountMsg.innerHTML =
-              '<span style="color:green">Current email: ' +
-              response.content.email +
-              "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = "Current email: " + response.content.email;
+            accountMsg.appendChild(s);
           } else {
-            accountMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            accountMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/account",

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
@@ -17,7 +17,7 @@
     b.textContent = account.username;
     pill.appendChild(b);
     pill.appendChild(
-      document.createTextNode(" (email: " + account.email + ")"),
+      document.createTextNode(" (email: " + account.email + ")")
     );
     loginState.appendChild(pill);
   }
@@ -44,7 +44,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data,
+        data
       );
     });
 
@@ -65,7 +65,7 @@
         },
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
-        data,
+        data
       );
     });
 
@@ -90,7 +90,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true,
+        true
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_1/CSRF.js
@@ -1,0 +1,87 @@
+(function () {
+  const username = document.getElementById("csrf_l1_username");
+  const password = document.getElementById("csrf_l1_password");
+  const newEmail = document.getElementById("csrf_l1_new_email");
+  const loginState = document.getElementById("csrf_l1_login_state");
+  const loginMsg = document.getElementById("csrf_l1_login_msg");
+  const changeMsg = document.getElementById("csrf_l1_change_msg");
+  const accountMsg = document.getElementById("csrf_l1_account_msg");
+
+  function showLoginState(account) {
+    loginState.classList.remove("hidden");
+    loginState.innerHTML =
+      '<div class="login-pill">Logged in as <b>' +
+      account.username +
+      "</b> (email: " +
+      account.email +
+      ")</div>";
+  }
+
+  document
+    .getElementById("csrf_l1_login_btn")
+    .addEventListener("click", function () {
+      loginMsg.innerHTML = "";
+      const data =
+        "username=" +
+        encodeURIComponent(username.value) +
+        "&password=" +
+        encodeURIComponent(password.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            showLoginState(response.content);
+            loginMsg.innerHTML =
+              '<span style="color:green">Login successful</span>';
+          } else {
+            loginMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel(),
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l1_change_btn")
+    .addEventListener("click", function () {
+      changeMsg.innerHTML = "";
+      const data = "email=" + encodeURIComponent(newEmail.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            changeMsg.innerHTML =
+              '<span style="color:green">' + response.content + "</span>";
+          } else {
+            changeMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/changeEmail",
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l1_account_btn")
+    .addEventListener("click", function () {
+      accountMsg.innerHTML = "";
+      doGetAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            accountMsg.innerHTML =
+              '<span style="color:green">Current email: ' +
+              response.content.email +
+              "</span>";
+          } else {
+            accountMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/account",
+        true
+      );
+    });
+})();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.css
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.css
@@ -1,0 +1,123 @@
+.csrf-shell {
+    width: 100%;
+    max-width: 600px;
+    margin: 12px auto;
+    padding: 6px;
+    box-sizing: border-box;
+    text-align: center;
+    color: black;
+}
+
+.csrf-title {
+    margin: 0 0 6px;
+    font-size: 22px;
+}
+
+.csrf-subtitle {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+
+.csrf-card {
+    border: 1px solid black;
+    border-radius: 4px;
+    border-left: 6px solid burlywood;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.csrf-card + .csrf-card {
+    margin-top: 16px;
+}
+
+.csrf-card h5 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.csrf-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.csrf-field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.csrf-field label {
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.csrf-field input,
+.csrf-field select {
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-size: 13px;
+    min-width: 150px;
+}
+
+.csrf-card button {
+    padding: 5px 14px;
+    border: 1px solid black;
+    border-radius: 3px;
+    background: burlywood;
+    color: black;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.csrf-card button:hover {
+    background: #d2a55c;
+}
+
+.status-message {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.login-pill {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: #d4edda;
+    border: 1px solid #28a745;
+    font-size: 13px;
+}
+
+.token-box {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #f8f9fa;
+    border: 1px dashed #888;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    text-align: left;
+}
+
+.csrf-attack-note {
+    margin-top: 8px;
+    padding: 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: left;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.html
@@ -18,6 +18,12 @@
             <div class="csrf-field">
                 <label for="csrf_l2_password">Password</label>
                 <input type="password" id="csrf_l2_password" value="Victim@123" />
+                <script>
+                document.getElementById("csrf_l2_username").addEventListener("change", function() {
+                    document.getElementById("csrf_l2_password").value =
+                        this.value === "attacker" ? "Attacker@123" : "Victim@123";
+                });
+                </script>
             </div>
             <button id="csrf_l2_login_btn">Login</button>
         </div>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.html
@@ -1,0 +1,50 @@
+<div id="csrf_ui" class="csrf-shell">
+    <h3 class="csrf-title">CSRF Vulnerability - Level 2</h3>
+    <p class="csrf-subtitle">
+        The server issues a CSRF token after login, but the email change
+        endpoint reads the X-CSRF-Token header and never validates it.
+    </p>
+
+    <div class="csrf-card">
+        <h5>Login</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l2_username">Username</label>
+                <select id="csrf_l2_username">
+                    <option value="victim">victim</option>
+                    <option value="attacker">attacker</option>
+                </select>
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l2_password">Password</label>
+                <input type="password" id="csrf_l2_password" value="Victim@123" />
+            </div>
+            <button id="csrf_l2_login_btn">Login</button>
+        </div>
+        <div class="hidden" id="csrf_l2_login_state"></div>
+        <div class="status-message" id="csrf_l2_login_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l2_new_email">New email</label>
+                <input type="text" id="csrf_l2_new_email" value="attacker@example.com" />
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l2_token">X-CSRF-Token value</label>
+                <input type="text" id="csrf_l2_token" value="anything" />
+            </div>
+            <button id="csrf_l2_change_btn">Change Email</button>
+        </div>
+        <div class="status-message" id="csrf_l2_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Account</h5>
+        <div class="status-message" id="csrf_l2_account_msg"></div>
+        <button id="csrf_l2_account_btn">Show Current Email</button>
+    </div>
+</div>
+<script src="/VulnerableApp/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js"></script>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
@@ -17,7 +17,9 @@
     var bUser = document.createElement("b");
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
-    pill.appendChild(document.createTextNode(" (email: " + account.account.email + ")"));
+    pill.appendChild(
+        document.createTextNode(" (email: " + account.account.email + ")")
+    );
     loginState.appendChild(pill);
 
     var tokenBox = document.createElement("div");
@@ -26,8 +28,11 @@
     var bToken = document.createElement("b");
     bToken.textContent = account.csrfToken;
     tokenBox.appendChild(bToken);
-    tokenBox.appendChild(document.createTextNode(
-      "\nThe page is expected to echo it back in the X-CSRF-Token header."));
+    tokenBox.appendChild(
+        document.createTextNode(
+            "\nThe page is expected to echo it back in the X-CSRF-Token header."
+        )
+    );
     loginState.appendChild(tokenBox);
   }
 
@@ -78,8 +83,9 @@
             var bTok = document.createElement("b");
             bTok.textContent = tokenInput.value;
             note.appendChild(bTok);
-            note.appendChild(document.createTextNode(
-              " was accepted - it is never validated."));
+            note.appendChild(
+                document.createTextNode(" was accepted - it is never validated.")
+            );
             changeMsg.appendChild(document.createElement("br"));
             changeMsg.appendChild(note);
           } else {

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
@@ -18,7 +18,7 @@
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
     pill.appendChild(
-      document.createTextNode(" (email: " + account.account.email + ")"),
+      document.createTextNode(" (email: " + account.account.email + ")")
     );
     loginState.appendChild(pill);
 
@@ -30,8 +30,8 @@
     tokenBox.appendChild(bToken);
     tokenBox.appendChild(
       document.createTextNode(
-        "\nThe page is expected to echo it back in the X-CSRF-Token header.",
-      ),
+        "\nThe page is expected to echo it back in the X-CSRF-Token header."
+      )
     );
     loginState.appendChild(tokenBox);
   }
@@ -58,7 +58,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data,
+        data
       );
     });
 
@@ -84,7 +84,7 @@
             bTok.textContent = tokenInput.value;
             note.appendChild(bTok);
             note.appendChild(
-              document.createTextNode(" was accepted - it is never validated."),
+              document.createTextNode(" was accepted - it is never validated.")
             );
             changeMsg.appendChild(document.createElement("br"));
             changeMsg.appendChild(note);
@@ -99,7 +99,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers,
+        headers
       );
     });
 
@@ -124,7 +124,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true,
+        true
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
@@ -1,0 +1,96 @@
+(function () {
+  const username = document.getElementById("csrf_l2_username");
+  const password = document.getElementById("csrf_l2_password");
+  const newEmail = document.getElementById("csrf_l2_new_email");
+  const tokenInput = document.getElementById("csrf_l2_token");
+  const loginState = document.getElementById("csrf_l2_login_state");
+  const loginMsg = document.getElementById("csrf_l2_login_msg");
+  const changeMsg = document.getElementById("csrf_l2_change_msg");
+  const accountMsg = document.getElementById("csrf_l2_account_msg");
+
+  function showLoginState(account) {
+    loginState.classList.remove("hidden");
+    loginState.innerHTML =
+      '<div class="login-pill">Logged in as <b>' +
+      account.username +
+      "</b> (email: " +
+      account.email +
+      ')</div><div class="token-box">Server issued token: <b>' +
+      account.csrfToken +
+      "</b><br/>The page is expected to echo it back in the X-CSRF-Token header.</div>";
+  }
+
+  document
+    .getElementById("csrf_l2_login_btn")
+    .addEventListener("click", function () {
+      loginMsg.innerHTML = "";
+      const data =
+        "username=" +
+        encodeURIComponent(username.value) +
+        "&password=" +
+        encodeURIComponent(password.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            showLoginState(response.content);
+            loginMsg.innerHTML =
+              '<span style="color:green">Login successful</span>';
+          } else {
+            loginMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel(),
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l2_change_btn")
+    .addEventListener("click", function () {
+      changeMsg.innerHTML = "";
+      const data = "email=" + encodeURIComponent(newEmail.value);
+      const headers = { "X-CSRF-Token": tokenInput.value };
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            changeMsg.innerHTML =
+              '<span style="color:green">' +
+              response.content +
+              '</span><br/><span style="color:black;font-size:12px">Note: the token value <b>' +
+              tokenInput.value +
+              "</b> was accepted - it is never validated.</span>";
+          } else {
+            changeMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/changeEmail",
+        true,
+        data,
+        headers
+      );
+    });
+
+  document
+    .getElementById("csrf_l2_account_btn")
+    .addEventListener("click", function () {
+      accountMsg.innerHTML = "";
+      doGetAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            accountMsg.innerHTML =
+              '<span style="color:green">Current email: ' +
+              response.content.email +
+              "</span>";
+          } else {
+            accountMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/account",
+        true
+      );
+    });
+})();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
@@ -18,7 +18,7 @@
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
     pill.appendChild(
-        document.createTextNode(" (email: " + account.account.email + ")")
+      document.createTextNode(" (email: " + account.account.email + ")"),
     );
     loginState.appendChild(pill);
 
@@ -29,9 +29,9 @@
     bToken.textContent = account.csrfToken;
     tokenBox.appendChild(bToken);
     tokenBox.appendChild(
-        document.createTextNode(
-            "\nThe page is expected to echo it back in the X-CSRF-Token header."
-        )
+      document.createTextNode(
+        "\nThe page is expected to echo it back in the X-CSRF-Token header.",
+      ),
     );
     loginState.appendChild(tokenBox);
   }
@@ -58,7 +58,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data
+        data,
       );
     });
 
@@ -84,7 +84,7 @@
             bTok.textContent = tokenInput.value;
             note.appendChild(bTok);
             note.appendChild(
-                document.createTextNode(" was accepted - it is never validated.")
+              document.createTextNode(" was accepted - it is never validated."),
             );
             changeMsg.appendChild(document.createElement("br"));
             changeMsg.appendChild(note);
@@ -99,7 +99,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers
+        headers,
       );
     });
 
@@ -124,7 +124,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true
+        true,
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_2/CSRF.js
@@ -10,14 +10,25 @@
 
   function showLoginState(account) {
     loginState.classList.remove("hidden");
-    loginState.innerHTML =
-      '<div class="login-pill">Logged in as <b>' +
-      account.username +
-      "</b> (email: " +
-      account.email +
-      ')</div><div class="token-box">Server issued token: <b>' +
-      account.csrfToken +
-      "</b><br/>The page is expected to echo it back in the X-CSRF-Token header.</div>";
+    loginState.textContent = "";
+    var pill = document.createElement("div");
+    pill.className = "login-pill";
+    pill.appendChild(document.createTextNode("Logged in as "));
+    var bUser = document.createElement("b");
+    bUser.textContent = account.account.username;
+    pill.appendChild(bUser);
+    pill.appendChild(document.createTextNode(" (email: " + account.account.email + ")"));
+    loginState.appendChild(pill);
+
+    var tokenBox = document.createElement("div");
+    tokenBox.className = "token-box";
+    tokenBox.appendChild(document.createTextNode("Server issued token: "));
+    var bToken = document.createElement("b");
+    bToken.textContent = account.csrfToken;
+    tokenBox.appendChild(bToken);
+    tokenBox.appendChild(document.createTextNode(
+      "\nThe page is expected to echo it back in the X-CSRF-Token header."));
+    loginState.appendChild(tokenBox);
   }
 
   document
@@ -55,15 +66,28 @@
       doPostAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            changeMsg.innerHTML =
-              '<span style="color:green">' +
-              response.content +
-              '</span><br/><span style="color:black;font-size:12px">Note: the token value <b>' +
-              tokenInput.value +
-              "</b> was accepted - it is never validated.</span>";
+            changeMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = response.content;
+            changeMsg.appendChild(s);
+            var note = document.createElement("span");
+            note.style.color = "black";
+            note.style.fontSize = "12px";
+            note.appendChild(document.createTextNode("Note: the token value "));
+            var bTok = document.createElement("b");
+            bTok.textContent = tokenInput.value;
+            note.appendChild(bTok);
+            note.appendChild(document.createTextNode(
+              " was accepted - it is never validated."));
+            changeMsg.appendChild(document.createElement("br"));
+            changeMsg.appendChild(note);
           } else {
-            changeMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            changeMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            changeMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/changeEmail",
@@ -80,13 +104,17 @@
       doGetAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            accountMsg.innerHTML =
-              '<span style="color:green">Current email: ' +
-              response.content.email +
-              "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = "Current email: " + response.content.email;
+            accountMsg.appendChild(s);
           } else {
-            accountMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            accountMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/account",

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.css
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.css
@@ -1,0 +1,123 @@
+.csrf-shell {
+    width: 100%;
+    max-width: 600px;
+    margin: 12px auto;
+    padding: 6px;
+    box-sizing: border-box;
+    text-align: center;
+    color: black;
+}
+
+.csrf-title {
+    margin: 0 0 6px;
+    font-size: 22px;
+}
+
+.csrf-subtitle {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+
+.csrf-card {
+    border: 1px solid black;
+    border-radius: 4px;
+    border-left: 6px solid burlywood;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.csrf-card + .csrf-card {
+    margin-top: 16px;
+}
+
+.csrf-card h5 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.csrf-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.csrf-field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.csrf-field label {
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.csrf-field input,
+.csrf-field select {
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-size: 13px;
+    min-width: 150px;
+}
+
+.csrf-card button {
+    padding: 5px 14px;
+    border: 1px solid black;
+    border-radius: 3px;
+    background: burlywood;
+    color: black;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.csrf-card button:hover {
+    background: #d2a55c;
+}
+
+.status-message {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.login-pill {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: #d4edda;
+    border: 1px solid #28a745;
+    font-size: 13px;
+}
+
+.token-box {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #f8f9fa;
+    border: 1px dashed #888;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    text-align: left;
+}
+
+.csrf-attack-note {
+    margin-top: 8px;
+    padding: 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: left;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
@@ -1,0 +1,51 @@
+<div id="csrf_ui" class="csrf-shell">
+    <h3 class="csrf-title">CSRF Vulnerability - Level 3</h3>
+    <p class="csrf-subtitle">
+        The server validates the X-CSRF-Token header, but the token is
+        generated as username:epochSeconds, so an attacker can forge a valid
+        token for the current time window.
+    </p>
+
+    <div class="csrf-card">
+        <h5>Login</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l3_username">Username</label>
+                <select id="csrf_l3_username">
+                    <option value="victim">victim</option>
+                    <option value="attacker">attacker</option>
+                </select>
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l3_password">Password</label>
+                <input type="password" id="csrf_l3_password" value="Victim@123" />
+            </div>
+            <button id="csrf_l3_login_btn">Login</button>
+        </div>
+        <div class="hidden" id="csrf_l3_login_state"></div>
+        <div class="status-message" id="csrf_l3_login_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l3_new_email">New email</label>
+                <input type="text" id="csrf_l3_new_email" value="attacker@example.com" />
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l3_token">Forged X-CSRF-Token (victim:&lt;epoch seconds&gt;)</label>
+                <input type="text" id="csrf_l3_token" placeholder="victim:0000000000" />
+            </div>
+            <button id="csrf_l3_change_btn">Change Email</button>
+        </div>
+        <div class="status-message" id="csrf_l3_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Account</h5>
+        <div class="status-message" id="csrf_l3_account_msg"></div>
+        <button id="csrf_l3_account_btn">Show Current Email</button>
+    </div>
+</div>
+<script src="/VulnerableApp/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js"></script>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
@@ -1,9 +1,9 @@
 <div id="csrf_ui" class="csrf-shell">
     <h3 class="csrf-title">CSRF Vulnerability - Level 3</h3>
     <p class="csrf-subtitle">
-        The server validates the X-CSRF-Token header, but the token is
-        generated as username:epochSeconds, so an attacker can forge a valid
-        token for the current time window.
+        The server validates the CSRF token, but the token is generated as
+        username:epochSeconds, so an attacker can forge a valid token.
+        The token is accepted via header <i>or</i> form field, enabling cross-site form attacks.
     </p>
 
     <div class="csrf-card">
@@ -33,19 +33,33 @@
     </div>
 
     <div class="csrf-card">
-        <h5>Change Email</h5>
+        <h5>Change Email (normal flow)</h5>
         <div class="csrf-row">
             <div class="csrf-field">
                 <label for="csrf_l3_new_email">New email</label>
                 <input type="text" id="csrf_l3_new_email" value="attacker@example.com" />
             </div>
             <div class="csrf-field">
-                <label for="csrf_l3_token">Forged X-CSRF-Token (victim:&lt;epoch seconds&gt;)</label>
+                <label for="csrf_l3_token">Forged CSRF Token (victim:<epoch seconds>)</label>
                 <input type="text" id="csrf_l3_token" placeholder="victim:0000000000" />
             </div>
             <button id="csrf_l3_change_btn">Change Email</button>
         </div>
         <div class="status-message" id="csrf_l3_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Cross-site attack demo (form submission)</h5>
+        <p class="csrf-subtitle">
+            An attacker can host this form on a different origin. The token is sent as a form field,
+            so no custom header is needed - the browser will include the victim's session cookie.
+        </p>
+        <form id="csrf_l3_attack_form" action="/VulnerableApp/CSRFVulnerability/LEVEL_3/changeEmail" method="POST" target="_blank">
+            <input type="hidden" name="email" value="attacker@example.com" />
+            <input type="hidden" name="csrfToken" id="csrf_l3_attack_token" value="" />
+            <button type="submit" id="csrf_l3_attack_btn">Launch Cross-Site Attack</button>
+        </form>
+        <div class="status-message" id="csrf_l3_attack_msg"></div>
     </div>
 
     <div class="csrf-card">

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.html
@@ -19,6 +19,12 @@
             <div class="csrf-field">
                 <label for="csrf_l3_password">Password</label>
                 <input type="password" id="csrf_l3_password" value="Victim@123" />
+                <script>
+                document.getElementById("csrf_l3_username").addEventListener("change", function() {
+                    document.getElementById("csrf_l3_password").value =
+                        this.value === "attacker" ? "Attacker@123" : "Victim@123";
+                });
+                </script>
             </div>
             <button id="csrf_l3_login_btn">Login</button>
         </div>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -18,7 +18,7 @@
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
     pill.appendChild(
-      document.createTextNode(" (email: " + account.account.email + ")"),
+      document.createTextNode(" (email: " + account.account.email + ")")
     );
     loginState.appendChild(pill);
 
@@ -35,8 +35,8 @@
     tokenBox.appendChild(document.createElement("br"));
     tokenBox.appendChild(
       document.createTextNode(
-        "The token is simply username:epochSeconds - forge one as ",
-      ),
+        "The token is simply username:epochSeconds - forge one as "
+      )
     );
     var i = document.createElement("i");
     i.textContent = "victim:<now>";
@@ -67,7 +67,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data,
+        data
       );
     });
 
@@ -92,7 +92,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers,
+        headers
       );
     });
 
@@ -117,7 +117,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true,
+        true
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -18,7 +18,7 @@
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
     pill.appendChild(
-        document.createTextNode(" (email: " + account.account.email + ")")
+      document.createTextNode(" (email: " + account.account.email + ")"),
     );
     loginState.appendChild(pill);
 
@@ -34,9 +34,9 @@
     tokenBox.appendChild(bTok);
     tokenBox.appendChild(document.createElement("br"));
     tokenBox.appendChild(
-        document.createTextNode(
-            "The token is simply username:epochSeconds - forge one as "
-        )
+      document.createTextNode(
+        "The token is simply username:epochSeconds - forge one as ",
+      ),
     );
     var i = document.createElement("i");
     i.textContent = "victim:<now>";
@@ -67,7 +67,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data
+        data,
       );
     });
 
@@ -92,7 +92,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers
+        headers,
       );
     });
 
@@ -117,7 +117,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true
+        true,
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -10,16 +10,34 @@
 
   function showLoginState(account) {
     loginState.classList.remove("hidden");
-    loginState.innerHTML =
-      '<div class="login-pill">Logged in as <b>' +
-      account.username +
-      "</b> (email: " +
-      account.email +
-      ')</div><div class="token-box">Token for <b>' +
-      account.account.username +
-      "</b>: <b>" +
-      account.csrfToken +
-      "</b><br/>The token is simply username:epochSeconds - forge one as <i>victim:&lt;now&gt;</i>.</div>";
+    loginState.textContent = "";
+    var pill = document.createElement("div");
+    pill.className = "login-pill";
+    pill.appendChild(document.createTextNode("Logged in as "));
+    var bUser = document.createElement("b");
+    bUser.textContent = account.account.username;
+    pill.appendChild(bUser);
+    pill.appendChild(document.createTextNode(" (email: " + account.account.email + ")"));
+    loginState.appendChild(pill);
+
+    var tokenBox = document.createElement("div");
+    tokenBox.className = "token-box";
+    tokenBox.appendChild(document.createTextNode("Token for "));
+    var bFor = document.createElement("b");
+    bFor.textContent = account.account.username;
+    tokenBox.appendChild(bFor);
+    tokenBox.appendChild(document.createTextNode(": "));
+    var bTok = document.createElement("b");
+    bTok.textContent = account.csrfToken;
+    tokenBox.appendChild(bTok);
+    tokenBox.appendChild(document.createElement("br"));
+    tokenBox.appendChild(document.createTextNode(
+      "The token is simply username:epochSeconds - forge one as "));
+    var i = document.createElement("i");
+    i.textContent = "victim:<now>";
+    tokenBox.appendChild(i);
+    tokenBox.appendChild(document.createTextNode("."));
+    loginState.appendChild(tokenBox);
   }
 
   document
@@ -80,13 +98,17 @@
       doGetAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            accountMsg.innerHTML =
-              '<span style="color:green">Current email: ' +
-              response.content.email +
-              "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = "Current email: " + response.content.email;
+            accountMsg.appendChild(s);
           } else {
-            accountMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            accountMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/account",

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -1,0 +1,96 @@
+(function () {
+  const username = document.getElementById("csrf_l3_username");
+  const password = document.getElementById("csrf_l3_password");
+  const newEmail = document.getElementById("csrf_l3_new_email");
+  const tokenInput = document.getElementById("csrf_l3_token");
+  const loginState = document.getElementById("csrf_l3_login_state");
+  const loginMsg = document.getElementById("csrf_l3_login_msg");
+  const changeMsg = document.getElementById("csrf_l3_change_msg");
+  const accountMsg = document.getElementById("csrf_l3_account_msg");
+
+  function showLoginState(account) {
+    loginState.classList.remove("hidden");
+    loginState.innerHTML =
+      '<div class="login-pill">Logged in as <b>' +
+      account.username +
+      "</b> (email: " +
+      account.email +
+      ')</div><div class="token-box">Token for <b>' +
+      account.account.username +
+      "</b>: <b>" +
+      account.csrfToken +
+      "</b><br/>The token is simply username:epochSeconds - forge one as <i>victim:&lt;now&gt;</i>.</div>";
+  }
+
+  document
+    .getElementById("csrf_l3_login_btn")
+    .addEventListener("click", function () {
+      loginMsg.innerHTML = "";
+      const data =
+        "username=" +
+        encodeURIComponent(username.value) +
+        "&password=" +
+        encodeURIComponent(password.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            showLoginState(response.content);
+            loginMsg.innerHTML =
+              '<span style="color:green">Login successful</span>';
+          } else {
+            loginMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel(),
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l3_change_btn")
+    .addEventListener("click", function () {
+      changeMsg.innerHTML = "";
+      const data = "email=" + encodeURIComponent(newEmail.value);
+      const headers = { "X-CSRF-Token": tokenInput.value };
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            changeMsg.innerHTML =
+              '<span style="color:green">' + response.content + "</span>";
+          } else {
+            changeMsg.innerHTML =
+              '<span style="color:red">' +
+              response.content +
+              '</span><br/><span style="color:black;font-size:12px">Hint: use victim:&lt;current epoch seconds&gt; as the token value.</span>';
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/changeEmail",
+        true,
+        data,
+        headers
+      );
+    });
+
+  document
+    .getElementById("csrf_l3_account_btn")
+    .addEventListener("click", function () {
+      accountMsg.innerHTML = "";
+      doGetAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            accountMsg.innerHTML =
+              '<span style="color:green">Current email: ' +
+              response.content.email +
+              "</span>";
+          } else {
+            accountMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/account",
+        true
+      );
+    });
+})();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -3,9 +3,11 @@
   const password = document.getElementById("csrf_l3_password");
   const newEmail = document.getElementById("csrf_l3_new_email");
   const tokenInput = document.getElementById("csrf_l3_token");
+  const attackTokenInput = document.getElementById("csrf_l3_attack_token");
   const loginState = document.getElementById("csrf_l3_login_state");
   const loginMsg = document.getElementById("csrf_l3_login_msg");
   const changeMsg = document.getElementById("csrf_l3_change_msg");
+  const attackMsg = document.getElementById("csrf_l3_attack_msg");
   const accountMsg = document.getElementById("csrf_l3_account_msg");
 
   function showLoginState(account) {
@@ -75,8 +77,7 @@
     .getElementById("csrf_l3_change_btn")
     .addEventListener("click", function () {
       changeMsg.innerHTML = "";
-      const data = "email=" + encodeURIComponent(newEmail.value);
-      const headers = { "X-CSRF-Token": tokenInput.value };
+      const data = "email=" + encodeURIComponent(newEmail.value) + "&csrfToken=" + encodeURIComponent(tokenInput.value);
       doPostAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
@@ -86,14 +87,25 @@
             changeMsg.innerHTML =
               '<span style="color:red">' +
               response.content +
-              '</span><br/><span style="color:black;font-size:12px">Hint: use victim:&lt;current epoch seconds&gt; as the token value.</span>';
+              '</span><br/><span style="color:black;font-size:12px">Hint: use victim:<current epoch seconds> as the token value.</span>';
           }
         },
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
-        data,
-        headers
+        data
       );
+    });
+
+  document
+    .getElementById("csrf_l3_attack_btn")
+    .addEventListener("click", function (e) {
+      e.preventDefault();
+      attackMsg.innerHTML = "";
+      var epoch = Math.floor(Date.now() / 1000);
+      attackTokenInput.value = "victim:" + epoch;
+      var form = document.getElementById("csrf_l3_attack_form");
+      form.submit();
+      attackMsg.innerHTML = '<span style="color:green">Attack form submitted with token: victim:' + epoch + '</span>';
     });
 
   document

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_3/CSRF.js
@@ -17,7 +17,9 @@
     var bUser = document.createElement("b");
     bUser.textContent = account.account.username;
     pill.appendChild(bUser);
-    pill.appendChild(document.createTextNode(" (email: " + account.account.email + ")"));
+    pill.appendChild(
+        document.createTextNode(" (email: " + account.account.email + ")")
+    );
     loginState.appendChild(pill);
 
     var tokenBox = document.createElement("div");
@@ -31,8 +33,11 @@
     bTok.textContent = account.csrfToken;
     tokenBox.appendChild(bTok);
     tokenBox.appendChild(document.createElement("br"));
-    tokenBox.appendChild(document.createTextNode(
-      "The token is simply username:epochSeconds - forge one as "));
+    tokenBox.appendChild(
+        document.createTextNode(
+            "The token is simply username:epochSeconds - forge one as "
+        )
+    );
     var i = document.createElement("i");
     i.textContent = "victim:<now>";
     tokenBox.appendChild(i);

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.css
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.css
@@ -1,0 +1,123 @@
+.csrf-shell {
+    width: 100%;
+    max-width: 600px;
+    margin: 12px auto;
+    padding: 6px;
+    box-sizing: border-box;
+    text-align: center;
+    color: black;
+}
+
+.csrf-title {
+    margin: 0 0 6px;
+    font-size: 22px;
+}
+
+.csrf-subtitle {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+
+.csrf-card {
+    border: 1px solid black;
+    border-radius: 4px;
+    border-left: 6px solid burlywood;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.csrf-card + .csrf-card {
+    margin-top: 16px;
+}
+
+.csrf-card h5 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.csrf-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.csrf-field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.csrf-field label {
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.csrf-field input,
+.csrf-field select {
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-size: 13px;
+    min-width: 150px;
+}
+
+.csrf-card button {
+    padding: 5px 14px;
+    border: 1px solid black;
+    border-radius: 3px;
+    background: burlywood;
+    color: black;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.csrf-card button:hover {
+    background: #d2a55c;
+}
+
+.status-message {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.login-pill {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: #d4edda;
+    border: 1px solid #28a745;
+    font-size: 13px;
+}
+
+.token-box {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #f8f9fa;
+    border: 1px dashed #888;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    text-align: left;
+}
+
+.csrf-attack-note {
+    margin-top: 8px;
+    padding: 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: left;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.html
@@ -19,6 +19,12 @@
             <div class="csrf-field">
                 <label for="csrf_l4_password">Password</label>
                 <input type="password" id="csrf_l4_password" value="Victim@123" />
+                <script>
+                document.getElementById("csrf_l4_username").addEventListener("change", function() {
+                    document.getElementById("csrf_l4_password").value =
+                        this.value === "attacker" ? "Attacker@123" : "Victim@123";
+                });
+                </script>
             </div>
             <button id="csrf_l4_login_btn">Login</button>
         </div>
@@ -40,7 +46,14 @@
 
     <div class="csrf-card">
         <h5>Change Email (GET - state changing)</h5>
+        <p class="csrf-subtitle">
+            This link simulates a cross-site attack (e.g., from a phishing email or malicious site).
+            The request targets the vulnerable app but originates from a different origin.
+        </p>
         <div class="csrf-attack-note" id="csrf_l4_attack_note"></div>
+        <a id="csrf_l4_get_link" href="/VulnerableApp/CSRFVulnerability/LEVEL_4/changeEmail?email=attacker@example.com" target="_blank" rel="noopener">
+            Click here to trigger state-changing GET (opens in new tab - simulates cross-site nav)
+        </a>
         <div class="status-message" id="csrf_l4_get_msg"></div>
     </div>
 

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.html
@@ -1,0 +1,53 @@
+<div id="csrf_ui" class="csrf-shell">
+    <h3 class="csrf-title">CSRF Vulnerability - Level 4</h3>
+    <p class="csrf-subtitle">
+        The POST endpoint properly validates the CSRF token. But the same
+        operation is also exposed over GET - and a top-level navigation carries
+        the session cookie even with the default SameSite=Lax policy.
+    </p>
+
+    <div class="csrf-card">
+        <h5>Login</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l4_username">Username</label>
+                <select id="csrf_l4_username">
+                    <option value="victim">victim</option>
+                    <option value="attacker">attacker</option>
+                </select>
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l4_password">Password</label>
+                <input type="password" id="csrf_l4_password" value="Victim@123" />
+            </div>
+            <button id="csrf_l4_login_btn">Login</button>
+        </div>
+        <div class="hidden" id="csrf_l4_login_state"></div>
+        <div class="status-message" id="csrf_l4_login_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email (POST - protected)</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l4_new_email">New email</label>
+                <input type="text" id="csrf_l4_new_email" value="legit@example.com" />
+            </div>
+            <button id="csrf_l4_change_btn">Change Email</button>
+        </div>
+        <div class="status-message" id="csrf_l4_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email (GET - state changing)</h5>
+        <div class="csrf-attack-note" id="csrf_l4_attack_note"></div>
+        <div class="status-message" id="csrf_l4_get_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Account</h5>
+        <div class="status-message" id="csrf_l4_account_msg"></div>
+        <button id="csrf_l4_account_btn">Show Current Email</button>
+    </div>
+</div>
+<script src="/VulnerableApp/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js"></script>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
@@ -95,13 +95,17 @@
       doGetAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            accountMsg.innerHTML =
-              '<span style="color:green">Current email: ' +
-              response.content.email +
-              "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = "Current email: " + response.content.email;
+            accountMsg.appendChild(s);
           } else {
-            accountMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            accountMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/account",

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
@@ -54,7 +54,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data,
+        data
       );
     });
 
@@ -84,7 +84,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers,
+        headers
       );
     });
 
@@ -109,7 +109,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true,
+        true
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
@@ -1,0 +1,111 @@
+(function () {
+  const username = document.getElementById("csrf_l4_username");
+  const password = document.getElementById("csrf_l4_password");
+  const newEmail = document.getElementById("csrf_l4_new_email");
+  const loginState = document.getElementById("csrf_l4_login_state");
+  const loginMsg = document.getElementById("csrf_l4_login_msg");
+  const changeMsg = document.getElementById("csrf_l4_change_msg");
+  const getMsg = document.getElementById("csrf_l4_get_msg");
+  const accountMsg = document.getElementById("csrf_l4_account_msg");
+  const attackNote = document.getElementById("csrf_l4_attack_note");
+
+  let currentToken = null;
+
+  attackNote.innerHTML =
+    "POST without the token is rejected with 403. However the operation is also reachable over GET. " +
+    "A GET request has no custom headers, so no CSRF token can be attached - yet the session cookie is " +
+    "still sent on a top-level navigation. Try the GET variant on this URL:<br/>" +
+    '<a href="/VulnerableApp/CSRFVulnerability/LEVEL_4/changeEmail?email=attacker@example.com" target="_blank">' +
+    "/VulnerableApp/CSRFVulnerability/LEVEL_4/changeEmail?email=attacker@example.com</a>" +
+    "<br/><i>(open it while logged in - same tab or new tab, it is a top-level navigation)</i>";
+
+  function showLoginState(account) {
+    currentToken = account.csrfToken;
+    loginState.classList.remove("hidden");
+    loginState.innerHTML =
+      '<div class="login-pill">Logged in as <b>' +
+      account.account.username +
+      "</b> (email: " +
+      account.account.email +
+      ')</div><div class="token-box">CSRF token kept in page memory: <b>' +
+      account.csrfToken +
+      "</b></div>";
+  }
+
+  document
+    .getElementById("csrf_l4_login_btn")
+    .addEventListener("click", function () {
+      loginMsg.innerHTML = "";
+      const data =
+        "username=" +
+        encodeURIComponent(username.value) +
+        "&password=" +
+        encodeURIComponent(password.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            showLoginState(response.content);
+            loginMsg.innerHTML =
+              '<span style="color:green">Login successful</span>';
+          } else {
+            loginMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel(),
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l4_change_btn")
+    .addEventListener("click", function () {
+      changeMsg.innerHTML = "";
+      const data = "email=" + encodeURIComponent(newEmail.value);
+      const headers = { "X-CSRF-Token": currentToken };
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            changeMsg.innerHTML =
+              '<span style="color:green">' + response.content + "</span>";
+          } else if (xhr.status === 403) {
+            changeMsg.innerHTML =
+              '<span style="color:red">' +
+              response.content +
+              '</span><br/><span style="color:black;font-size:12px">Note: without a valid token the POST is rejected - the header was: "' +
+              (headers["X-CSRF-Token"] || "missing") +
+              '".</span>';
+          } else {
+            changeMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/changeEmail",
+        true,
+        data,
+        headers
+      );
+    });
+
+  document
+    .getElementById("csrf_l4_account_btn")
+    .addEventListener("click", function () {
+      accountMsg.innerHTML = "";
+      doGetAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            accountMsg.innerHTML =
+              '<span style="color:green">Current email: ' +
+              response.content.email +
+              "</span>";
+          } else {
+            accountMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/account",
+        true
+      );
+    });
+})();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
@@ -54,7 +54,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data
+        data,
       );
     });
 
@@ -84,7 +84,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers
+        headers,
       );
     });
 
@@ -109,7 +109,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true
+        true,
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_4/CSRF.js
@@ -22,14 +22,23 @@
   function showLoginState(account) {
     currentToken = account.csrfToken;
     loginState.classList.remove("hidden");
-    loginState.innerHTML =
-      '<div class="login-pill">Logged in as <b>' +
-      account.account.username +
-      "</b> (email: " +
-      account.account.email +
-      ')</div><div class="token-box">CSRF token kept in page memory: <b>' +
-      account.csrfToken +
-      "</b></div>";
+    loginState.innerHTML = "";
+    var pill = document.createElement("div");
+    pill.className = "login-pill";
+    pill.appendChild(document.createTextNode("Logged in as "));
+    var bUser = document.createElement("b");
+    bUser.textContent = account.account.username;
+    pill.appendChild(bUser);
+    pill.appendChild(document.createTextNode(" (email: " + account.account.email + ")"));
+    loginState.appendChild(pill);
+
+    var tokenBox = document.createElement("div");
+    tokenBox.className = "token-box";
+    tokenBox.appendChild(document.createTextNode("CSRF token kept in page memory: "));
+    var bToken = document.createElement("b");
+    bToken.textContent = account.csrfToken;
+    tokenBox.appendChild(bToken);
+    loginState.appendChild(tokenBox);
   }
 
   document

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.css
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.css
@@ -1,0 +1,123 @@
+.csrf-shell {
+    width: 100%;
+    max-width: 600px;
+    margin: 12px auto;
+    padding: 6px;
+    box-sizing: border-box;
+    text-align: center;
+    color: black;
+}
+
+.csrf-title {
+    margin: 0 0 6px;
+    font-size: 22px;
+}
+
+.csrf-subtitle {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+
+.csrf-card {
+    border: 1px solid black;
+    border-radius: 4px;
+    border-left: 6px solid burlywood;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.csrf-card + .csrf-card {
+    margin-top: 16px;
+}
+
+.csrf-card h5 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.csrf-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+}
+
+.csrf-field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.csrf-field label {
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.csrf-field input,
+.csrf-field select {
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 3px;
+    font-size: 13px;
+    min-width: 150px;
+}
+
+.csrf-card button {
+    padding: 5px 14px;
+    border: 1px solid black;
+    border-radius: 3px;
+    background: burlywood;
+    color: black;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.csrf-card button:hover {
+    background: #d2a55c;
+}
+
+.status-message {
+    margin-top: 6px;
+    font-size: 13px;
+    font-weight: bold;
+}
+
+.login-pill {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: #d4edda;
+    border: 1px solid #28a745;
+    font-size: 13px;
+}
+
+.token-box {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #f8f9fa;
+    border: 1px dashed #888;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
+    word-break: break-all;
+    text-align: left;
+}
+
+.csrf-attack-note {
+    margin-top: 8px;
+    padding: 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: left;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.html
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.html
@@ -1,0 +1,47 @@
+<div id="csrf_ui" class="csrf-shell">
+    <h3 class="csrf-title">CSRF Vulnerability - Level 5</h3>
+    <p class="csrf-subtitle">
+        Secure implementation: an unpredictable token is issued at login,
+        validated on every state change, the operation is never exposed over
+        GET, and the session cookie is marked SameSite=Lax.
+    </p>
+
+    <div class="csrf-card">
+        <h5>Login</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l5_username">Username</label>
+                <select id="csrf_l5_username">
+                    <option value="victim">victim</option>
+                    <option value="attacker">attacker</option>
+                </select>
+            </div>
+            <div class="csrf-field">
+                <label for="csrf_l5_password">Password</label>
+                <input type="password" id="csrf_l5_password" value="Victim@123" />
+            </div>
+            <button id="csrf_l5_login_btn">Login</button>
+        </div>
+        <div class="hidden" id="csrf_l5_login_state"></div>
+        <div class="status-message" id="csrf_l5_login_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Change Email</h5>
+        <div class="csrf-row">
+            <div class="csrf-field">
+                <label for="csrf_l5_new_email">New email</label>
+                <input type="text" id="csrf_l5_new_email" value="victim@example.com" />
+            </div>
+            <button id="csrf_l5_change_btn">Change Email</button>
+        </div>
+        <div class="status-message" id="csrf_l5_change_msg"></div>
+    </div>
+
+    <div class="csrf-card">
+        <h5>Account</h5>
+        <div class="status-message" id="csrf_l5_account_msg"></div>
+        <button id="csrf_l5_account_btn">Show Current Email</button>
+    </div>
+</div>
+<script src="/VulnerableApp/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js"></script>

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
@@ -1,0 +1,99 @@
+(function () {
+  const username = document.getElementById("csrf_l5_username");
+  const password = document.getElementById("csrf_l5_password");
+  const newEmail = document.getElementById("csrf_l5_new_email");
+  const loginState = document.getElementById("csrf_l5_login_state");
+  const loginMsg = document.getElementById("csrf_l5_login_msg");
+  const changeMsg = document.getElementById("csrf_l5_change_msg");
+  const accountMsg = document.getElementById("csrf_l5_account_msg");
+
+  let currentToken = null;
+
+  function showLoginState(account) {
+    currentToken = account.csrfToken;
+    loginState.classList.remove("hidden");
+    loginState.innerHTML =
+      '<div class="login-pill">Logged in as <b>' +
+      account.account.username +
+      "</b> (email: " +
+      account.account.email +
+      ')</div><div class="token-box">CSRF token kept in page memory: <b>' +
+      account.csrfToken +
+      "</b><br/>SameSite=Lax on the session cookie blocks cross-site POSTs.</div>";
+  }
+
+  document
+    .getElementById("csrf_l5_login_btn")
+    .addEventListener("click", function () {
+      loginMsg.innerHTML = "";
+      const data =
+        "username=" +
+        encodeURIComponent(username.value) +
+        "&password=" +
+        encodeURIComponent(password.value);
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            showLoginState(response.content);
+            loginMsg.innerHTML =
+              '<span style="color:green">Login successful</span>';
+          } else {
+            loginMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel(),
+        true,
+        data
+      );
+    });
+
+  document
+    .getElementById("csrf_l5_change_btn")
+    .addEventListener("click", function () {
+      changeMsg.innerHTML = "";
+      const data = "email=" + encodeURIComponent(newEmail.value);
+      const headers = { "X-CSRF-Token": currentToken };
+      doPostAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            changeMsg.innerHTML =
+              '<span style="color:green">' + response.content + "</span>";
+          } else if (xhr.status === 403) {
+            changeMsg.innerHTML =
+              '<span style="color:red">' +
+              response.content +
+              '</span><br/><span style="color:black;font-size:12px">Note: the request was rejected because the X-CSRF-Token header was missing or wrong.</span>';
+          } else {
+            changeMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/changeEmail",
+        true,
+        data,
+        headers
+      );
+    });
+
+  document
+    .getElementById("csrf_l5_account_btn")
+    .addEventListener("click", function () {
+      accountMsg.innerHTML = "";
+      doGetAjaxCall(
+        function (response, xhr) {
+          if (response.isValid) {
+            accountMsg.innerHTML =
+              '<span style="color:green">Current email: ' +
+              response.content.email +
+              "</span>";
+          } else {
+            accountMsg.innerHTML =
+              '<span style="color:red">' + response.content + "</span>";
+          }
+        },
+        getUrlForVulnerabilityLevel() + "/account",
+        true
+      );
+    });
+})();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
@@ -44,7 +44,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data
+        data,
       );
     });
 
@@ -72,7 +72,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers
+        headers,
       );
     });
 
@@ -97,7 +97,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true
+        true,
       );
     });
 })();

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
@@ -83,13 +83,17 @@
       doGetAjaxCall(
         function (response, xhr) {
           if (response.isValid) {
-            accountMsg.innerHTML =
-              '<span style="color:green">Current email: ' +
-              response.content.email +
-              "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "green";
+            s.textContent = "Current email: " + response.content.email;
+            accountMsg.appendChild(s);
           } else {
-            accountMsg.innerHTML =
-              '<span style="color:red">' + response.content + "</span>";
+            accountMsg.textContent = "";
+            var s = document.createElement("span");
+            s.style.color = "red";
+            s.textContent = response.content;
+            accountMsg.appendChild(s);
           }
         },
         getUrlForVulnerabilityLevel() + "/account",

--- a/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
+++ b/src/main/resources/static/templates/CSRFVulnerability/LEVEL_5/CSRF.js
@@ -44,7 +44,7 @@
         },
         getUrlForVulnerabilityLevel(),
         true,
-        data,
+        data
       );
     });
 
@@ -72,7 +72,7 @@
         getUrlForVulnerabilityLevel() + "/changeEmail",
         true,
         data,
-        headers,
+        headers
       );
     });
 
@@ -97,7 +97,7 @@
           }
         },
         getUrlForVulnerabilityLevel() + "/account",
-        true,
+        true
       );
     });
 })();

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccountTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFAccountTest.java
@@ -1,0 +1,58 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class CSRFAccountTest {
+
+    @Test
+    void constructorWithoutPassword_ShouldSetFieldsCorrectly() {
+        CSRFAccount account = new CSRFAccount(1, "victim", "victim@example.com");
+
+        assertEquals(1, account.getId());
+        assertEquals("victim", account.getUsername());
+        assertEquals("victim@example.com", account.getEmail());
+        assertNull(account.getStoredPassword());
+    }
+
+    @Test
+    void constructorWithPassword_ShouldSetAllFields() {
+        CSRFAccount account =
+                new CSRFAccount(
+                        2,
+                        "attacker",
+                        "CSRF_SALT_L1:d6f84008e9cbadae9ed05181db30fd185ab79266574e388ccda0aaa30f6f525f",
+                        "attacker@example.com");
+
+        assertEquals(2, account.getId());
+        assertEquals("attacker", account.getUsername());
+        assertEquals("attacker@example.com", account.getEmail());
+        assertEquals(
+                "CSRF_SALT_L1:d6f84008e9cbadae9ed05181db30fd185ab79266574e388ccda0aaa30f6f525f",
+                account.getStoredPassword());
+    }
+
+    @Test
+    void setters_ShouldUpdateFields() {
+        CSRFAccount account = new CSRFAccount(1, "user1", "old@example.com");
+
+        account.setId(99);
+        account.setUsername("user2");
+        account.setEmail("new@example.com");
+
+        assertEquals(99, account.getId());
+        assertEquals("user2", account.getUsername());
+        assertEquals("new@example.com", account.getEmail());
+    }
+
+    @Test
+    void emailCanBeUpdated() {
+        CSRFAccount account = new CSRFAccount(1, "victim", "victim@example.com");
+
+        account.setEmail("attacker@evil.com");
+
+        assertEquals("attacker@evil.com", account.getEmail());
+    }
+}

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
@@ -1,0 +1,395 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class CSRFSessionServiceTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private CSRFSessionService service;
+
+    private static final CSRFAccount VICTIM =
+            new CSRFAccount(1, "victim", "victim@example.com");
+    private static final CSRFAccount ATTACKER =
+            new CSRFAccount(2, "attacker", "attacker@example.com");
+
+    @BeforeEach
+    void setup() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        service = new CSRFSessionService(jdbcTemplate);
+    }
+
+    // ----- authenticate -----
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void authenticate_ShouldReturnAccount_WhenCredentialsValid() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenAnswer(
+                        inv -> {
+                            RowMapper<CSRFAccount> mapper = inv.getArgument(2);
+                            ResultSet rs = mock(ResultSet.class);
+                            when(rs.getInt("id")).thenReturn(1);
+                            when(rs.getString("username")).thenReturn("victim");
+                            when(rs.getString("password"))
+                                    .thenReturn(
+                                            "CSRF_SALT_L1:f5e2a35c9dac8a96fbe2ddf38a7694cf5177ed293bc6e600236ae8aefb677407");
+                            when(rs.getString("email")).thenReturn("victim@example.com");
+                            return Arrays.asList(mapper.mapRow(rs, 0));
+                        });
+
+        CSRFAccount result = service.authenticate(1, "victim", "Victim@123");
+
+        assertNotNull(result);
+        assertEquals("victim", result.getUsername());
+        assertEquals("victim@example.com", result.getEmail());
+        assertNull(result.getStoredPassword());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void authenticate_ShouldReturnNull_WhenPasswordInvalid() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenAnswer(
+                        inv -> {
+                            RowMapper<CSRFAccount> mapper = inv.getArgument(2);
+                            ResultSet rs = mock(ResultSet.class);
+                            when(rs.getInt("id")).thenReturn(1);
+                            when(rs.getString("username")).thenReturn("victim");
+                            when(rs.getString("password"))
+                                    .thenReturn(
+                                            "CSRF_SALT_L1:f5e2a35c9dac8a96fbe2ddf38a7694cf5177ed293bc6e600236ae8aefb677407");
+                            when(rs.getString("email")).thenReturn("victim@example.com");
+                            return Arrays.asList(mapper.mapRow(rs, 0));
+                        });
+
+        CSRFAccount result = service.authenticate(1, "victim", "WrongPassword");
+
+        assertNull(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void authenticate_ShouldReturnNull_WhenUserNotFound() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenReturn(Collections.emptyList());
+
+        CSRFAccount result = service.authenticate(1, "nonexistent", "password");
+
+        assertNull(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void authenticate_ShouldReturnNull_WhenPasswordHasNoSeparator() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenAnswer(
+                        inv -> {
+                            RowMapper<CSRFAccount> mapper = inv.getArgument(2);
+                            ResultSet rs = mock(ResultSet.class);
+                            when(rs.getInt("id")).thenReturn(1);
+                            when(rs.getString("username")).thenReturn("user");
+                            when(rs.getString("password")).thenReturn("plaintextNoColon");
+                            when(rs.getString("email")).thenReturn("u@e.com");
+                            return Arrays.asList(mapper.mapRow(rs, 0));
+                        });
+
+        CSRFAccount result = service.authenticate(1, "user", "plaintextNoColon");
+
+        assertNull(result);
+    }
+
+    // ----- createSession -----
+
+    @Test
+    void createSession_ShouldReturnTokenAndStoreSession() {
+        String token = service.createSession(1, VICTIM);
+
+        assertNotNull(token);
+        assertTrue(token.length() == 64);
+        assertNotNull(service.getSession(1, token));
+        assertEquals("victim", service.getSession(1, token).getUsername());
+        assertEquals("victim@example.com", service.getSession(1, token).getEmail());
+    }
+
+    @Test
+    void createSession_DifferentLevels_ShouldBeIsolated() {
+        String token1 = service.createSession(1, VICTIM);
+        String token2 = service.createSession(2, ATTACKER);
+
+        assertNotNull(service.getSession(1, token1));
+        assertNotNull(service.getSession(2, token2));
+        assertNull(service.getSession(1, token2));
+        assertNull(service.getSession(2, token1));
+    }
+
+    // ----- createSecureCsrfToken -----
+
+    @Test
+    void createSecureCsrfToken_ShouldReturnRandomToken() {
+        String sessionToken = service.createSession(5, VICTIM);
+        String csrfToken = service.createSecureCsrfToken(5, sessionToken);
+
+        assertNotNull(csrfToken);
+        assertTrue(csrfToken.length() == 64);
+        assertEquals(csrfToken, service.getSession(5, sessionToken).getCsrfToken());
+    }
+
+    @Test
+    void createSecureCsrfToken_ShouldThrow_WhenSessionInvalid() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.createSecureCsrfToken(1, "nonexistent-token"));
+    }
+
+    // ----- createWeakCsrfToken -----
+
+    @Test
+    void createWeakCsrfToken_ShouldHaveUsernameEpochFormat() {
+        String weakToken = service.createWeakCsrfToken(VICTIM);
+
+        assertNotNull(weakToken);
+        assertTrue(weakToken.startsWith("victim:"));
+        String[] parts = weakToken.split(":", 2);
+        assertEquals(2, parts.length);
+        Long.parseLong(parts[1]);
+    }
+
+    // ----- isValidWeakToken -----
+
+    @Test
+    void isValidWeakToken_ShouldAcceptValidFormat() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        String token = "victim:" + (System.currentTimeMillis() / 1000);
+
+        assertTrue(service.isValidWeakToken(session, token));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldRejectNullSession() {
+        assertFalse(service.isValidWeakToken(null, "victim:12345"));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldRejectNullToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertFalse(service.isValidWeakToken(session, null));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldRejectWrongUsername() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertFalse(service.isValidWeakToken(session, "attacker:12345"));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldRejectNonNumericTimestamp() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertFalse(service.isValidWeakToken(session, "victim:notanumber"));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldRejectNoColon() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertFalse(service.isValidWeakToken(session, "victim12345"));
+    }
+
+    @Test
+    void isValidWeakToken_ShouldAcceptAnyTimestampWithinSession() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertTrue(service.isValidWeakToken(session, "victim:0"));
+        assertTrue(service.isValidWeakToken(session, "victim:9999999999"));
+    }
+
+    // ----- isValidSecureToken -----
+
+    @Test
+    void isValidSecureToken_ShouldAcceptMatchingToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        session.setCsrfToken("abc123");
+
+        assertTrue(service.isValidSecureToken(session, "abc123"));
+    }
+
+    @Test
+    void isValidSecureToken_ShouldRejectNullSession() {
+        assertFalse(service.isValidSecureToken(null, "abc"));
+    }
+
+    @Test
+    void isValidSecureToken_ShouldRejectNullTokenInSession() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        assertFalse(service.isValidSecureToken(session, "abc"));
+    }
+
+    @Test
+    void isValidSecureToken_ShouldRejectNullHeaderValue() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        session.setCsrfToken("abc");
+        assertFalse(service.isValidSecureToken(session, null));
+    }
+
+    @Test
+    void isValidSecureToken_ShouldRejectDifferentToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        session.setCsrfToken("abc123");
+        assertFalse(service.isValidSecureToken(session, "abc124"));
+    }
+
+    @Test
+    void isValidSecureToken_ShouldRejectShorterToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "v@example.com");
+        session.setCsrfToken("abc123");
+        assertFalse(service.isValidSecureToken(session, "abc"));
+    }
+
+    // ----- updateEmail -----
+
+    @Test
+    void updateEmail_ShouldCallJdbcUpdate() {
+        when(jdbcTemplate.update(anyString(), any(), any())).thenReturn(1);
+
+        service.updateEmail(1, 1, "new@example.com");
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> argsCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(jdbcTemplate).update(sqlCaptor.capture(), argsCaptor.capture(), argsCaptor.capture());
+        assertEquals("UPDATE csrf_accounts_l1 SET email=? WHERE id=?", sqlCaptor.getValue());
+    }
+
+    // ----- emailOf -----
+
+    @Test
+    void emailOf_ShouldReturnEmail_WhenSessionExists() {
+        String sessionToken = service.createSession(1, VICTIM);
+        assertEquals("victim@example.com", service.emailOf(1, sessionToken));
+    }
+
+    @Test
+    void emailOf_ShouldReturnNull_WhenSessionMissing() {
+        assertNull(service.emailOf(1, "nonexistent"));
+    }
+
+    // ----- accountByUsername -----
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void accountByUsername_ShouldReturnAccount_WhenFound() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenAnswer(
+                        inv -> {
+                            RowMapper<CSRFAccount> mapper = inv.getArgument(2);
+                            ResultSet rs = mock(ResultSet.class);
+                            when(rs.getInt("id")).thenReturn(1);
+                            when(rs.getString("username")).thenReturn("victim");
+                            when(rs.getString("email")).thenReturn("victim@example.com");
+                            return Arrays.asList(mapper.mapRow(rs, 0));
+                        });
+
+        CSRFAccount result = service.accountByUsername(1, "victim");
+
+        assertNotNull(result);
+        assertEquals("victim", result.getUsername());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void accountByUsername_ShouldReturnNull_WhenNotFound() {
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenReturn(Collections.emptyList());
+
+        assertNull(service.accountByUsername(1, "nonexistent"));
+    }
+
+    // ----- refreshSessionEmail -----
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void refreshSessionEmail_ShouldUpdateSessionEmail() {
+        String sessionToken = service.createSession(1, VICTIM);
+        assertEquals("victim@example.com", service.emailOf(1, sessionToken));
+
+        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+                .thenAnswer(
+                        inv -> {
+                            RowMapper<CSRFAccount> mapper = inv.getArgument(2);
+                            ResultSet rs = mock(ResultSet.class);
+                            when(rs.getInt("id")).thenReturn(1);
+                            when(rs.getString("username")).thenReturn("victim");
+                            when(rs.getString("email")).thenReturn("updated@example.com");
+                            return Arrays.asList(mapper.mapRow(rs, 0));
+                        });
+
+        service.refreshSessionEmail(1, sessionToken);
+
+        assertEquals("updated@example.com", service.emailOf(1, sessionToken));
+    }
+
+    @Test
+    void refreshSessionEmail_ShouldHandleNullSession() {
+        service.refreshSessionEmail(1, "nonexistent");
+    }
+
+    // ----- CSRFLoginSession -----
+
+    @Test
+    void loginSession_ShouldHaveCreatedAt() {
+        long before = System.currentTimeMillis();
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("user", "u@e.com");
+        long after = System.currentTimeMillis();
+
+        assertTrue(session.getCreatedAt() >= before);
+        assertTrue(session.getCreatedAt() <= after);
+    }
+
+    @Test
+    void loginSession_SetEmail_ShouldUpdateEmail() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("user", "old@e.com");
+
+        session.setEmail("new@e.com");
+
+        assertEquals("new@e.com", session.getEmail());
+    }
+
+    @Test
+    void loginSession_SetCsrfToken_ShouldUpdateToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("user", "u@e.com");
+
+        assertNull(session.getCsrfToken());
+        session.setCsrfToken("tok123");
+        assertEquals("tok123", session.getCsrfToken());
+    }
+}

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
@@ -41,7 +41,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void authenticate_ShouldReturnAccount_WhenCredentialsValid() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenAnswer(
                         inv -> {
                             RowMapper<CSRFAccount> mapper = inv.getArgument(2);
@@ -66,7 +66,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void authenticate_ShouldReturnNull_WhenPasswordInvalid() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenAnswer(
                         inv -> {
                             RowMapper<CSRFAccount> mapper = inv.getArgument(2);
@@ -88,7 +88,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void authenticate_ShouldReturnNull_WhenUserNotFound() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenReturn(Collections.emptyList());
 
         CSRFAccount result = service.authenticate(1, "nonexistent", "password");
@@ -99,7 +99,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void authenticate_ShouldReturnNull_WhenPasswordHasNoSeparator() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenAnswer(
                         inv -> {
                             RowMapper<CSRFAccount> mapper = inv.getArgument(2);
@@ -304,7 +304,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void accountByUsername_ShouldReturnAccount_WhenFound() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenAnswer(
                         inv -> {
                             RowMapper<CSRFAccount> mapper = inv.getArgument(2);
@@ -324,7 +324,7 @@ class CSRFSessionServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     void accountByUsername_ShouldReturnNull_WhenNotFound() {
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenReturn(Collections.emptyList());
 
         assertNull(service.accountByUsername(1, "nonexistent"));
@@ -338,7 +338,7 @@ class CSRFSessionServiceTest {
         String sessionToken = service.createSession(1, VICTIM);
         assertEquals("victim@example.com", service.emailOf(1, sessionToken));
 
-        when(jdbcTemplate.query(anyString(), any(), any(RowMapper.class)))
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
                 .thenAnswer(
                         inv -> {
                             RowMapper<CSRFAccount> mapper = inv.getArgument(2);

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFSessionServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,8 +26,7 @@ class CSRFSessionServiceTest {
     private JdbcTemplate jdbcTemplate;
     private CSRFSessionService service;
 
-    private static final CSRFAccount VICTIM =
-            new CSRFAccount(1, "victim", "victim@example.com");
+    private static final CSRFAccount VICTIM = new CSRFAccount(1, "victim", "victim@example.com");
     private static final CSRFAccount ATTACKER =
             new CSRFAccount(2, "attacker", "attacker@example.com");
 
@@ -283,7 +281,8 @@ class CSRFSessionServiceTest {
 
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Object> argsCaptor = ArgumentCaptor.forClass(Object.class);
-        verify(jdbcTemplate).update(sqlCaptor.capture(), argsCaptor.capture(), argsCaptor.capture());
+        verify(jdbcTemplate)
+                .update(sqlCaptor.capture(), argsCaptor.capture(), argsCaptor.capture());
         assertEquals("UPDATE csrf_accounts_l1 SET email=? WHERE id=?", sqlCaptor.getValue());
     }
 

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
@@ -26,10 +26,8 @@ class CSRFVulnerabilityTest {
     private HttpServletRequest request;
     private HttpServletResponse response;
 
-    private static final CSRFAccount VICTIM =
-            new CSRFAccount(1, "victim", "victim@example.com");
-    private static final CSRFAccount ATTACKER =
-            new CSRFAccount(2, "attacker", "attacker@evil.com");
+    private static final CSRFAccount VICTIM = new CSRFAccount(1, "victim", "victim@example.com");
+    private static final CSRFAccount ATTACKER = new CSRFAccount(2, "attacker", "attacker@evil.com");
     private static final String SESSION_TOKEN = "abc123def456";
     private static final String CSRF_TOKEN = "tok123";
 
@@ -68,8 +66,9 @@ class CSRFVulnerabilityTest {
 
     @Test
     void level1ChangeEmail_ShouldSucceed_WhenSessionValid() {
-        when(csrfSessionService.getSession(1, SESSION_TOKEN)).thenReturn(
-                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.getSession(1, SESSION_TOKEN))
+                .thenReturn(
+                        new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
         when(csrfSessionService.accountByUsername(1, "victim")).thenReturn(VICTIM);
 
         ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
@@ -93,8 +92,9 @@ class CSRFVulnerabilityTest {
 
     @Test
     void level1Account_ShouldReturnAccount_WhenSessionValid() {
-        when(csrfSessionService.getSession(1, SESSION_TOKEN)).thenReturn(
-                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.getSession(1, SESSION_TOKEN))
+                .thenReturn(
+                        new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
         when(csrfSessionService.accountByUsername(1, "victim")).thenReturn(VICTIM);
 
         ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
@@ -262,8 +262,7 @@ class CSRFVulnerabilityTest {
                 controller.level5Login("victim", "Victim@123", request, response);
 
         assertTrue(result.getBody().getIsValid());
-        verify(response).addHeader(
-                eq("Set-Cookie"), anyString());
+        verify(response).addHeader(eq("Set-Cookie"), anyString());
     }
 
     @Test
@@ -308,8 +307,9 @@ class CSRFVulnerabilityTest {
 
     @Test
     void level5Account_ShouldReturnAccount() {
-        when(csrfSessionService.getSession(5, SESSION_TOKEN)).thenReturn(
-                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.getSession(5, SESSION_TOKEN))
+                .thenReturn(
+                        new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
         when(csrfSessionService.accountByUsername(5, "victim")).thenReturn(VICTIM);
 
         ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
@@ -1,0 +1,335 @@
+package org.sasanlabs.service.vulnerability.csrf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class CSRFVulnerabilityTest {
+
+    private CSRFSessionService csrfSessionService;
+    private CSRFVulnerability controller;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    private static final CSRFAccount VICTIM =
+            new CSRFAccount(1, "victim", "victim@example.com");
+    private static final CSRFAccount ATTACKER =
+            new CSRFAccount(2, "attacker", "attacker@evil.com");
+    private static final String SESSION_TOKEN = "abc123def456";
+    private static final String CSRF_TOKEN = "tok123";
+
+    @BeforeEach
+    void setup() {
+        csrfSessionService = mock(CSRFSessionService.class);
+        controller = new CSRFVulnerability(csrfSessionService);
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    // ===== LEVEL 1 =====
+
+    @Test
+    void level1Login_ShouldReturnAccount_WhenAuthenticated() {
+        when(csrfSessionService.authenticate(1, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(1), any())).thenReturn(SESSION_TOKEN);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1Login("victim", "Victim@123", request, response);
+
+        assertTrue(result.getBody().getIsValid());
+        verify(response).addCookie(any(Cookie.class));
+    }
+
+    @Test
+    void level1Login_ShouldReturnInvalidCredentials_WhenAuthFails() {
+        when(csrfSessionService.authenticate(1, "victim", "wrong")).thenReturn(null);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1Login("victim", "wrong", request, response);
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals("Invalid credentials", result.getBody().getContent());
+    }
+
+    @Test
+    void level1ChangeEmail_ShouldSucceed_WhenSessionValid() {
+        when(csrfSessionService.getSession(1, SESSION_TOKEN)).thenReturn(
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.accountByUsername(1, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1ChangeEmail(SESSION_TOKEN, "new@example.com");
+
+        assertTrue(result.getBody().getIsValid());
+        assertEquals("Email updated successfully", result.getBody().getContent());
+        verify(csrfSessionService).updateEmail(1, 1, "new@example.com");
+    }
+
+    @Test
+    void level1ChangeEmail_ShouldReturn401_WhenSessionMissing() {
+        when(csrfSessionService.getSession(1, null)).thenReturn(null);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1ChangeEmail(null, "new@example.com");
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+    }
+
+    @Test
+    void level1Account_ShouldReturnAccount_WhenSessionValid() {
+        when(csrfSessionService.getSession(1, SESSION_TOKEN)).thenReturn(
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.accountByUsername(1, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1Account(SESSION_TOKEN);
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    @Test
+    void level1Account_ShouldReturn401_WhenSessionMissing() {
+        when(csrfSessionService.getSession(1, null)).thenReturn(null);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level1Account(null);
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+    }
+
+    // ===== LEVEL 2 =====
+
+    @Test
+    void level2Login_ShouldReturnLoginResponseWithCsrfToken() {
+        when(csrfSessionService.authenticate(2, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(2), any())).thenReturn(SESSION_TOKEN);
+        when(csrfSessionService.createSecureCsrfToken(2, SESSION_TOKEN)).thenReturn(CSRF_TOKEN);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level2Login("victim", "Victim@123", request, response);
+
+        assertTrue(result.getBody().getIsValid());
+        Object content = result.getBody().getContent();
+        assertTrue(content instanceof CSRFVulnerability.CSRFLoginResponse);
+        CSRFVulnerability.CSRFLoginResponse loginResponse =
+                (CSRFVulnerability.CSRFLoginResponse) content;
+        assertEquals(CSRF_TOKEN, loginResponse.getCsrfToken());
+        assertEquals("victim", loginResponse.getAccount().getUsername());
+    }
+
+    @Test
+    void level2ChangeEmail_ShouldSucceed_WithAnyToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(2, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.accountByUsername(2, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level2ChangeEmail(SESSION_TOKEN, "any-token", "evil@hacker.com");
+
+        assertTrue(result.getBody().getIsValid());
+        verify(csrfSessionService).updateEmail(2, 1, "evil@hacker.com");
+    }
+
+    // ===== LEVEL 3 =====
+
+    @Test
+    void level3Login_ShouldReturnWeakToken() {
+        when(csrfSessionService.authenticate(3, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(3), any())).thenReturn(SESSION_TOKEN);
+        when(csrfSessionService.createWeakCsrfToken(VICTIM)).thenReturn("victim:1234567890");
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level3Login("victim", "Victim@123", request, response);
+
+        assertTrue(result.getBody().getIsValid());
+        CSRFVulnerability.CSRFLoginResponse loginResponse =
+                (CSRFVulnerability.CSRFLoginResponse) result.getBody().getContent();
+        assertEquals("victim:1234567890", loginResponse.getCsrfToken());
+    }
+
+    @Test
+    void level3ChangeEmail_ShouldSucceed_WithValidWeakToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(3, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidWeakToken(session, "victim:9999999")).thenReturn(true);
+        when(csrfSessionService.accountByUsername(3, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level3ChangeEmail(SESSION_TOKEN, "victim:9999999", "evil@hacker.com");
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    @Test
+    void level3ChangeEmail_ShouldReturn403_WithInvalidWeakToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(3, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidWeakToken(session, "wrong:token")).thenReturn(false);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level3ChangeEmail(SESSION_TOKEN, "wrong:token", "evil@hacker.com");
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals(HttpStatus.FORBIDDEN, result.getStatusCode());
+    }
+
+    // ===== LEVEL 4 =====
+
+    @Test
+    void level4Login_ShouldReturnSecureToken() {
+        when(csrfSessionService.authenticate(4, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(4), any())).thenReturn(SESSION_TOKEN);
+        when(csrfSessionService.createSecureCsrfToken(4, SESSION_TOKEN)).thenReturn(CSRF_TOKEN);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level4Login("victim", "Victim@123", request, response);
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    @Test
+    void level4ChangeEmail_ShouldSucceed_WithValidSecureToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(4, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidSecureToken(session, CSRF_TOKEN)).thenReturn(true);
+        when(csrfSessionService.accountByUsername(4, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level4ChangeEmail(SESSION_TOKEN, CSRF_TOKEN, "new@email.com");
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    @Test
+    void level4ChangeEmail_ShouldReturn403_WithInvalidToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(4, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidSecureToken(session, "wrong")).thenReturn(false);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level4ChangeEmail(SESSION_TOKEN, "wrong", "evil@hacker.com");
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals(HttpStatus.FORBIDDEN, result.getStatusCode());
+    }
+
+    @Test
+    void level4ChangeEmailViaGet_ShouldSucceed_WithoutTokenCheck() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(4, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.accountByUsername(4, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level4ChangeEmailViaGet(SESSION_TOKEN, "evil@hacker.com");
+
+        assertTrue(result.getBody().getIsValid());
+        verify(csrfSessionService).updateEmail(4, 1, "evil@hacker.com");
+    }
+
+    // ===== LEVEL 5 =====
+
+    @Test
+    void level5Login_ShouldSetSameSiteLaxCookie() {
+        when(csrfSessionService.authenticate(5, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(5), any())).thenReturn(SESSION_TOKEN);
+        when(csrfSessionService.createSecureCsrfToken(5, SESSION_TOKEN)).thenReturn(CSRF_TOKEN);
+        when(request.isSecure()).thenReturn(true);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level5Login("victim", "Victim@123", request, response);
+
+        assertTrue(result.getBody().getIsValid());
+        verify(response).addHeader(
+                eq("Set-Cookie"), anyString());
+    }
+
+    @Test
+    void level5Login_ShouldAddSecureFlag_WhenSecureRequest() {
+        when(csrfSessionService.authenticate(5, "victim", "Victim@123")).thenReturn(VICTIM);
+        when(csrfSessionService.createSession(eq(5), any())).thenReturn(SESSION_TOKEN);
+        when(csrfSessionService.createSecureCsrfToken(5, SESSION_TOKEN)).thenReturn(CSRF_TOKEN);
+        when(request.isSecure()).thenReturn(true);
+
+        controller.level5Login("victim", "Victim@123", request, response);
+
+        verify(response).addHeader(eq("Set-Cookie"), anyString());
+    }
+
+    @Test
+    void level5ChangeEmail_ShouldSucceed_WithValidToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(5, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidSecureToken(session, CSRF_TOKEN)).thenReturn(true);
+        when(csrfSessionService.accountByUsername(5, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level5ChangeEmail(SESSION_TOKEN, CSRF_TOKEN, "new@email.com");
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    @Test
+    void level5ChangeEmail_ShouldReturn403_WithInvalidToken() {
+        CSRFSessionService.CSRFLoginSession session =
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com");
+        when(csrfSessionService.getSession(5, SESSION_TOKEN)).thenReturn(session);
+        when(csrfSessionService.isValidSecureToken(session, "wrong")).thenReturn(false);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level5ChangeEmail(SESSION_TOKEN, "wrong", "evil@hacker.com");
+
+        assertFalse(result.getBody().getIsValid());
+        assertEquals(HttpStatus.FORBIDDEN, result.getStatusCode());
+    }
+
+    @Test
+    void level5Account_ShouldReturnAccount() {
+        when(csrfSessionService.getSession(5, SESSION_TOKEN)).thenReturn(
+                new CSRFSessionService.CSRFLoginSession("victim", "victim@example.com"));
+        when(csrfSessionService.accountByUsername(5, "victim")).thenReturn(VICTIM);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<Object>> result =
+                controller.level5Account(SESSION_TOKEN);
+
+        assertTrue(result.getBody().getIsValid());
+    }
+
+    // ===== CSRFLoginResponse =====
+
+    @Test
+    void csrfLoginResponse_Getters_ShouldWork() {
+        CSRFVulnerability.CSRFLoginResponse loginResponse =
+                new CSRFVulnerability.CSRFLoginResponse(VICTIM, CSRF_TOKEN);
+
+        assertEquals(VICTIM, loginResponse.getAccount());
+        assertEquals(CSRF_TOKEN, loginResponse.getCsrfToken());
+    }
+}

--- a/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/csrf/CSRFVulnerabilityTest.java
@@ -2,15 +2,11 @@ package org.sasanlabs.service.vulnerability.csrf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
Fixes #713

## What

Adds a full CSRF (Cross-Site Request Forgery, CWE-352) lab with five progressive levels, following the same structure as the existing labs (IDOR, XSS, etc.):

- **Level 1** – No CSRF protection at all: the email change endpoint only checks the session cookie.
- **Level 2** – The server issues a CSRF token after login, but the change endpoint reads the `X-CSRF-Token` header and never validates it.
- **Level 3** – The token is validated, but it is generated as `username:epochSeconds`, so an attacker can forge a valid token within the 2 minute acceptance window.
- **Level 4** – The POST endpoint is properly protected, but the same state-changing operation is also exposed over GET, which works as a real browser attack (top-level navigation carries the Lax cookie).
- **Level 5** – Secure implementation: unpredictable server-side token validated on every state change, session cookie marked `SameSite=Lax`, no state change over GET.

## Implementation details

- Each level has its own isolated user table (`csrf_accounts_l1..l5`) and session cookie (`csrf_session_l1..l5`) so that solving one level does not break the state of the others. Two users per table: `victim`/`Victim@123` and `attacker`/`Attacker@123`.
- Passwords are stored as salted SHA-256 hashes, reusing the existing `PasswordHashingUtils`.
- Every level ships a challenge card with three hints plus a payload description, the attack vector is annotated with `@AttackVector` and the benchmark CSV is updated with the CWE-352 expected issues.
- UI follows the existing vanilla JS template pattern (`static/templates/CSRFVulnerability/LEVEL_X/CSRF.{html,js,css}`). The issue mentions a React SPA; this repo currently has no React setup and all labs use the plain template approach, so I kept it consistent with the codebase. Happy to adjust if a React migration is preferred.

## How to test

```bash
./gradlew bootRun
```

1. Open `http://localhost:9090/VulnerableApp/CSRFVulnerability`
2. Login as `victim` / `Victim@123` on each level
3. Levels 1–3 can be exploited with a curl request that carries the victim's session cookie (hints show the exact commands)
4. Level 4 works by opening the GET link in a new tab while logged in
5. Level 5 rejects requests without a valid token and the cookie is `SameSite=Lax`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a five-level Cross-Site Request Forgery (CSRF) training lab.
  * Covers missing protection, invalid and predictable tokens, unsafe state-changing requests, and secure token validation.
  * Added login, account, email-update, token, and attack-demonstration interactions for each level.
  * Added seeded accounts and responsive pages with status feedback, hints, and example requests.
  * Secure demonstrations include protected cookies and server-side token validation.

* **Documentation**
  * Added challenge descriptions, attack-vector explanations, payload guidance, and progressive-level instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->