### PR TITLE
feat: add two secure FileUpload implementations

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.Random;
+import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.apache.commons.text.StringEscapeUtils;
@@ -625,7 +626,10 @@ public class UnrestrictedFileUpload {
     // with .png, regardless of what bytes are actually inside it. This level reads the file's
     // own binary signature instead, and the stored name is built from that detected type rather
     // than from anything the client sent, so a renamed non-image file is rejected and a real
-    // image can never be stored under an attacker-chosen extension like .html.
+    // image can never be stored under an attacker-chosen extension like .html. The name itself
+    // is a UUID rather than RANDOM.nextInt(): genericFileUploadUtility overwrites on a name
+    // collision, and a 32-bit int is small enough that one becomes likely after tens of
+    // thousands of uploads, which a reference secure level should not carry.
     @AttackVector(
             vulnerabilityExposed = {
                 VulnerabilityType.UNRESTRICTED_FILE_UPLOAD,
@@ -643,7 +647,7 @@ public class UnrestrictedFileUpload {
         byte[] content = file.getBytes();
         String extension = detectImageExtension(content);
         Supplier<Boolean> validator = () -> extension != null;
-        String storedFileName = RANDOM.nextInt() + (extension == null ? "" : extension);
+        String storedFileName = UUID.randomUUID() + (extension == null ? "" : extension);
         return genericFileUploadUtility(root, storedFileName, validator, file, true, false);
     }
 
@@ -670,7 +674,7 @@ public class UnrestrictedFileUpload {
         String extension = detectImageExtension(content);
         Supplier<Boolean> validator =
                 () -> extension != null && content.length <= MAX_UPLOAD_SIZE_BYTES;
-        String storedFileName = RANDOM.nextInt() + (extension == null ? "" : extension);
+        String storedFileName = UUID.randomUUID() + (extension == null ? "" : extension);
         return genericFileUploadUtility(root, storedFileName, validator, file, true, false);
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -67,6 +67,11 @@ public class UnrestrictedFileUpload {
         (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
     };
     private static final byte[] JPEG_SIGNATURE = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF};
+    // Spring Boot's own multipart default already caps a single part at 1 MB
+    // (spring.servlet.multipart.max-file-size), so the limit here has to sit below that or a
+    // request over it never reaches this validator at all, it is rejected by the framework with
+    // a 500 before level 12's code runs.
+    private static final int MAX_UPLOAD_SIZE_BYTES = 512 * 1024;
     private static final transient Logger LOGGER =
             LogManager.getLogger(UnrestrictedFileUpload.class);
 
@@ -618,12 +623,14 @@ public class UnrestrictedFileUpload {
 
     // The file name is irrelevant here: level 10 accepts "shell.php.png" because the name ends
     // with .png, regardless of what bytes are actually inside it. This level reads the file's
-    // own binary signature instead, so a renamed non-image file is rejected even though its
-    // extension looks fine.
+    // own binary signature instead, and the stored name is built from that detected type rather
+    // than from anything the client sent, so a renamed non-image file is rejected and a real
+    // image can never be stored under an attacker-chosen extension like .html.
     @AttackVector(
             vulnerabilityExposed = {
                 VulnerabilityType.UNRESTRICTED_FILE_UPLOAD,
-                VulnerabilityType.PERSISTENT_XSS
+                VulnerabilityType.PERSISTENT_XSS,
+                VulnerabilityType.PATH_TRAVERSAL
             },
             description = "UNRESTRICTED_FILE_UPLOAD_IF_FILE_CONTENT_NOT_PNG_OR_JPEG_SIGNATURE")
     @VulnerableAppRequestMapping(
@@ -634,27 +641,24 @@ public class UnrestrictedFileUpload {
     public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel11(
             @RequestParam(REQUEST_PARAMETER) MultipartFile file) throws IOException {
         byte[] content = file.getBytes();
-        Supplier<Boolean> validator = () -> detectImageExtension(content) != null;
-        return genericFileUploadUtility(
-                root,
-                RANDOM.nextInt() + "_" + file.getOriginalFilename(),
-                validator,
-                file,
-                true,
-                false);
+        String extension = detectImageExtension(content);
+        Supplier<Boolean> validator = () -> extension != null;
+        String storedFileName = RANDOM.nextInt() + (extension == null ? "" : extension);
+        return genericFileUploadUtility(root, storedFileName, validator, file, true, false);
     }
 
-    // Every level above still stores the file under some form of the client-supplied name, so a
-    // crafted name (a path, a double extension, a null byte) is always part of what the server
-    // has to defend against. This level never looks at the client-supplied name at all: it is
-    // discarded, and the stored name is a random value plus the extension the server itself
-    // detected from the file's binary signature.
+    // Level 11 already stores a signature-validated image under a server-generated name, so
+    // nothing about the name is left to exploit. Level 9, right above it, accepts a file of any
+    // size, so an upload capped at nothing is still an unaddressed cost even once content and
+    // naming are both handled. This level adds that missing bound: the signature check from
+    // level 11 still applies, and on top of it a file over MAX_UPLOAD_SIZE_BYTES is rejected
+    // before it is written to disk.
     @AttackVector(
             vulnerabilityExposed = {
                 VulnerabilityType.UNRESTRICTED_FILE_UPLOAD,
-                VulnerabilityType.PATH_TRAVERSAL
+                VulnerabilityType.UNCONTROLLED_RESOURCE_CONSUMPTION
             },
-            description = "UNRESTRICTED_FILE_UPLOAD_IGNORES_CLIENT_SUPPLIED_FILE_NAME")
+            description = "UNRESTRICTED_FILE_UPLOAD_ENFORCES_SIGNATURE_AND_SIZE_LIMIT")
     @VulnerableAppRequestMapping(
             value = LevelConstants.LEVEL_12,
             variant = Variant.SECURE,
@@ -664,13 +668,9 @@ public class UnrestrictedFileUpload {
             @RequestParam(REQUEST_PARAMETER) MultipartFile file) throws IOException {
         byte[] content = file.getBytes();
         String extension = detectImageExtension(content);
-        if (extension == null) {
-            return new ResponseEntity<>(
-                    new GenericVulnerabilityResponseBean<String>("Input is invalid", false),
-                    HttpStatus.OK);
-        }
-        String serverGeneratedFileName = Math.abs(RANDOM.nextInt()) + extension;
-        return genericFileUploadUtility(
-                root, serverGeneratedFileName, () -> true, file, true, false);
+        Supplier<Boolean> validator =
+                () -> extension != null && content.length <= MAX_UPLOAD_SIZE_BYTES;
+        String storedFileName = RANDOM.nextInt() + (extension == null ? "" : extension);
+        return genericFileUploadUtility(root, storedFileName, validator, file, true, false);
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -63,6 +63,10 @@ public class UnrestrictedFileUpload {
             Pattern.compile(CONTAINS_PNG_JPEG_REGEX);
     private static final Pattern ENDS_WITH_PNG_OR_JPEG_PATTERN =
             Pattern.compile(CONTAINS_PNG_JPEG_REGEX + "$");
+    private static final byte[] PNG_SIGNATURE = {
+        (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+    };
+    private static final byte[] JPEG_SIGNATURE = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF};
     private static final transient Logger LOGGER =
             LogManager.getLogger(UnrestrictedFileUpload.class);
 
@@ -143,6 +147,28 @@ public class UnrestrictedFileUpload {
 
     Path getContentDispositionRoot() {
         return contentDispositionRoot;
+    }
+
+    private static boolean startsWithSignature(byte[] content, byte[] signature) {
+        if (content.length < signature.length) {
+            return false;
+        }
+        for (int i = 0; i < signature.length; i++) {
+            if (content[i] != signature[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String detectImageExtension(byte[] content) {
+        if (startsWithSignature(content, PNG_SIGNATURE)) {
+            return ".png";
+        }
+        if (startsWithSignature(content, JPEG_SIGNATURE)) {
+            return ".jpeg";
+        }
+        return null;
     }
 
     // <img src="" onerror=alert(1) /> file name reflected and stored is there.
@@ -588,5 +614,63 @@ public class UnrestrictedFileUpload {
                 file,
                 true,
                 false);
+    }
+
+    // The file name is irrelevant here: level 10 accepts "shell.php.png" because the name ends
+    // with .png, regardless of what bytes are actually inside it. This level reads the file's
+    // own binary signature instead, so a renamed non-image file is rejected even though its
+    // extension looks fine.
+    @AttackVector(
+            vulnerabilityExposed = {
+                VulnerabilityType.UNRESTRICTED_FILE_UPLOAD,
+                VulnerabilityType.PERSISTENT_XSS
+            },
+            description = "UNRESTRICTED_FILE_UPLOAD_IF_FILE_CONTENT_NOT_PNG_OR_JPEG_SIGNATURE")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_11,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/FileUpload",
+            requestMethod = RequestMethod.POST)
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel11(
+            @RequestParam(REQUEST_PARAMETER) MultipartFile file) throws IOException {
+        byte[] content = file.getBytes();
+        Supplier<Boolean> validator = () -> detectImageExtension(content) != null;
+        return genericFileUploadUtility(
+                root,
+                RANDOM.nextInt() + "_" + file.getOriginalFilename(),
+                validator,
+                file,
+                true,
+                false);
+    }
+
+    // Every level above still stores the file under some form of the client-supplied name, so a
+    // crafted name (a path, a double extension, a null byte) is always part of what the server
+    // has to defend against. This level never looks at the client-supplied name at all: it is
+    // discarded, and the stored name is a random value plus the extension the server itself
+    // detected from the file's binary signature.
+    @AttackVector(
+            vulnerabilityExposed = {
+                VulnerabilityType.UNRESTRICTED_FILE_UPLOAD,
+                VulnerabilityType.PATH_TRAVERSAL
+            },
+            description = "UNRESTRICTED_FILE_UPLOAD_IGNORES_CLIENT_SUPPLIED_FILE_NAME")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_12,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/FileUpload",
+            requestMethod = RequestMethod.POST)
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel12(
+            @RequestParam(REQUEST_PARAMETER) MultipartFile file) throws IOException {
+        byte[] content = file.getBytes();
+        String extension = detectImageExtension(content);
+        if (extension == null) {
+            return new ResponseEntity<>(
+                    new GenericVulnerabilityResponseBean<String>("Input is invalid", false),
+                    HttpStatus.OK);
+        }
+        String serverGeneratedFileName = Math.abs(RANDOM.nextInt()) + extension;
+        return genericFileUploadUtility(
+                root, serverGeneratedFileName, () -> true, file, true, false);
     }
 }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -129,6 +129,8 @@ UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIV
 UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE=Only file name is allowed if it ends with case insensitive .jpeg or .png and it is considered before Null Bytes only.
 UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE=Only file name is allowed if it ends with case insensitive .jpeg or .png.
 UNRESTRICTED_FILE_UPLOAD_UNCONTROLLED_RESOURCE_CONSUMPTION=Maximum uploaded file size is not limited.
+UNRESTRICTED_FILE_UPLOAD_IF_FILE_CONTENT_NOT_PNG_OR_JPEG_SIGNATURE=Only files whose content starts with a valid PNG or JPEG binary signature are allowed, checked independently of the file name.
+UNRESTRICTED_FILE_UPLOAD_IGNORES_CLIENT_SUPPLIED_FILE_NAME=The stored file name is generated entirely by the server from a random value and the detected content type; the client-supplied file name is never used.
 
 # XXE Vulnerability
 XXE_VULNERABILITY=An XML External Entity attack is a type of attack against an \

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -129,8 +129,8 @@ UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_CONTAINS_.PNG_OR_.JPEG_CASE_INSENSITIV
 UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE_AND_FILE_NAMES_CONSIDERED_BEFORE_NULL_BYTE=Only file name is allowed if it ends with case insensitive .jpeg or .png and it is considered before Null Bytes only.
 UNRESTRICTED_FILE_UPLOAD_IF_FILE_NAME_NOT_ENDS_WITH_.PNG_OR_.JPEG_CASE_INSENSITIVE=Only file name is allowed if it ends with case insensitive .jpeg or .png.
 UNRESTRICTED_FILE_UPLOAD_UNCONTROLLED_RESOURCE_CONSUMPTION=Maximum uploaded file size is not limited.
-UNRESTRICTED_FILE_UPLOAD_IF_FILE_CONTENT_NOT_PNG_OR_JPEG_SIGNATURE=Only files whose content starts with a valid PNG or JPEG binary signature are allowed, checked independently of the file name.
-UNRESTRICTED_FILE_UPLOAD_IGNORES_CLIENT_SUPPLIED_FILE_NAME=The stored file name is generated entirely by the server from a random value and the detected content type; the client-supplied file name is never used.
+UNRESTRICTED_FILE_UPLOAD_IF_FILE_CONTENT_NOT_PNG_OR_JPEG_SIGNATURE=Only files whose content starts with a valid PNG or JPEG binary signature are allowed. The client-supplied file name is never used; the stored name is a random value plus the extension the server detected from the signature.
+UNRESTRICTED_FILE_UPLOAD_ENFORCES_SIGNATURE_AND_SIZE_LIMIT=Same PNG or JPEG signature check and server-generated name as the level above, with an added 512 KB upload size limit.
 
 # XXE Vulnerability
 XXE_VULNERABILITY=An XML External Entity attack is a type of attack against an \

--- a/src/test/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUploadTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUploadTest.java
@@ -182,4 +182,65 @@ class UnrestrictedFileUploadTest {
 
         assertThat(response.getBody().getIsValid()).isFalse();
     }
+
+    @Test
+    void test_getVulnerablePayloadLevel11_realPngContentAccepted() throws Exception {
+        byte[] pngBytes = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00};
+        MockMultipartFile file = new MockMultipartFile("file", "photo.png", "image/png", pngBytes);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel11(file);
+
+        assertThat(response.getBody().getIsValid()).isTrue();
+    }
+
+    @Test
+    void test_getVulnerablePayloadLevel11_pngExtensionWithNonImageContentRejected()
+            throws Exception {
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "file",
+                        "shell.png",
+                        "image/png",
+                        "<?php system($_GET['c']); ?>".getBytes());
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel11(file);
+
+        assertThat(response.getBody().getIsValid())
+                .withFailMessage("A .png extension with non-image content should be rejected")
+                .isFalse();
+    }
+
+    @Test
+    void test_getVulnerablePayloadLevel12_storesUnderServerGeneratedName() throws Exception {
+        byte[] jpegBytes = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x00, 0x00};
+        MockMultipartFile file =
+                new MockMultipartFile("file", "../../etc/passwd.jpeg", "image/jpeg", jpegBytes);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel12(file);
+
+        assertThat(response.getBody().getIsValid()).isTrue();
+        try (Stream<Path> files = Files.list(tempRoot)) {
+            List<String> fileNames =
+                    files.map(p -> p.getFileName().toString()).collect(Collectors.toList());
+            assertThat(fileNames)
+                    .withFailMessage(
+                            "Client file name must never reach the stored name: %s", fileNames)
+                    .noneMatch(name -> name.contains("passwd"));
+            assertThat(fileNames).anyMatch(name -> name.endsWith(".jpeg"));
+        }
+    }
+
+    @Test
+    void test_getVulnerablePayloadLevel12_nonImageContentRejected() throws Exception {
+        MockMultipartFile file =
+                new MockMultipartFile("file", "shell.jpeg", "image/jpeg", "content".getBytes());
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel12(file);
+
+        assertThat(response.getBody().getIsValid()).isFalse();
+    }
 }

--- a/src/test/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUploadTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUploadTest.java
@@ -213,7 +213,31 @@ class UnrestrictedFileUploadTest {
     }
 
     @Test
-    void test_getVulnerablePayloadLevel12_storesUnderServerGeneratedName() throws Exception {
+    void test_getVulnerablePayloadLevel11_storedNameIgnoresClientExtension() throws Exception {
+        byte[] pngBytes = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00};
+        MockMultipartFile file =
+                new MockMultipartFile("file", "../../shell.html", "image/png", pngBytes);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel11(file);
+
+        assertThat(response.getBody().getIsValid()).isTrue();
+        try (Stream<Path> files = Files.list(tempRoot)) {
+            List<String> fileNames =
+                    files.map(p -> p.getFileName().toString()).collect(Collectors.toList());
+            assertThat(fileNames)
+                    .withFailMessage(
+                            "A validated PNG must never be stored under a client-chosen"
+                                    + " extension like .html: %s",
+                            fileNames)
+                    .noneMatch(name -> name.endsWith(".html"));
+            assertThat(fileNames).noneMatch(name -> name.contains("shell"));
+            assertThat(fileNames).anyMatch(name -> name.endsWith(".png"));
+        }
+    }
+
+    @Test
+    void test_getVulnerablePayloadLevel12_withinSizeLimitAccepted() throws Exception {
         byte[] jpegBytes = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x00, 0x00};
         MockMultipartFile file =
                 new MockMultipartFile("file", "../../etc/passwd.jpeg", "image/jpeg", jpegBytes);
@@ -231,6 +255,22 @@ class UnrestrictedFileUploadTest {
                     .noneMatch(name -> name.contains("passwd"));
             assertThat(fileNames).anyMatch(name -> name.endsWith(".jpeg"));
         }
+    }
+
+    @Test
+    void test_getVulnerablePayloadLevel12_overSizeLimitRejected() throws Exception {
+        byte[] oversized = new byte[512 * 1024 + 1];
+        oversized[0] = (byte) 0xFF;
+        oversized[1] = (byte) 0xD8;
+        oversized[2] = (byte) 0xFF;
+        MockMultipartFile file = new MockMultipartFile("file", "big.jpeg", "image/jpeg", oversized);
+
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                fileUpload.getVulnerablePayloadLevel12(file);
+
+        assertThat(response.getBody().getIsValid())
+                .withFailMessage("A valid JPEG over the 512 KB cap should still be rejected")
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
Closes #401.

FileUpload currently has one secure level (level 10), which checks that the file name ends in `.png` or `.jpeg`. That check never looks past the name: a file named `shell.php.png` still clears it, since it ends with `.png`.

**Level 11** reads the file's own bytes and checks them against the actual PNG and JPEG binary signatures. The stored name is built only from the extension the server detects that way, never from anything the client sent, so a renamed non-image file is rejected and a real image can never end up stored under an attacker-chosen extension like `.html`.

**Level 12** carries the same signature check and server-generated name as level 11, plus an upload size cap of 512 KB. That cap has to sit below Spring Boot's own multipart default of 1 MB, or a request over it would never reach the method at all, it would be rejected by the framework with a 500 before any of this code ran.

Both are additive. Nothing in levels 1 to 10 changed.

How I checked it: unit tests cover a real PNG being accepted on level 11, a PHP payload renamed to `.png` being rejected, a real PNG uploaded with a name of `../../shell.html` still ending up stored as `.png`, level 12 accepting a small JPEG and rejecting one over its own cap, and a non-image upload being rejected on both levels. I also ran the built jar and posted the same cases with curl: the `.html`-named PNG landed on disk as plain `.png`, and a 700 KB JPEG, over level 12's cap but under Spring's own 1 MB limit, came back rejected by this code rather than by the framework.

```sh
./gradlew clean build
java -jar build/libs/VulnerableApp-1.0.0.jar &
B=http://localhost:9090/VulnerableApp/UnrestrictedFileUpload
until curl -sf -o /dev/null http://localhost:9090/VulnerableApp/VulnerabilityDefinitions
do sleep 2; done

# level 11: real PNG bytes, name ends in .html, stored as .png anyway
curl -s -F "file=@real.png;filename=../../shell.html;type=image/png" "$B/LEVEL_11"

# level 12: ~700 KB JPEG, over the 512 KB cap but under Spring's 1 MB limit
curl -s -F "file=@mid.jpeg;filename=mid.jpeg;type=image/jpeg" "$B/LEVEL_12"
```

`./gradlew clean build` passes with 454 tests, 0 failures, on master `c833c66`.

Update: an earlier revision of level 11 in this PR kept the client-supplied extension for the stored name even after validating the signature, which CodeRabbit correctly flagged as still allowing a signature-valid PNG to be stored as `.html`. Fixed in the second commit, which is also where level 12's distinct control (the size cap) was added, since after that fix the two levels would otherwise have ended up doing the same thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PNG and JPEG validation based on file content for applicable upload levels.
  * Added server-generated filenames with detected image extensions, preventing client-provided names and path traversal from affecting stored files.
  * Added a 512 KB upload-size limit for the stricter validation level.
  * Invalid image content and oversized uploads are rejected.

* **Documentation**
  * Updated upload-validation messages to describe signature checks, generated filenames, and the size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->