### PR TITLE
feat: add Challenge mode to Cryptographic Failures

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cryptographicFailures/CryptographicFailuresVulnerability.java
@@ -3,6 +3,7 @@ package org.sasanlabs.service.vulnerability.cryptographicFailures;
 import java.util.Map;
 import org.sasanlabs.internal.utility.*;
 import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.ChallengeCard;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
 import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
 import org.sasanlabs.internal.utility.exception.EncryptionException;
@@ -47,6 +48,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.INSECURE_CRYPTOGRAPHIC_STORAGE,
             description = "CRYPTOGRAPHIC_FAILURES_PLAINTEXT_STORAGE")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_1,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -89,6 +100,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.INSECURE_CRYPTOGRAPHIC_STORAGE,
             description = "CRYPTOGRAPHIC_FAILURES_BASE64_ENCODING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_2,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -136,6 +157,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.USE_OF_BROKEN_CRYPTOGRAPHIC_ALGORITHM,
             description = "CRYPTOGRAPHIC_FAILURES_INSECURE_CIPHER")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_3,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -182,6 +213,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.USE_OF_BROKEN_CRYPTOGRAPHIC_ALGORITHM,
             description = "CRYPTOGRAPHIC_FAILURES_SECURITY_BY_OBSCURITY")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_4,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -227,6 +268,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEAK_CRYPTOGRAPHIC_HASH,
             description = "CRYPTOGRAPHIC_FAILURES_MD4_HASHING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_5,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -273,6 +324,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEAK_CRYPTOGRAPHIC_HASH,
             description = "CRYPTOGRAPHIC_FAILURES_MD5_HASHING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_6,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -320,6 +381,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEAK_CRYPTOGRAPHIC_HASH,
             description = "CRYPTOGRAPHIC_FAILURES_SHA1_HASHING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_7,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -365,6 +436,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEAK_CRYPTOGRAPHIC_HASH,
             description = "CRYPTOGRAPHIC_FAILURES_LM_HASHING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_8,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -413,6 +494,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEAK_CRYPTOGRAPHIC_HASH,
             description = "CRYPTOGRAPHIC_FAILURES_SHA256_HASHING")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_9,
             htmlTemplate = "LEVEL_1/CryptographicFailures")
@@ -461,6 +552,16 @@ public class CryptographicFailuresVulnerability {
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.USE_OF_BROKEN_CRYPTOGRAPHIC_ALGORITHM,
             description = "CRYPTOGRAPHIC_FAILURES_INSECURE_AES128")
