### PR TITLE
feat: add Challenge mode to Error-Based and Union-Based SQL Injection

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/ErrorBasedSQLInjectionVulnerability.java
@@ -9,6 +9,7 @@ import org.sasanlabs.internal.utility.JSONSerializationUtils;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
@@ -54,6 +55,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
             description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -99,6 +115,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             description =
                     "ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -145,6 +176,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             description =
                     "ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_3")
+    @ChallengeCard(
+            challengeText = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -195,6 +241,21 @@ public class ErrorBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
             description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY",
             payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_4")
+    @ChallengeCard(
+            challengeText = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION",
+                            value = "ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")

--- a/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/sqlInjection/UnionBasedSQLInjectionVulnerability.java
@@ -12,6 +12,7 @@ import javax.persistence.criteria.Root;
 import org.sasanlabs.internal.utility.LevelConstants;
 import org.sasanlabs.internal.utility.Variant;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.vulnerability.types.VulnerabilityType;
@@ -59,6 +60,21 @@ public class UnionBasedSQLInjectionVulnerability {
             vulnerabilityExposed = VulnerabilityType.UNION_BASED_SQL_INJECTION,
             description = "UNION_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
             payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
+    @ChallengeCard(
+            challengeText = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION",
+                            value = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")
@@ -74,6 +90,21 @@ public class UnionBasedSQLInjectionVulnerability {
             description =
                     "UNION_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
             payload = "UNION_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
+    @ChallengeCard(
+            challengeText = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(
+                        order = 1,
+                        text = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1"),
+                @ChallengeCard.Hint(
+                        order = 2,
+                        text = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description =
+                                    "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION",
+                            value = "UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/SQLInjection_Level1")

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1064,3 +1064,41 @@ PERSISTENT_XSS_LEVEL7_HINT2=Even the null-byte-prefix trick that worked on level
 PERSISTENT_XSS_LEVEL7_PAYLOAD_DESCRIPTION=The same null-byte-prefixed script payload that broke level 6 is now fully escaped and rendered as inert text.
 PERSISTENT_XSS_LEVEL7_PAYLOAD_VALUE=%00<script>alert(1)</script>
 BLIND_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE2_PAYLOAD_VALUE=1 AND (SELECT SUBSTRING(password,1,1) FROM auth_users WHERE username='admin_sqli')='n'
+
+# Error Based SQL Injection Challenge Mode
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Get a car back for an id that doesn't exist in the table.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated straight into "select * from cars where id=" + id with no quoting or filtering at all - it lands directly in a numeric SQL context.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A boolean tautology like OR 1=1 makes the WHERE clause true for every row in the table, not just the id you asked for.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=999 OR 1=1 turns the query into "id=999 OR 1=1", which is true for every row, so the first car in the table comes back even though car 999 was never there.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=999 OR 1=1
+
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The id is now wrapped in single quotes before being appended to the query. Get the same nonexistent-id bypass anyway.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The template changed to id='<value>', but your input still isn't escaped - a single quote inside it still closes the app's string literal early.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Once the quote is closed you're writing real SQL again - reuse the level 1 OR-tautology trick, just wrap each side in its own quotes so the total quote count balances out with the one the app appends at the end.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The four quotes in 999' OR '1'='1 pair up with the app's opening and closing quotes to form the fully balanced, valid expression id='999' OR '1'='1', which is true for every row.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=999' OR '1'='1
+
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Every single quote you send is now stripped before it reaches the query, so the level 2 breakout is dead, and the id column's strict typing means no bypass gets you a different car either. The query's own error message still tells you more than it should, though - trigger it.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=id.replaceAll("'", "") removes every apostrophe from your input before it's ever used, and since the id column is INT, anything that isn't a clean number fails a strict type-conversion check - there's no quote to close, and no backslash or look-alike Unicode quote reopens that door either.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=When that type conversion fails, the database reports the exact SQL statement it tried to run, including the table name and column layout - a well-behaved app would catch that exception and return a generic error instead of relaying it.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Any non-numeric value fails H2's type conversion, and the response echoes the full query text (select * from cars where id='...') straight back to you - confirming the table name, the column being queried, and the database engine, without ever bypassing the actual access control.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=not-a-number
+
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=This level wraps the query in a PreparedStatement - but check whether the "?" placeholder it's known for is actually used before assuming that alone makes it safe.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=conn.prepareStatement("select * from cars where id='" + id + "'") builds the complete SQL text, your id value included, by string concatenation before the statement object even exists - the (ps) -> {} callback that runs afterward never calls setString, so there's no bind parameter here despite the PreparedStatement wrapper.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=id still goes through the same replaceAll("'", "") stripping as level 3, so the same limits apply: no quote breakout, and a non-numeric value fails with the same verbose type-conversion error - the PreparedStatement class here adds no protection your input didn't already have on level 3.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=A non-numeric id fails exactly the way it did on level 3, and the leaked error confirms this "prepared" statement's SQL text was built by concatenation, not parameterization - the PreparedStatement object provides no real protection here.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=not-a-number
+
+# Union Based SQL Injection Challenge Mode
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=This endpoint returns one car record. Use it to leak a row from a completely different table you were never meant to see - the users table.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated directly into "select * from cars where id=" + id in a numeric context, with no quoting or filtering at all.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A UNION SELECT appends a second, attacker-chosen query onto the original one - as long as it returns the same number of columns (three, matching id/name/image here), the database merges both result sets into one.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Forcing the original query to match nothing (-1) means the single row the app returns comes entirely from the injected UNION SELECT id, name, email FROM users instead - the response's "imagePath" field ends up holding a user's email address.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=-1 UNION SELECT id, name, email FROM users
+
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The id is now wrapped in single quotes. Get the same cross-table UNION leak anyway.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=Just like level 1, your input isn't escaped - a single quote in it still closes the app's opening quote early, and everything after that is parsed as real SQL again.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the quote, write your UNION SELECT as normal, then comment out the rest of the original query - including the app's own trailing quote - with -- so the combined statement still parses.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The leading quote closes the app's string literal, the UNION SELECT pulls a row from users instead of cars, and the trailing -- comments out the app's own closing quote so the combined query stays syntactically valid.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=-1' UNION SELECT id, name, email FROM users --

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1091,14 +1091,14 @@ ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=A non-numeric
 ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=not-a-number
 
 # Union Based SQL Injection Challenge Mode
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract admin_sqli's username and password from the auth_users table.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract the ADMIN user's username and salary from the idor_users table.
 UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated directly into the query with no quoting or filtering at all, in a plain numeric context.
 UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A UNION SELECT appends a second, attacker-chosen query onto the original one, as long as both return the same number of columns - point the original query at an id that doesn't exist so only your injected row comes back.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Forcing the original query to match nothing (-1) means the single row returned comes entirely from the injected UNION SELECT against auth_users, filtered down to admin_sqli's own row - the response's "name" and "imagePath" fields end up holding the username and password.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=-1 UNION SELECT id, username, password FROM auth_users WHERE username='admin_sqli'
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Forcing the original query to match nothing (-1) means the single row returned comes entirely from the injected UNION SELECT against idor_users, filtered down to the ADMIN role - the response's "name" and "imagePath" fields end up holding the username and salary.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=-1 UNION SELECT id, username, salary FROM idor_users WHERE role='ADMIN'
 
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract admin_sqli's username and password from the auth_users table.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract the ADMIN user's username and salary from the idor_users table.
 UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=Your id value is placed between single quotes before the query runs, but it still isn't escaped.
 UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the quote, write your UNION SELECT as normal against an id that doesn't exist, then comment out the rest of the original query - including the app's own trailing quote - so the combined statement still parses.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The leading quote closes the app's string literal, the UNION SELECT filters auth_users down to admin_sqli's own row, and the trailing -- comments out the app's own closing quote so the combined query stays syntactically valid.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=-1' UNION SELECT id, username, password FROM auth_users WHERE username='admin_sqli' --
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The leading quote closes the app's string literal, the UNION SELECT filters idor_users down to the ADMIN role, and the trailing -- comments out the app's own closing quote so the combined query stays syntactically valid.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=-1' UNION SELECT id, username, salary FROM idor_users WHERE role='ADMIN' --

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1066,39 +1066,39 @@ PERSISTENT_XSS_LEVEL7_PAYLOAD_VALUE=%00<script>alert(1)</script>
 BLIND_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE2_PAYLOAD_VALUE=1 AND (SELECT SUBSTRING(password,1,1) FROM auth_users WHERE username='admin_sqli')='n'
 
 # Error Based SQL Injection Challenge Mode
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Get a car back for an id that doesn't exist in the table.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated straight into "select * from cars where id=" + id with no quoting or filtering at all - it lands directly in a numeric SQL context.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A boolean tautology like OR 1=1 makes the WHERE clause true for every row in the table, not just the id you asked for.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=999 OR 1=1 turns the query into "id=999 OR 1=1", which is true for every row, so the first car in the table comes back even though car 999 was never there.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=999 OR 1=1
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Using nothing but the database's own error messages, find the password stored for admin_sqli in the auth_users table.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated straight into the query with no quoting or filtering at all, so anything you send becomes part of the SQL the database executes.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=Wrap a subquery in CAST(... AS int) - if the value it reads back can't convert to a number, the database's own error message includes the exact value it tried to convert.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=CAST((SELECT password FROM auth_users WHERE username='admin_sqli') AS int) forces the database to try converting admin_sqli's password to a number; since it isn't one, the conversion fails and the error message echoes the password back in full.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=1 AND CAST((SELECT password FROM auth_users WHERE username='admin_sqli') AS int)=1
 
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The id is now wrapped in single quotes before being appended to the query. Get the same nonexistent-id bypass anyway.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=The template changed to id='<value>', but your input still isn't escaped - a single quote inside it still closes the app's string literal early.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Once the quote is closed you're writing real SQL again - reuse the level 1 OR-tautology trick, just wrap each side in its own quotes so the total quote count balances out with the one the app appends at the end.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The four quotes in 999' OR '1'='1 pair up with the app's opening and closing quotes to form the fully balanced, valid expression id='999' OR '1'='1', which is true for every row.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=999' OR '1'='1
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Using the database's own error messages, find the password stored for admin_sqli in the auth_users table.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=Your id value is placed between single quotes before the query runs, but it still isn't escaped.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the quote with a value that still matches a real car, add your CAST-based subquery after AND, then comment out the rest of the line so the statement still parses.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=Closing the app's quote with 1' AND CAST(...)=1 -- keeps the query syntactically valid while forcing the same password-leaking conversion error as an unquoted context.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=1' AND CAST((SELECT password FROM auth_users WHERE username='admin_sqli') AS int)=1 --
 
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Every single quote you send is now stripped before it reaches the query, so the level 2 breakout is dead, and the id column's strict typing means no bypass gets you a different car either. The query's own error message still tells you more than it should, though - trigger it.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=id.replaceAll("'", "") removes every apostrophe from your input before it's ever used, and since the id column is INT, anything that isn't a clean number fails a strict type-conversion check - there's no quote to close, and no backslash or look-alike Unicode quote reopens that door either.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=When that type conversion fails, the database reports the exact SQL statement it tried to run, including the table name and column layout - a well-behaved app would catch that exception and return a generic error instead of relaying it.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Any non-numeric value fails H2's type conversion, and the response echoes the full query text (select * from cars where id='...') straight back to you - confirming the table name, the column being queried, and the database engine, without ever bypassing the actual access control.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_CHALLENGE=Find out which database engine powers this endpoint, using nothing but the response it gives you back.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT1=Every single quote is stripped from your input before the query runs, and the id column only accepts numbers - so nothing you send can change the shape of the query itself, only whether it fails.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_HINT2=A value that isn't a valid number still gets sent to the database and still fails there - and the exception the app relays back to you names its own class, which gives away exactly which engine is running underneath.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_DESCRIPTION=Any non-numeric value fails the database's own type check, and the relayed exception's class name - org.h2.jdbc.JdbcSQLDataException - confirms this endpoint runs on the H2 database engine, along with the exact query text and table involved.
 ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL3_PAYLOAD_VALUE=not-a-number
 
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=This level wraps the query in a PreparedStatement - but check whether the "?" placeholder it's known for is actually used before assuming that alone makes it safe.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=conn.prepareStatement("select * from cars where id='" + id + "'") builds the complete SQL text, your id value included, by string concatenation before the statement object even exists - the (ps) -> {} callback that runs afterward never calls setString, so there's no bind parameter here despite the PreparedStatement wrapper.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=id still goes through the same replaceAll("'", "") stripping as level 3, so the same limits apply: no quote breakout, and a non-numeric value fails with the same verbose type-conversion error - the PreparedStatement class here adds no protection your input didn't already have on level 3.
-ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=A non-numeric id fails exactly the way it did on level 3, and the leaked error confirms this "prepared" statement's SQL text was built by concatenation, not parameterization - the PreparedStatement object provides no real protection here.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_CHALLENGE=This endpoint builds its query using a PreparedStatement object. Confirm whether that alone is enough to stop the database's own errors from leaking information about it.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT1=A PreparedStatement is created here, but check whether the placeholder ("?") it's designed around is actually used, or whether the SQL text is already fully built before the statement object even exists.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_HINT2=Since your value is still concatenated as plain text into the SQL string first, a non-numeric input fails exactly the same way it would with no PreparedStatement at all.
+ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_DESCRIPTION=A non-numeric id fails the database's type check exactly as it would without a PreparedStatement, and the leaked error again names the H2 engine and exposes the query text - proving the PreparedStatement object here adds no real protection.
 ERROR_BASED_SQL_INJECTION_VULNERABILITY_LEVEL4_PAYLOAD_VALUE=not-a-number
 
 # Union Based SQL Injection Challenge Mode
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=This endpoint returns one car record. Use it to leak a row from a completely different table you were never meant to see - the users table.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated directly into "select * from cars where id=" + id in a numeric context, with no quoting or filtering at all.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A UNION SELECT appends a second, attacker-chosen query onto the original one - as long as it returns the same number of columns (three, matching id/name/image here), the database merges both result sets into one.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Forcing the original query to match nothing (-1) means the single row the app returns comes entirely from the injected UNION SELECT id, name, email FROM users instead - the response's "imagePath" field ends up holding a user's email address.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=-1 UNION SELECT id, name, email FROM users
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_CHALLENGE=Extract admin_sqli's username and password from the auth_users table.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT1=The id parameter is concatenated directly into the query with no quoting or filtering at all, in a plain numeric context.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_HINT2=A UNION SELECT appends a second, attacker-chosen query onto the original one, as long as both return the same number of columns - point the original query at an id that doesn't exist so only your injected row comes back.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_DESCRIPTION=Forcing the original query to match nothing (-1) means the single row returned comes entirely from the injected UNION SELECT against auth_users, filtered down to admin_sqli's own row - the response's "name" and "imagePath" fields end up holding the username and password.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL1_PAYLOAD_VALUE=-1 UNION SELECT id, username, password FROM auth_users WHERE username='admin_sqli'
 
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=The id is now wrapped in single quotes. Get the same cross-table UNION leak anyway.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=Just like level 1, your input isn't escaped - a single quote in it still closes the app's opening quote early, and everything after that is parsed as real SQL again.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the quote, write your UNION SELECT as normal, then comment out the rest of the original query - including the app's own trailing quote - with -- so the combined statement still parses.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The leading quote closes the app's string literal, the UNION SELECT pulls a row from users instead of cars, and the trailing -- comments out the app's own closing quote so the combined query stays syntactically valid.
-UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=-1' UNION SELECT id, name, email FROM users --
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_CHALLENGE=Extract admin_sqli's username and password from the auth_users table.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT1=Your id value is placed between single quotes before the query runs, but it still isn't escaped.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_HINT2=Close the quote, write your UNION SELECT as normal against an id that doesn't exist, then comment out the rest of the original query - including the app's own trailing quote - so the combined statement still parses.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_DESCRIPTION=The leading quote closes the app's string literal, the UNION SELECT filters auth_users down to admin_sqli's own row, and the trailing -- comments out the app's own closing quote so the combined query stays syntactically valid.
+UNION_BASED_SQL_INJECTION_VULNERABILITY_LEVEL2_PAYLOAD_VALUE=-1' UNION SELECT id, username, password FROM auth_users WHERE username='admin_sqli' --


### PR DESCRIPTION
## Summary

Part of #561. Adds `@ChallengeCard` to `ErrorBasedSQLInjectionVulnerability` and `UnionBasedSQLInjectionVulnerability`, the two SQL injection types Blind SQL Injection's challenge mode PR left uncovered.

Edit: redesigned per [@preetkaran20's review](https://github.com/SasanLabs/VulnerableApp/pull/761#pullrequestreview-4945163621). All four levels now extract `admin_sqli`'s real credentials instead of generic bypasses, matching the Blind SQL Injection pattern.

## Scope

UNSECURE levels only, same precedent as Blind SQL Injection:

- Error-Based: levels 1-4 get cards, level 5 (parameterized) doesn't.
- Union-Based: levels 1-2 get cards, levels 3-9 (parameterized/JPA/Criteria/Spring Data) don't.

## Approach

- **Levels 1-2**: CAST-error and UNION SELECT payloads pull `admin_sqli`'s password/username directly, verified against a running instance.
- **Levels 3-4**: quotes are stripped and `id` is INT-typed, so no data-access bypass is possible. Challenge targets the verbose SQL error instead (CWE-209), and level 4 shows a `PreparedStatement` used without `setString` gives no protection.

Every challenge is self-contained, mechanism details live in the hints only.

## Test plan

- [x] `./gradlew compileJava`, `./gradlew test`, `./gradlew spotlessApply` all clean
- [x] All 6 payloads verified against a running instance
- [x] Confirmed `@ChallengeCard` is present on exactly the 6 UNSECURE levels via `/VulnerableApp/allEndPointJson`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive challenge cards for error-based SQL injection levels 1–4.
  * Added challenge cards for UNION-based SQL injection levels 1–2.
  * Included localized challenge descriptions, hints, and example payload guidance for each challenge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
