### PR TITLE
feat: add a challenge card to the secure cache poisoning level

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
@@ -231,6 +231,10 @@ public class CachePoisoningVulnerability {
 
     @ChallengeCard(
             challengeText = "CACHE_POISONING_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CACHE_POISONING_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CACHE_POISONING_LEVEL_5_HINT_2")
+            },
             payload =
                     @ChallengeCard.Payload(
                             description = "CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION",

--- a/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
@@ -229,6 +229,16 @@ public class CachePoisoningVulnerability {
                 true);
     }
 
+    @ChallengeCard(
+            challengeText = "CACHE_POISONING_LEVEL_5_CHALLENGE",
+            hints = {
+                @ChallengeCard.Hint(order = 1, text = "CACHE_POISONING_LEVEL_5_HINT_1"),
+                @ChallengeCard.Hint(order = 2, text = "CACHE_POISONING_LEVEL_5_HINT_2")
+            },
+            payload =
+                    @ChallengeCard.Payload(
+                            description = "CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION",
+                            value = "CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE"))
     @AttackVector(
             vulnerabilityExposed = VulnerabilityType.WEB_CACHE_POISONING,
             description = "CACHE_POISONING_LEVEL_5_SECURE_CACHE_POLICY",

--- a/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/cachePoisoning/CachePoisoningVulnerability.java
@@ -231,10 +231,6 @@ public class CachePoisoningVulnerability {
 
     @ChallengeCard(
             challengeText = "CACHE_POISONING_LEVEL_5_CHALLENGE",
-            hints = {
-                @ChallengeCard.Hint(order = 1, text = "CACHE_POISONING_LEVEL_5_HINT_1"),
-                @ChallengeCard.Hint(order = 2, text = "CACHE_POISONING_LEVEL_5_HINT_2")
-            },
             payload =
                     @ChallengeCard.Payload(
                             description = "CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION",

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -749,8 +749,10 @@ CACHE_POISONING_LEVEL_4_HINT_2=Set the demo_user cookie to a specific value to p
 CACHE_POISONING_LEVEL_4_PAYLOAD_DESCRIPTION=Cookie value used to poison the shared, publicly-cached personalized response.
 CACHE_POISONING_LEVEL_4_PAYLOAD_VALUE=Cookie: demo_user=admin
 CACHE_POISONING_LEVEL_5_CHALLENGE=Confirm there's no way to make this level serve your content to another visitor - it never stores the response and ignores the forwarded host.
-CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION=
-CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE=
+CACHE_POISONING_LEVEL_5_HINT_1=Every response reports the cache lookup next to the key. On the earlier levels it turns to a hit once the entry exists; watch whether it ever does here.
+CACHE_POISONING_LEVEL_5_HINT_2=Replay each earlier payload in turn. The banner comes back escaped, the asset host comes from configuration rather than the request, and the response is never stored.
+CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION=Any payload from the earlier levels, replayed here to confirm that none of them survives.
+CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE=?banner=<img src=x onerror=alert(document.domain)>
 
 #IDOR ChallengeCard Labels
 IDOR_VULNERABILITY_LEVEL_1_CHALLENGE=Can you bypass the authorization check and access another user's profile?

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -748,6 +748,11 @@ CACHE_POISONING_LEVEL_4_HINT_1=The response is built from the demo_user cookie, 
 CACHE_POISONING_LEVEL_4_HINT_2=Set the demo_user cookie to a specific value to poison the route, then request the same route again with a different (or no) cookie and check whether you still get the first user's data.
 CACHE_POISONING_LEVEL_4_PAYLOAD_DESCRIPTION=Cookie value used to poison the shared, publicly-cached personalized response.
 CACHE_POISONING_LEVEL_4_PAYLOAD_VALUE=Cookie: demo_user=admin
+CACHE_POISONING_LEVEL_5_CHALLENGE=Confirm there's no way to make this level serve your content to another visitor - it never stores the response and ignores the forwarded host.
+CACHE_POISONING_LEVEL_5_HINT_1=Every response reports the cache lookup next to the key. On the earlier levels it turns to a hit once the entry exists; watch whether it ever does here.
+CACHE_POISONING_LEVEL_5_HINT_2=Replay each earlier payload in turn. The banner comes back escaped, the asset host comes from configuration rather than the request, and the response is never stored.
+CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION=Any payload from the earlier levels, replayed here to confirm that none of them survives.
+CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE=?banner=<img src=x onerror=alert(document.domain)>
 
 #IDOR ChallengeCard Labels
 IDOR_VULNERABILITY_LEVEL_1_CHALLENGE=Can you bypass the authorization check and access another user's profile?

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -749,10 +749,8 @@ CACHE_POISONING_LEVEL_4_HINT_2=Set the demo_user cookie to a specific value to p
 CACHE_POISONING_LEVEL_4_PAYLOAD_DESCRIPTION=Cookie value used to poison the shared, publicly-cached personalized response.
 CACHE_POISONING_LEVEL_4_PAYLOAD_VALUE=Cookie: demo_user=admin
 CACHE_POISONING_LEVEL_5_CHALLENGE=Confirm there's no way to make this level serve your content to another visitor - it never stores the response and ignores the forwarded host.
-CACHE_POISONING_LEVEL_5_HINT_1=Every response reports the cache lookup next to the key. On the earlier levels it turns to a hit once the entry exists; watch whether it ever does here.
-CACHE_POISONING_LEVEL_5_HINT_2=Replay each earlier payload in turn. The banner comes back escaped, the asset host comes from configuration rather than the request, and the response is never stored.
-CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION=Any payload from the earlier levels, replayed here to confirm that none of them survives.
-CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE=?banner=<img src=x onerror=alert(document.domain)>
+CACHE_POISONING_LEVEL_5_PAYLOAD_DESCRIPTION=
+CACHE_POISONING_LEVEL_5_PAYLOAD_VALUE=
 
 #IDOR ChallengeCard Labels
 IDOR_VULNERABILITY_LEVEL_1_CHALLENGE=Can you bypass the authorization check and access another user's profile?


### PR DESCRIPTION
Cache poisoning is the only challenge mode module whose secure level carries no card. This adds one.

@preetkaran20 asked on #764 whether a card on a secure level is shown in the UI and said there is no harm in adding one if it is. It is: on `XXEVulnerability` LEVEL_5 the card renders in full, with its text and both the Reveal hint and Show Payload controls. That question is what this PR follows up.

**Built to match the module rather than copied from my closed PR.** The goal is short and close ended in the style @pereiravp landed in #779, and the card carries two hints and a payload to match the other seven cards in the class and the ten carded secure levels elsewhere in the tree. The card asks the reader to confirm rather than to attack, which is the same pattern as `XXE_LEVEL5_CHALLENGE` and `PATH_TRAVERSAL_LEVEL13_CHALLENGE`.

Ten Java lines and five keys, in the default bundle only, which is what all nine challenge mode PRs merged so far have done.

**Verified against a running instance, not just built.** Each claim the card makes was checked, with a positive control so a passing result means something:

| Claim in the card | Result |
|---|---|
| the response is never stored | six consecutive requests to level 5 all answer `MISS` |
| control, so `MISS` is not vacuous | level 1 answers `HIT` on five of six |
| the forwarded host is ignored | `X-Forwarded-Host: attacker-controlled.example` never reaches the asset address |
| the asset host comes from configuration | the configured `static.vulnerableapp.local` appears instead |
| the banner comes back escaped | an `img` payload returns as `&lt;img`, not as an executable tag |

`./gradlew spotlessCheck build` passes: 471 tests, 0 failures, 2 skipped, and `MessageBundleDuplicateKeyTest` passes with the new keys.

The wording is a teaching decision rather than a coding one, so please rewrite anything pitched wrong. The keys and structure would not change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added two hints to the Level 5 cache-poisoning challenge.
  - Added a concrete banner XSS payload example to clarify how to verify that no payload survives.
  - Clarified that responses are never cached and that the asset host is determined by configuration rather than the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->