+    @ChallengeCard(
+            challengeText = "CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION",
+                            value = "CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_VALUE"))
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_10,
             htmlTemplate = "LEVEL_1/CryptographicFailures")

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -506,6 +506,56 @@ CRYPTOGRAPHIC_FAILURES_LM_HASHING=Password is hashed using LM algorithm which ha
 CRYPTOGRAPHIC_FAILURES_SHA256_HASHING=Password is hashed using SHA-256 without a salt, making it vulnerable to rainbow table and precomputed hash attacks. The user must crack the SHA-256 hash using online tools to find the original password.
 CRYPTOGRAPHIC_FAILURES_INSECURE_AES128=Password is encrypted with AES-128 but implemented with a weak key making it insecure to brute-force attacks. Encryption is a two-way function meaning that anyone with the key can decrypt the password. The user must crack the password using common password lists or key-recovery techniques.
 CRYPTOGRAPHIC_FAILURES_SECURE_BCRYPT=Password is hashed using Bcrypt with salt with a work factor (strength) of at least 4, making any type of brute-force or rainbow table attacks infeasible.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=Recover the password without any cracking at all, since the system exposes it directly.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The challenge response already contains the real password in plaintext.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read it and submit it back through the 'password' parameter.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password copied straight from the challenge response.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value shown in the CHALLENGE response>
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=Decode the Base64 "encoded" value to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=Base64 is an encoding, not encryption, and is reversible with any standard decoder.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Base64-decoded password submitted back to verify the guess.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<base64-decoded value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=Reverse the Caesar cipher shift to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1=A Caesar cipher only has 25 possible shifts, so it can be brute-forced entirely by hand.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2=Try shifting each letter of the ciphertext backwards by a few positions and see when it turns into readable text.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password recovered by reversing the Caesar cipher shift.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_VALUE=?password=<decrypted value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE=Figure out the custom obfuscation logic layered on top of encoding to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_1=The stored value looks encoded, look for a familiar transformation first.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_2=Try decoding it as Base64 first, then look for a second, simpler transformation applied underneath.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password recovered by undoing the custom obfuscation logic.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_VALUE=?password=<recovered value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=Crack the MD4 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_1=MD4 has no salt and is trivially reversible with public rainbow tables.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 900).
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD4 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_VALUE=?password=<cracked value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=Crack the MD5 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_1=MD5 is unsalted and cryptographically broken, precomputed rainbow tables cover most common passwords.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 0).
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD5 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_VALUE=?password=<cracked value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=Crack the SHA1 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_1=SHA1 is deprecated for password storage and has no salt.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 100).
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password recovered by cracking the SHA1 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_VALUE=?password=<cracked value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=Crack the LM hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_1=LM hashes are case-insensitive and split the password into two independent 7-character halves.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_2=Crack each 7-character half separately with hashcat (-m 3000), then combine and try different capitalizations.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password recovered by cracking the LM hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_VALUE=?password=<cracked value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=Crack the unsalted SHA-256 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_1=SHA-256 is fast and unsalted here, which makes brute-forcing and rainbow tables practical.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_2=Try common password lists against the hash with hashcat (-m 1400).
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password recovered by cracking the unsalted SHA-256 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_VALUE=?password=<cracked value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=Recover the password knowing it was used as its own AES-128 encryption key.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1=The encryption key is derived directly from the same password that gets encrypted.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_2=Try common passwords as both the plaintext and the key until the resulting ciphertext matches.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password recovered by guessing the value used as both plaintext and encryption key.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_VALUE=?password=<guessed value>
 
 ### IDOR Vulnerability
 IDOR_VULNERABILITY=<b>Insecure Direct Object Reference (IDOR)</b> is an access control vulnerability where an application exposes a reference to an internal object (such as a database ID, file name, or user identifier) and fails to verify whether the user is authorized to access that object. \

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -506,11 +506,11 @@ CRYPTOGRAPHIC_FAILURES_LM_HASHING=Password is hashed using LM algorithm which ha
 CRYPTOGRAPHIC_FAILURES_SHA256_HASHING=Password is hashed using SHA-256 without a salt, making it vulnerable to rainbow table and precomputed hash attacks. The user must crack the SHA-256 hash using online tools to find the original password.
 CRYPTOGRAPHIC_FAILURES_INSECURE_AES128=Password is encrypted with AES-128 but implemented with a weak key making it insecure to brute-force attacks. Encryption is a two-way function meaning that anyone with the key can decrypt the password. The user must crack the password using common password lists or key-recovery techniques.
 CRYPTOGRAPHIC_FAILURES_SECURE_BCRYPT=Password is hashed using Bcrypt with salt with a work factor (strength) of at least 4, making any type of brute-force or rainbow table attacks infeasible.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=Recover the password without any cracking at all, since the system exposes it directly.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The challenge response already contains the real password in plaintext.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read it and submit it back through the 'password' parameter.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password copied straight from the challenge response.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value shown in the CHALLENGE response>
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=Retrieve the plaintext password from the database, then submit it to the endpoint.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The endpoint's own challenge text tells you to check the database when the password parameter is absent.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read the stored plaintext value and submit it back through the 'password' parameter.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password read from the database and submitted to the endpoint.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value read from the database>
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=Decode the Base64 "encoded" value to recover the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=Base64 is an encoding, not encryption, and is reversible with any standard decoder.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -514,47 +514,47 @@ CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value read from the data
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=The system "encodes" passwords. Decode the stored value and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=This is an encoding, not encryption, and is reversible with any standard decoder once you identify the scheme.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Decoded password submitted back to verify the guess.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Password extracted by decoding the value already shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<decoded value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=A user's password is encrypted using an insecure cipher. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1=A Caesar cipher only has 25 possible shifts, so it can be brute-forced entirely by hand.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2=Try shifting each letter of the ciphertext backwards by a few positions and see when it turns into readable text.
-CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password recovered by reversing the Caesar cipher shift.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password extracted by reversing the cipher shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_VALUE=?password=<decrypted value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE=A user's password is stored using custom logic. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_1=The stored value looks encoded, look for a familiar transformation first.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_2=Try decoding it as Base64 first, then look for a second, simpler transformation applied underneath.
-CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password recovered by undoing the custom obfuscation logic.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password extracted by undoing the custom logic applied to the value shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_VALUE=?password=<recovered value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=A user's password is stored as an MD4 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_1=MD4 has no salt and is trivially reversible with public rainbow tables.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 900).
-CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD4 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD4 hash shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_VALUE=?password=<cracked value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=A user's password is stored as an MD5 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_1=MD5 is unsalted and cryptographically broken, precomputed rainbow tables cover most common passwords.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 0).
-CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD5 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD5 hash shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_VALUE=?password=<cracked value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=A user's password is stored as a SHA1 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_1=SHA1 is deprecated for password storage and has no salt.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 100).
-CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password recovered by cracking the SHA1 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password extracted by cracking the SHA1 hash shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_VALUE=?password=<cracked value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=This password is hashed with LM. Try to crack it with an LM hashing tool.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_1=LM hashes are case-insensitive and split the password into two independent 7-character halves.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_2=Crack each 7-character half separately with hashcat (-m 3000), then combine and try different capitalizations.
-CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password recovered by cracking the LM hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password extracted by cracking the LM hash shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_VALUE=?password=<cracked value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=A user's password is stored as an unsalted SHA-256 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_1=SHA-256 is fast and unsalted here, which makes brute-forcing and rainbow tables practical.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_2=Try common password lists against the hash with hashcat (-m 1400).
-CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password recovered by cracking the unsalted SHA-256 hash.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password extracted by cracking the unsalted SHA-256 hash shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_VALUE=?password=<cracked value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=The password is encrypted using AES-128 with a weak key: in this challenge, the password is the key that was used to encrypt itself. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1=The encryption key is derived directly from the same password that gets encrypted.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_2=Try common passwords as both the plaintext and the key until the resulting ciphertext matches.
-CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password recovered by guessing the value used as both plaintext and encryption key.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password extracted by testing it as both the plaintext and the key against the ciphertext shown in the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_VALUE=?password=<guessed value>
 
 ### IDOR Vulnerability

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -511,47 +511,47 @@ CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The endpoint's own challenge text tells yo
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read the stored plaintext value and submit it back through the 'password' parameter.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password read from the database and submitted to the endpoint.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value read from the database>
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=The system "encodes" passwords. Decode the stored value and submit the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=The system "encodes" passwords. Decode the stored value and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=This is an encoding, not encryption, and is reversible with any standard decoder once you identify the scheme.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Decoded password submitted back to verify the guess.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<decoded value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=Reverse the Caesar cipher shift to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=A user's password is encrypted using an insecure cipher. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1=A Caesar cipher only has 25 possible shifts, so it can be brute-forced entirely by hand.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2=Try shifting each letter of the ciphertext backwards by a few positions and see when it turns into readable text.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password recovered by reversing the Caesar cipher shift.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_VALUE=?password=<decrypted value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE=Figure out the custom obfuscation logic layered on top of encoding to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE=A user's password is stored using custom logic. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_1=The stored value looks encoded, look for a familiar transformation first.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_2=Try decoding it as Base64 first, then look for a second, simpler transformation applied underneath.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password recovered by undoing the custom obfuscation logic.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_VALUE=?password=<recovered value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=Crack the MD4 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=A user's password is stored as an MD4 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_1=MD4 has no salt and is trivially reversible with public rainbow tables.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 900).
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD4 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=Crack the MD5 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=A user's password is stored as an MD5 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_1=MD5 is unsalted and cryptographically broken, precomputed rainbow tables cover most common passwords.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 0).
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password recovered by cracking the MD5 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=Crack the SHA1 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=A user's password is stored as a SHA1 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_1=SHA1 is deprecated for password storage and has no salt.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 100).
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password recovered by cracking the SHA1 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=Crack the LM hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=This password is hashed with LM. Try to crack it with an LM hashing tool.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_1=LM hashes are case-insensitive and split the password into two independent 7-character halves.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_2=Crack each 7-character half separately with hashcat (-m 3000), then combine and try different capitalizations.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password recovered by cracking the LM hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=Crack the unsalted SHA-256 hash to recover the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=A user's password is stored as an unsalted SHA-256 hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_1=SHA-256 is fast and unsalted here, which makes brute-forcing and rainbow tables practical.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_2=Try common password lists against the hash with hashcat (-m 1400).
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password recovered by cracking the unsalted SHA-256 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=Recover the password knowing it was used as its own AES-128 encryption key.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=The password is encrypted using AES-128 with a weak key: in this challenge, the password is the key that was used to encrypt itself. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1=The encryption key is derived directly from the same password that gets encrypted.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_2=Try common passwords as both the plaintext and the key until the resulting ciphertext matches.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password recovered by guessing the value used as both plaintext and encryption key.

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -507,54 +507,54 @@ CRYPTOGRAPHIC_FAILURES_SHA256_HASHING=Password is hashed using SHA-256 without a
 CRYPTOGRAPHIC_FAILURES_INSECURE_AES128=Password is encrypted with AES-128 but implemented with a weak key making it insecure to brute-force attacks. Encryption is a two-way function meaning that anyone with the key can decrypt the password. The user must crack the password using common password lists or key-recovery techniques.
 CRYPTOGRAPHIC_FAILURES_SECURE_BCRYPT=Password is hashed using Bcrypt with salt with a work factor (strength) of at least 4, making any type of brute-force or rainbow table attacks infeasible.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=The system stores passwords in plaintext. Check the database for the password to crack the challenge.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The endpoint's own challenge text tells you to check the database when the password parameter is absent.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=When the password parameter is absent, check the database directly for the stored value.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read the stored plaintext value and submit it back through the 'password' parameter.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password read from the database and submitted to the endpoint.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value read from the database>
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=The system "encodes" passwords. Decode the stored value and enter the original password.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=This is an encoding, not encryption, and is reversible with any standard decoder once you identify the scheme.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=This is Base64 encoding, not encryption, and is reversible with any standard Base64 decoder.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Password extracted by decoding the value already shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Password extracted by decoding the Base64 value.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<decoded value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=A user's password is encrypted using an insecure cipher. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1=A Caesar cipher only has 25 possible shifts, so it can be brute-forced entirely by hand.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2=Try shifting each letter of the ciphertext backwards by a few positions and see when it turns into readable text.
-CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password extracted by reversing the cipher shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_DESCRIPTION=Password extracted by reversing the cipher.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_PAYLOAD_VALUE=?password=<decrypted value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_CHALLENGE=A user's password is stored using custom logic. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_1=The stored value looks encoded, look for a familiar transformation first.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_HINT_2=Try decoding it as Base64 first, then look for a second, simpler transformation applied underneath.
-CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password extracted by undoing the custom logic applied to the value shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_DESCRIPTION=Password extracted by undoing the custom logic applied to the stored value.
 CRYPTOGRAPHIC_FAILURES_LEVEL_4_PAYLOAD_VALUE=?password=<recovered value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=A user's password is stored as an MD4 hash. Crack it and enter the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_CHALLENGE=A user's password is stored as a hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_1=MD4 has no salt and is trivially reversible with public rainbow tables.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 900).
-CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD4 hash shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD4 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_5_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=A user's password is stored as an MD5 hash. Crack it and enter the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_CHALLENGE=A user's password is stored as a hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_1=MD5 is unsalted and cryptographically broken, precomputed rainbow tables cover most common passwords.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 0).
-CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD5 hash shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_DESCRIPTION=Password extracted by cracking the MD5 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_6_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=A user's password is stored as a SHA1 hash. Crack it and enter the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_CHALLENGE=A user's password is stored as a hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_1=SHA1 is deprecated for password storage and has no salt.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_HINT_2=Paste the hash into an online hash-lookup tool, or crack it locally with hashcat (-m 100).
-CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password extracted by cracking the SHA1 hash shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_DESCRIPTION=Password extracted by cracking the SHA1 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_7_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=This password is hashed with LM. Try to crack it with an LM hashing tool.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_CHALLENGE=This password is hashed. Try to crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_1=LM hashes are case-insensitive and split the password into two independent 7-character halves.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_HINT_2=Crack each 7-character half separately with hashcat (-m 3000), then combine and try different capitalizations.
-CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password extracted by cracking the LM hash shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_DESCRIPTION=Password extracted by cracking the LM hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_8_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=A user's password is stored as an unsalted SHA-256 hash. Crack it and enter the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_CHALLENGE=A user's password is stored as an unsalted hash. Crack it and enter the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_1=SHA-256 is fast and unsalted here, which makes brute-forcing and rainbow tables practical.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_HINT_2=Try common password lists against the hash with hashcat (-m 1400).
-CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password extracted by cracking the unsalted SHA-256 hash shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_DESCRIPTION=Password extracted by cracking the unsalted SHA-256 hash.
 CRYPTOGRAPHIC_FAILURES_LEVEL_9_PAYLOAD_VALUE=?password=<cracked value>
-CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=The password is encrypted using AES-128 with a weak key: in this challenge, the password is the key that was used to encrypt itself. Crack it and enter the original password.
-CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1=The encryption key is derived directly from the same password that gets encrypted.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_CHALLENGE=The password is encrypted with a weak key: in this challenge, the password is the key that was used to encrypt itself. Crack it and enter the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_1=This uses AES-128, with the encryption key derived directly from the same password that gets encrypted.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_HINT_2=Try common passwords as both the plaintext and the key until the resulting ciphertext matches.
-CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password extracted by testing it as both the plaintext and the key against the ciphertext shown in the challenge.
+CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_DESCRIPTION=Password extracted by testing it as both the plaintext and the key against the ciphertext.
 CRYPTOGRAPHIC_FAILURES_LEVEL_10_PAYLOAD_VALUE=?password=<guessed value>
 
 ### IDOR Vulnerability

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -506,16 +506,16 @@ CRYPTOGRAPHIC_FAILURES_LM_HASHING=Password is hashed using LM algorithm which ha
 CRYPTOGRAPHIC_FAILURES_SHA256_HASHING=Password is hashed using SHA-256 without a salt, making it vulnerable to rainbow table and precomputed hash attacks. The user must crack the SHA-256 hash using online tools to find the original password.
 CRYPTOGRAPHIC_FAILURES_INSECURE_AES128=Password is encrypted with AES-128 but implemented with a weak key making it insecure to brute-force attacks. Encryption is a two-way function meaning that anyone with the key can decrypt the password. The user must crack the password using common password lists or key-recovery techniques.
 CRYPTOGRAPHIC_FAILURES_SECURE_BCRYPT=Password is hashed using Bcrypt with salt with a work factor (strength) of at least 4, making any type of brute-force or rainbow table attacks infeasible.
-CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=Retrieve the plaintext password from the database, then submit it to the endpoint.
+CRYPTOGRAPHIC_FAILURES_LEVEL_1_CHALLENGE=The system stores passwords in plaintext. Check the database for the password to crack the challenge.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_1=The endpoint's own challenge text tells you to check the database when the password parameter is absent.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_HINT_2=No decoding or cracking is needed, just read the stored plaintext value and submit it back through the 'password' parameter.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_DESCRIPTION=Plaintext password read from the database and submitted to the endpoint.
 CRYPTOGRAPHIC_FAILURES_LEVEL_1_PAYLOAD_VALUE=?password=<value read from the database>
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=Decode the Base64 "encoded" value to recover the original password.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=Base64 is an encoding, not encryption, and is reversible with any standard decoder.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_CHALLENGE=The system "encodes" passwords. Decode the stored value and submit the original password.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_1=This is an encoding, not encryption, and is reversible with any standard decoder once you identify the scheme.
 CRYPTOGRAPHIC_FAILURES_LEVEL_2_HINT_2=Once decoded, submit the plaintext result through the 'password' parameter to confirm.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Base64-decoded password submitted back to verify the guess.
-CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<base64-decoded value>
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_DESCRIPTION=Decoded password submitted back to verify the guess.
+CRYPTOGRAPHIC_FAILURES_LEVEL_2_PAYLOAD_VALUE=?password=<decoded value>
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_CHALLENGE=Reverse the Caesar cipher shift to recover the original password.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_1=A Caesar cipher only has 25 possible shifts, so it can be brute-forced entirely by hand.
 CRYPTOGRAPHIC_FAILURES_LEVEL_3_HINT_2=Try shifting each letter of the ciphertext backwards by a few positions and see when it turns into readable text.


### PR DESCRIPTION
## Summary
Closes #558.

Adds `@ChallengeCard` annotations to unsecure Cryptographic Failures levels 1-10, following the same pattern used for XXE, Path Traversal and Cache Poisoning (#779). Purely additive — `@AttackVector` and `@VulnerableAppRequestMapping` are untouched, level 11 (secure Bcrypt) is left as-is.

Note: this issue had an assignee who was last active on it about 4 weeks ago with no PR opened since. I asked in the issue if it was still being worked on and got no response, so picked it up.

## Test plan
- [x] `./gradlew compileJava`
- [x] `./gradlew spotlessCheck`
- [x] `MessageBundleDuplicateKeyTest` and `VulnerableAppRestControllerTest` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added challenge cards for cryptographic-failure levels 1–10.
  - Each challenge includes instructions, two progressive hints, payload descriptions, and example values.
  - Added guidance for plaintext exposure, Base64 decoding, weak hashing, password cracking, and insecure AES key usage.

- **Documentation**
  - Clarified Level 1 instructions to retrieve the plaintext password from the database.
  - Refined Levels 2–10 wording to provide clearer guidance for decoding or recovering passwords, including level-specific hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->