### PR TITLE
feat: add two secure PathTraversal implementations

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
@@ -52,9 +52,10 @@ public class PathTraversalVulnerability {
 
     private static final String BASE_RESOURCE_PATH = "/scripts/PathTraversal/";
 
-    // Letters, digits, dots, underscores and hyphens only, with no path separator of any kind
-    // in the character set at all, so there is nothing here for a traversal sequence to be
-    // built out of, encoded or not.
+    // Allows file names made of letters, digits, underscores or hyphens, followed by a single
+    // dot and a 2-5 character alphanumeric extension. No path separator or dot sequence is in
+    // that character set, so there is nothing here for a traversal segment to be built out of,
+    // encoded or not.
     private static final Pattern SAFE_FILE_NAME_PATTERN =
             Pattern.compile("^[A-Za-z0-9_-]+\\.[A-Za-z0-9]{2,5}$");
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
@@ -6,10 +6,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sasanlabs.internal.utility.LevelConstants;
@@ -46,11 +49,19 @@ public class PathTraversalVulnerability {
 
     private static final String URL_PARAM_KEY = "fileName";
 
+    private static final String BASE_RESOURCE_PATH = "/scripts/PathTraversal/";
+
+    // Letters, digits, dots, underscores and hyphens only, with no path separator of any kind
+    // in the character set at all, so there is nothing here for a traversal sequence to be
+    // built out of, encoded or not.
+    private static final Pattern SAFE_FILE_NAME_PATTERN =
+            Pattern.compile("^[A-Za-z0-9_-]+\\.[A-Za-z0-9]{2,5}$");
+
     private ResponseEntity<GenericVulnerabilityResponseBean<String>> readFile(
             Supplier<Boolean> condition, String fileName) {
         if (condition.get()) {
             InputStream infoFileStream =
-                    this.getClass().getResourceAsStream("/scripts/PathTraversal/" + fileName);
+                    this.getClass().getResourceAsStream(BASE_RESOURCE_PATH + fileName);
             if (infoFileStream != null) {
                 try (BufferedReader reader =
                         new BufferedReader(new InputStreamReader(infoFileStream))) {
@@ -498,5 +509,73 @@ public class PathTraversalVulnerability {
         String fileName = queryParams.get(URL_PARAM_KEY);
         return this.readFile(
                 () -> fileName != null && ALLOWED_FILE_NAMES.contains(fileName), fileName);
+    }
+
+    // Level 13 is safe because it only ever accepts two exact, hardcoded names. This level takes
+    // a different strategy that does not depend on knowing every legitimate file name in
+    // advance: it resolves the requested path lexically (no traversal segment is left standing,
+    // encoded or not, once Paths.normalize() runs) and only proceeds if the resolved path is
+    // still inside BASE_RESOURCE_PATH. A NUL byte makes the path itself invalid, which
+    // InvalidPathException catches as a rejection rather than a bypass.
+    @ChallengeCard(
+            challengeText = "PATH_TRAVERSAL_LEVEL14_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "PATH_TRAVERSAL_LEVEL14_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "PATH_TRAVERSAL_LEVEL14_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "PATH_TRAVERSAL_LEVEL14_PAYLOAD_DESCRIPTION",
+                            value = "PATH_TRAVERSAL_LEVEL14_PAYLOAD_VALUE"))
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_14,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/PathTraversal")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel14(
+            @RequestParam Map<String, String> queryParams) {
+        String fileName = queryParams.get(URL_PARAM_KEY);
+        Supplier<Boolean> validator =
+                () -> {
+                    if (fileName == null) {
+                        return false;
+                    }
+                    try {
+                        String normalizedBase =
+                                Paths.get(BASE_RESOURCE_PATH).normalize().toString();
+                        String normalizedTarget =
+                                Paths.get(BASE_RESOURCE_PATH + fileName).normalize().toString();
+                        return normalizedTarget.startsWith(normalizedBase);
+                    } catch (InvalidPathException e) {
+                        return false;
+                    }
+                };
+        return this.readFile(validator, fileName);
+    }
+
+    // A second, independent strategy: instead of resolving where the path ends up, this level
+    // never lets a structurally unsafe name in in the first place. SAFE_FILE_NAME_PATTERN allows
+    // only letters, digits, underscores, hyphens and a single extension, so "..", "/", "\" and a
+    // NUL byte are all rejected the same way, by never matching the pattern, rather than by
+    // being individually blocked.
+    @ChallengeCard(
+            challengeText = "PATH_TRAVERSAL_LEVEL15_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "PATH_TRAVERSAL_LEVEL15_HINT1"),
+                @ChallengeCard.Hint(order = 2, text = "PATH_TRAVERSAL_LEVEL15_HINT2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "PATH_TRAVERSAL_LEVEL15_PAYLOAD_DESCRIPTION",
+                            value = "PATH_TRAVERSAL_LEVEL15_PAYLOAD_VALUE"))
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_15,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/PathTraversal")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel15(
+            @RequestParam Map<String, String> queryParams) {
+        String fileName = queryParams.get(URL_PARAM_KEY);
+        return this.readFile(
+                () -> fileName != null && SAFE_FILE_NAME_PATTERN.matcher(fileName).matches(),
+                fileName);
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalVulnerability.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -540,10 +541,9 @@ public class PathTraversalVulnerability {
                         return false;
                     }
                     try {
-                        String normalizedBase =
-                                Paths.get(BASE_RESOURCE_PATH).normalize().toString();
-                        String normalizedTarget =
-                                Paths.get(BASE_RESOURCE_PATH + fileName).normalize().toString();
+                        Path normalizedBase = Paths.get(BASE_RESOURCE_PATH).normalize();
+                        Path normalizedTarget =
+                                Paths.get(BASE_RESOURCE_PATH + fileName).normalize();
                         return normalizedTarget.startsWith(normalizedBase);
                     } catch (InvalidPathException e) {
                         return false;

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1155,6 +1155,18 @@ PATH_TRAVERSAL_LEVEL13_HINT2=There is no separate raw-URL blocklist left to bypa
 PATH_TRAVERSAL_LEVEL13_PAYLOAD_DESCRIPTION=Only the two exact whitelisted filenames are ever accepted; anything else, including secret.json or any traversal/NUL-byte payload, returns an empty, invalid response.
 PATH_TRAVERSAL_LEVEL13_PAYLOAD_VALUE=UserInfo.json
 
+PATH_TRAVERSAL_LEVEL14_CHALLENGE=Confirm this level only ever serves files from inside its own directory, no matter how the fileName parameter is written.
+PATH_TRAVERSAL_LEVEL14_HINT1=The request is not checked against a fixed list of names. The path it resolves to is checked instead: fileName is appended to the base directory, Paths.normalize() collapses every ".." segment, and the result has to still start with that base directory.
+PATH_TRAVERSAL_LEVEL14_HINT2=A NUL byte makes the whole path invalid rather than truncating it, so the InvalidPathException it triggers is treated as a rejection, not a way in.
+PATH_TRAVERSAL_LEVEL14_PAYLOAD_DESCRIPTION=Any file name that normalizes to a path outside the PathTraversal resource directory is rejected; a plain in-directory name like OwaspAppInfo.json is accepted even though it was never hardcoded anywhere.
+PATH_TRAVERSAL_LEVEL14_PAYLOAD_VALUE=OwaspAppInfo.json
+
+PATH_TRAVERSAL_LEVEL15_CHALLENGE=Confirm this level rejects anything that is not a plain, single-extension file name, independent of what level 14 does.
+PATH_TRAVERSAL_LEVEL15_HINT1=The whole parameter has to match ^[A-Za-z0-9_-]+\\.[A-Za-z0-9]{2,5}$. There is no character in that set to build a "..", a "/", a "\\", or a NUL byte out of.
+PATH_TRAVERSAL_LEVEL15_HINT2=This does not resolve or normalize anything the way level 14 does; a name is either shaped like a safe file name or it is refused outright.
+PATH_TRAVERSAL_LEVEL15_PAYLOAD_DESCRIPTION=Only a file name built entirely from letters, digits, underscores, hyphens and a single extension is ever accepted.
+PATH_TRAVERSAL_LEVEL15_PAYLOAD_VALUE=UserInfo.json
+
 # XXE Challenge Mode
 XXE_LEVEL1_CHALLENGE=Read /etc/hostname (Linux/Docker) or C:\Windows\win.ini (Windows) and get its exact contents back in the response.
 XXE_LEVEL1_HINT1=The posted XML is unmarshalled with no restriction on DOCTYPE declarations or external entities at all - a <!ENTITY> declared with a SYSTEM identifier is resolved and substituted wherever it's referenced in the document.

--- a/src/test/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/pathTraversal/PathTraversalTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.sasanlabs.vulnerability.utils.Constants;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -492,5 +493,116 @@ class PathTraversalVulnerabilityTest {
         ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
                 pathTraversalVulnerability.getVulnerablePayloadLevel13(queryParams);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel14WithNullFileName() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", null);
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel14(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel14BlocksTraversalOutsideBaseDirectory() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", "../secret.json");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel14(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel14BlocksDeepTraversal() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", "../../../../../../etc/passwd");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel14(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel14BlocksNullByte() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put(
+                "fileName",
+                "../../../../../../etc/passwd" + Constants.NULL_BYTE_CHARACTER + "UserInfo.json");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel14(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel14AcceptsAnyInDirectoryFileName() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", "OwaspAppInfo.json");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel14(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getIsValid());
+        assertNotNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel15WithNullFileName() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", null);
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel15(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel15RejectsTraversalSequence() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", "../../../../../../etc/passwd");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel15(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel15RejectsNullByte() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put(
+                "fileName", "UserInfo.json" + Constants.NULL_BYTE_CHARACTER + "secret.json");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel15(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertFalse(response.getBody().getIsValid());
+        assertNull(response.getBody().getContent());
+    }
+
+    @Test
+    void testGetVulnerablePayloadLevel15() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fileName", "UserInfo.json");
+        ResponseEntity<GenericVulnerabilityResponseBean<String>> response =
+                pathTraversalVulnerability.getVulnerablePayloadLevel15(queryParams);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getIsValid());
+        assertNotNull(response.getBody().getContent());
     }
 }


### PR DESCRIPTION
Closes #404.

PathTraversal has one secure level (level 13), which checks the whole `fileName` parameter against two hardcoded strings. On the issue thread, the maintainer asked for a mix of strategies rather than a second name list, and named rejection of traversal attempts specifically as the other kind worth having.

**Level 14** resolves the requested path instead of matching a name against a list. `fileName` gets appended to the resource's base directory, run through `Paths.normalize()` so every `..` segment collapses, and the request only proceeds if the normalized result still starts inside that base directory. A NUL byte makes the path itself invalid rather than truncating it, so `InvalidPathException` is caught and treated as a rejection.

**Level 15** takes a third angle: the whole parameter has to match `^[A-Za-z0-9_-]+\.[A-Za-z0-9]{2,5}$`. There is no path separator or NUL byte in that character set, so nothing in it can be shaped into a traversal sequence.

Neither depends on knowing every legitimate file name ahead of time the way level 13 does. Both are additive; nothing in levels 1 to 13 changed.

How I checked it: unit tests cover both levels rejecting a deep `/etc/passwd` traversal, a `../secret.json` escape one directory up, and a NUL-byte payload, plus level 14 accepting `OwaspAppInfo.json` even though it is never referenced anywhere in that level's code. I also ran the built jar and hit both endpoints directly to see the actual responses.

```sh
./gradlew clean build
java -jar build/libs/VulnerableApp-1.0.0.jar &
B=http://localhost:9090/VulnerableApp/PathTraversal
until curl -sf -o /dev/null http://localhost:9090/VulnerableApp/VulnerabilityDefinitions
do sleep 2; done

# level 14: accepted even though never hardcoded
curl -s "$B/LEVEL_14?fileName=OwaspAppInfo.json"

# level 14: one directory up, rejected
curl -s "$B/LEVEL_14?fileName=../secret.json"

# level 15: traversal sequence, rejected
curl -s "$B/LEVEL_15?fileName=../../../../../../etc/passwd"
```

`./gradlew clean build` passes with 502 tests, 0 failures, on master `c833c66`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Path Traversal challenge levels 14 and 15.
  - Level 14 validates normalized paths and blocks requests that leave the permitted resource directory.
  - Level 15 accepts only filenames matching a restricted alphanumeric, underscore, and hyphen pattern with a single extension.
  - Added localized challenge descriptions, hints, and payload information for both levels.

- **Bug Fixes**
  - Invalid, null, traversal, and null-byte path inputs are now rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->