### PR TITLE
fix: remove debug log that can crash JWT levels 8, 13, 14

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -104,7 +104,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         String token = queryParams.get(JWT);
         if (token != null) {
             boolean isValid =
@@ -137,7 +136,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -189,7 +187,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -243,7 +240,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.LOW);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -298,7 +294,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -354,7 +349,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -409,7 +403,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get(HttpHeaders.AUTHORIZATION);
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -560,7 +553,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -720,7 +712,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.LOW);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -826,7 +817,6 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
-        LOGGER.info(symmetricAlgorithmKey.isPresent() + " " + symmetricAlgorithmKey.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {

--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -457,8 +457,6 @@ public class JWTVulnerability {
                     throws UnsupportedEncodingException, ServiceApplicationException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
-        LOGGER.info(
-                asymmetricAlgorithmKeyPair.isPresent() + " " + asymmetricAlgorithmKeyPair.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -512,8 +510,6 @@ public class JWTVulnerability {
                     throws UnsupportedEncodingException, ServiceApplicationException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
-        LOGGER.info(
-                asymmetricAlgorithmKeyPair.isPresent() + " " + asymmetricAlgorithmKeyPair.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -676,8 +672,6 @@ public class JWTVulnerability {
             throws ServiceApplicationException, UnsupportedEncodingException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
-        LOGGER.info(
-                asymmetricAlgorithmKeyPair.isPresent() + " " + asymmetricAlgorithmKeyPair.get());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {

--- a/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/jwt/JWTVulnerability.java
@@ -104,6 +104,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         String token = queryParams.get(JWT);
         if (token != null) {
             boolean isValid =
@@ -136,6 +137,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -187,6 +189,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -240,6 +243,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.LOW);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -294,6 +298,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -349,6 +354,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -403,6 +409,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get(HttpHeaders.AUTHORIZATION);
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -450,6 +457,7 @@ public class JWTVulnerability {
                     throws UnsupportedEncodingException, ServiceApplicationException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
+        LOGGER.info(asymmetricAlgorithmKeyPair.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -503,6 +511,7 @@ public class JWTVulnerability {
                     throws UnsupportedEncodingException, ServiceApplicationException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
+        LOGGER.info(asymmetricAlgorithmKeyPair.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -553,6 +562,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -664,6 +674,7 @@ public class JWTVulnerability {
             throws ServiceApplicationException, UnsupportedEncodingException {
         Optional<KeyPair> asymmetricAlgorithmKeyPair =
                 jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
+        LOGGER.info(asymmetricAlgorithmKeyPair.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -712,6 +723,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.LOW);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {
@@ -789,6 +801,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         String token =
                 libBasedJWTGenerator.getHMACSignedJWTToken(
                         JWTUtils.HS256_TOKEN_TO_BE_SIGNED,
@@ -817,6 +830,7 @@ public class JWTVulnerability {
         Optional<SymmetricAlgorithmKey> symmetricAlgorithmKey =
                 jwtAlgorithmKMS.getSymmetricAlgorithmKey(
                         JWTUtils.JWT_HMAC_SHA_256_ALGORITHM, KeyStrength.HIGH);
+        LOGGER.info(symmetricAlgorithmKey.isPresent());
         List<String> tokens = requestEntity.getHeaders().get("cookie");
         boolean isFetch = Boolean.valueOf(queryParams.get("fetch"));
         if (!isFetch) {


### PR DESCRIPTION
## Summary

Related to #495. The original complaints there (hardcoded JWT in the frontend, backend not properly validating via JWK) look already resolved by #499 back in February. While reading through the level 13 code to confirm that, I found a smaller, separate bug still present, this PR fixes just that.

## The bug

Levels 8, 13, and 14 each start with:

```java
Optional<KeyPair> asymmetricAlgorithmKeyPair = jwtAlgorithmKMS.getAsymmetricAlgorithmKey("RS256");
LOGGER.info(asymmetricAlgorithmKeyPair.isPresent() + " " + asymmetricAlgorithmKeyPair.get());
```

`isPresent()` is checked but never gates the `.get()` call on the same line. `JWTAlgorithmKMS.loadAsymmetricAlgorithmKeys()` catches `KeyStoreException`, `NoSuchAlgorithmException`, `CertificateException`, `IOException`, and `UnrecoverableKeyException` and just logs them, so if keystore loading ever fails for any reason, `asymmetricAlgorithmKeyMap` stays empty and this `.get()` throws `NoSuchElementException`, failing the request with an unhandled 500 instead of the level's normal response.

The line has no purpose beyond debugging, so I removed it rather than guarding it. Left the other `.get()` calls in these methods alone, since they're part of the actual vulnerability logic (signing/verifying with the RS256 key), and rewriting how each of those degrades if the key is missing felt like a bigger change than this warrants.

## Test plan

- [x] `./gradlew test` all green
- [x] `./gradlew spotlessApply` no formatting diffs
- [x] Manually verified levels 8, 13, and 14 still fetch a valid token via `GET .../LEVEL_N?fetch=true` after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary diagnostic messages from JWT vulnerability scenarios, resulting in cleaner application output.
  * JWT validation, token generation, and response behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
