### PR TITLE
feat: add a secure open redirect level that never takes a URL (#403)

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
@@ -6,7 +6,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.sasanlabs.internal.utility.FrameworkConstants;
@@ -58,6 +61,19 @@ public class Http3xxStatusCodeBasedInjection {
     private static final String RETURN_TO = "returnTo";
     private static final Set<String> WHITELISTED_URLS =
             new HashSet<>(Arrays.asList("/", "/VulnerableApp/"));
+
+    /**
+     * Destinations this level is willing to redirect to, keyed by a short name. The request never
+     * carries a URL, only one of these keys, so there is no attacker controlled value to validate.
+     */
+    private static final Map<String, String> REDIRECT_DESTINATIONS =
+            Collections.unmodifiableMap(
+                    new HashMap<String, String>() {
+                        {
+                            put("home", "/VulnerableApp/");
+                            put("root", "/");
+                        }
+                    });
 
     private ResponseEntity<?> getURLRedirectionResponseEntity(
             String urlToRedirect, Function<String, Boolean> validator) {
@@ -381,5 +397,27 @@ public class Http3xxStatusCodeBasedInjection {
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body("Redirect blocked: untrusted redirect target");
+    }
+
+    @AttackVector(
+            vulnerabilityExposed = {VulnerabilityType.OPEN_REDIRECT_3XX_STATUS_CODE},
+            description = "OPEN_REDIRECT_PHISHING_SECURE_INDIRECT_REFERENCE")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_12,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_12/Http3xxStatusCodeBasedInjection")
+    public ResponseEntity<String> getVulnerablePayloadLevel12(
+            @RequestParam(RETURN_TO) String destinationKey) {
+
+        String destination = REDIRECT_DESTINATIONS.get(destinationKey);
+
+        if (destination == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Redirect blocked: unknown destination");
+        }
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(LOCATION_HEADER_KEY, destination)
+                .build();
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjection.java
@@ -409,15 +409,13 @@ public class Http3xxStatusCodeBasedInjection {
     public ResponseEntity<String> getVulnerablePayloadLevel12(
             @RequestParam(RETURN_TO) String destinationKey) {
 
-        String destination = REDIRECT_DESTINATIONS.get(destinationKey);
-
-        if (destination == null) {
+        if (!REDIRECT_DESTINATIONS.containsKey(destinationKey)) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("Redirect blocked: unknown destination");
         }
 
         return ResponseEntity.status(HttpStatus.FOUND)
-                .header(LOCATION_HEADER_KEY, destination)
+                .header(LOCATION_HEADER_KEY, REDIRECT_DESTINATIONS.get(destinationKey))
                 .build();
     }
 }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -83,6 +83,7 @@ OPEN_REDIRECT_QUERY_PARAM_DIRECTLY_ADDED_TO_LOCATION_HEADER_BY_ADDING_DOMAIN_AS_
 OPEN_REDIRECT_PHISHING_NO_WARNING=no validation or warning allows for redirect to phishing page.
 OPEN_REDIRECT_PHISHING_WARNING_BEFORE_REDIRECT=\"returnTo\" query parameter's value is shown in a warning interstitial page before redirecting. The user can still be tricked into clicking \"Continue\" and landing on an attacker-controlled phishing page that harvests login credentials.
 OPEN_REDIRECT_PHISHING_SECURE_WHITELIST="returnTo" query parameter is only allowed when it points to an approved internal destination. Untrusted external redirect targets are blocked to reduce phishing risk.
+OPEN_REDIRECT_PHISHING_SECURE_INDIRECT_REFERENCE="returnTo" query parameter carries a short destination name rather than a URL, and the application maps that name to a destination it already knows. No caller supplied value ever reaches the Location header, so there is nothing to smuggle past a filter.
 
 ## Meta Tag based URL Redirection
 OPEN_REDIRECTION_VULNERABILITY_META_TAG_BASED=Open redirection vulnerabilities arise when an application incorporates user-controllable \

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.css
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.css
@@ -1,0 +1,140 @@
+#http3xxStatusCodeBasedInjection {
+    color: black;
+    text-align: left;
+    font-size: 18px;
+    font-weight: normal;
+}
+
+#http3xxStatusCodeBasedInjection * {
+    color: black;
+    text-align: left;
+}
+
+#http3xxStatusCodeBasedInjection strong {
+    font-weight: bold;
+}
+
+.test-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 10px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+#http3xxStatusCodeBasedInjection input {
+    width: 420px;
+    padding: 10px 12px;
+    border: 1px solid #999;
+    border-radius: 4px;
+    font-size: 16px;
+    background: white;
+}
+
+#testRedirectBtn {
+    background: #2e7d32;
+    color: white !important;
+    border: none;
+    border-radius: 4px;
+    padding: 10px 16px;
+    font-size: 15px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: 0.2s opacity;
+}
+
+#testRedirectBtn:hover {
+    opacity: 0.9;
+}
+
+#resultBox {
+    display: none;
+    margin-top: 14px;
+    margin-bottom: 18px;
+    padding: 14px 16px;
+    border: 2px solid #c0392b;
+    border-left: 8px solid #c0392b;
+    border-radius: 4px;
+    background: #fff5f5;
+    max-width: 900px;
+}
+
+#resultTitle {
+    color: #a93226 !important;
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+}
+
+.resultIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
+    border-radius: 50%;
+    background: #c0392b;
+    color: white !important;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+#resultMessage {
+    color: #c0392b !important;
+    font-size: 15px;
+    font-weight: bold;
+    word-break: break-word;
+}
+
+.policyNote {
+    margin-top: 14px;
+    margin-bottom: 18px;
+    padding: 12px;
+    border-left: 5px solid #2e7d32;
+    background: #eef7ee;
+    font-size: 15px;
+    line-height: 1.5;
+}
+
+.examples-section {
+    margin-top: 10px;
+    margin-bottom: 18px;
+}
+
+.example-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.allowed-link {
+    color: #1b5e20 !important;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.allowed-link:hover {
+    text-decoration: underline;
+}
+
+.blocked-link {
+    color: #c0392b !important;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.blocked-link:hover {
+    text-decoration: underline;
+}
+
+#mindset {
+    font-weight: bold;
+    margin-top: 10px;
+}

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.css
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.css
@@ -33,6 +33,8 @@
 }
 
 #testRedirectBtn {
+    display: inline-block;
+    text-decoration: none;
     background: #2e7d32;
     color: white !important;
     border: none;
@@ -46,50 +48,6 @@
 
 #testRedirectBtn:hover {
     opacity: 0.9;
-}
-
-#resultBox {
-    display: none;
-    margin-top: 14px;
-    margin-bottom: 18px;
-    padding: 14px 16px;
-    border: 2px solid #c0392b;
-    border-left: 8px solid #c0392b;
-    border-radius: 4px;
-    background: #fff5f5;
-    max-width: 900px;
-}
-
-#resultTitle {
-    color: #a93226 !important;
-    font-size: 20px;
-    font-weight: bold;
-    margin-bottom: 6px;
-    display: flex;
-    align-items: center;
-}
-
-.resultIcon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    margin-right: 8px;
-    border-radius: 50%;
-    background: #c0392b;
-    color: white !important;
-    font-size: 16px;
-    font-weight: bold;
-    line-height: 1;
-    flex-shrink: 0;
-}
-
-#resultMessage {
-    color: #c0392b !important;
-    font-size: 15px;
-    font-weight: bold;
-    word-break: break-word;
 }
 
 .policyNote {

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.html
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.html
@@ -11,15 +11,7 @@
 	<label for="returnToInput"><strong>Destination name:</strong></label>
 	<div class="test-row">
 		<input id="returnToInput" type="text" value="home" placeholder="Enter a destination name" />
-		<button id="testRedirectBtn">Test Secure Redirect</button>
-	</div>
-
-	<div id="resultBox" style="display:none;">
-		<div id="resultTitle">
-			<span class="resultIcon">!</span>
-			<span>Redirect Blocked</span>
-		</div>
-		<div id="resultMessage"></div>
+		<a id="testRedirectBtn" target="_blank">Test Secure Redirect</a>
 	</div>
 
 	<div class="policyNote">
@@ -29,21 +21,25 @@
 		table. The usual redirect payloads have nothing to act on here: there is
 		no value for them to smuggle through, only a key that is either known or
 		not.
+		<br /><br />
+		Each link opens in a new tab, so the browser follows the server&rsquo;s
+		302 itself. A known name lands on its destination, and an unknown one
+		shows the server&rsquo;s refusal.
 	</div>
 
 	<div class="examples-section">
 		<strong>Quick examples:</strong>
 		<div class="example-list">
-			<a href="#" class="sample-link allowed-link" data-value="home">
+			<a target="_blank" class="sample-link allowed-link" data-value="home">
 				Allowed: home
 			</a>
-			<a href="#" class="sample-link allowed-link" data-value="root">
+			<a target="_blank" class="sample-link allowed-link" data-value="root">
 				Allowed: root
 			</a>
-			<a href="#" class="sample-link blocked-link" data-value="https://www.google.com/">
+			<a target="_blank" class="sample-link blocked-link" data-value="https://www.google.com/">
 				Blocked: https://www.google.com/
 			</a>
-			<a href="#" class="sample-link blocked-link" data-value="//www.google.com/">
+			<a target="_blank" class="sample-link blocked-link" data-value="//www.google.com/">
 				Blocked: //www.google.com/
 			</a>
 		</div>

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.html
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.html
@@ -1,0 +1,51 @@
+<div id="http3xxStatusCodeBasedInjection">
+	This level demonstrates a <strong>secure redirect implementation</strong>
+	that never accepts a URL from the caller at all.
+	<br /><br />
+	The <code>returnTo</code> parameter carries a short destination name, and the
+	application looks that name up in a table it already holds. Whatever the
+	caller sends is only ever used as a lookup key, so no caller supplied value
+	can reach the <code>Location</code> header.
+	<br /><br />
+
+	<label for="returnToInput"><strong>Destination name:</strong></label>
+	<div class="test-row">
+		<input id="returnToInput" type="text" value="home" placeholder="Enter a destination name" />
+		<button id="testRedirectBtn">Test Secure Redirect</button>
+	</div>
+
+	<div id="resultBox" style="display:none;">
+		<div id="resultTitle">
+			<span class="resultIcon">!</span>
+			<span>Redirect Blocked</span>
+		</div>
+		<div id="resultMessage"></div>
+	</div>
+
+	<div class="policyNote">
+		<strong>How this secure level works:</strong>
+		Only the destination names below are known. Anything else is rejected,
+		including a perfectly ordinary URL, because a URL is not a name in the
+		table. The usual redirect payloads have nothing to act on here: there is
+		no value for them to smuggle through, only a key that is either known or
+		not.
+	</div>
+
+	<div class="examples-section">
+		<strong>Quick examples:</strong>
+		<div class="example-list">
+			<a href="#" class="sample-link allowed-link" data-value="home">
+				Allowed: home
+			</a>
+			<a href="#" class="sample-link allowed-link" data-value="root">
+				Allowed: root
+			</a>
+			<a href="#" class="sample-link blocked-link" data-value="https://www.google.com/">
+				Blocked: https://www.google.com/
+			</a>
+			<a href="#" class="sample-link blocked-link" data-value="//www.google.com/">
+				Blocked: //www.google.com/
+			</a>
+		</div>
+	</div>
+</div>

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
@@ -1,0 +1,55 @@
+const input = document.getElementById("returnToInput");
+const button = document.getElementById("testRedirectBtn");
+const sampleLinks = document.querySelectorAll(".sample-link");
+const resultBox = document.getElementById("resultBox");
+const resultTitle = document.getElementById("resultTitle");
+const resultMessage = document.getElementById("resultMessage");
+
+function testLevel11Redirect(value) {
+  const encoded = encodeURIComponent(value);
+  const url =
+    "/VulnerableApp/Http3xxStatusCodeBasedInjection/LEVEL_11?returnTo=" +
+    encoded;
+
+  fetch(url, {
+    method: "GET",
+    redirect: "follow",
+  })
+    .then(function (response) {
+      if (response.redirected) {
+        window.location.href = response.url;
+        return;
+      }
+
+      if (response.status === 403) {
+        return response.text().then(function (message) {
+          resultTitle.innerHTML =
+            '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
+          resultMessage.textContent = message + ": " + value;
+          resultBox.style.display = "block";
+        });
+      }
+    })
+    .catch(function () {
+      resultTitle.innerHTML =
+        '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
+      resultMessage.textContent = "Unable to test redirect right now.";
+      resultBox.style.display = "block";
+    });
+}
+
+if (button && input) {
+  button.addEventListener("click", function () {
+    testLevel11Redirect(input.value);
+  });
+}
+
+sampleLinks.forEach(function (link) {
+  link.addEventListener("click", function (event) {
+    event.preventDefault();
+    const value = link.getAttribute("data-value");
+    input.value = value;
+    resultBox.style.display = "none";
+    resultMessage.textContent = "";
+  });
+});

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
@@ -1,54 +1,24 @@
-const input = document.getElementById("returnToInput");
-const button = document.getElementById("testRedirectBtn");
-const sampleLinks = document.querySelectorAll(".sample-link");
-const resultBox = document.getElementById("resultBox");
-const resultTitle = document.getElementById("resultTitle");
-const resultMessage = document.getElementById("resultMessage");
-
-function showBlocked(message, value) {
-  resultTitle.innerHTML =
-    '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
-  resultMessage.textContent = value ? message + ": " + value : message;
-  resultBox.style.display = "block";
+function redirectUrlFor(destinationName) {
+  return (
+    getUrlForVulnerabilityLevel() +
+    "?returnTo=" +
+    encodeURIComponent(destinationName)
+  );
 }
 
-function testLevel12Redirect(value) {
-  const encoded = encodeURIComponent(value);
-  const url =
-    "/VulnerableApp/Http3xxStatusCodeBasedInjection/LEVEL_12?returnTo=" +
-    encoded;
+function updatePlaceholderDiv() {
+  let input = document.getElementById("returnToInput");
+  let testLink = document.getElementById("testRedirectBtn");
 
-  fetch(url, {
-    method: "GET",
-    redirect: "follow",
-  })
-    .then(function (response) {
-      if (response.redirected) {
-        window.location.href = response.url;
-        return;
-      }
+  let updateTestLink = function () {
+    testLink.href = redirectUrlFor(input.value);
+  };
+  input.addEventListener("input", updateTestLink);
+  updateTestLink();
 
-      return response.text().then(function (message) {
-        showBlocked(message || "Redirect blocked", value);
-      });
-    })
-    .catch(function () {
-      showBlocked("Unable to test redirect right now.", "");
-    });
-}
-
-if (button && input) {
-  button.addEventListener("click", function () {
-    testLevel12Redirect(input.value);
+  document.querySelectorAll(".sample-link").forEach(function (link) {
+    link.href = redirectUrlFor(link.getAttribute("data-value"));
   });
 }
 
-sampleLinks.forEach(function (link) {
-  link.addEventListener("click", function (event) {
-    event.preventDefault();
-    const value = link.getAttribute("data-value");
-    input.value = value;
-    resultBox.style.display = "none";
-    resultMessage.textContent = "";
-  });
-});
+updatePlaceholderDiv();

--- a/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
+++ b/src/main/resources/static/templates/Http3xxStatusCodeBasedInjection/LEVEL_12/Http3xxStatusCodeBasedInjection.js
@@ -5,10 +5,17 @@ const resultBox = document.getElementById("resultBox");
 const resultTitle = document.getElementById("resultTitle");
 const resultMessage = document.getElementById("resultMessage");
 
-function testLevel11Redirect(value) {
+function showBlocked(message, value) {
+  resultTitle.innerHTML =
+    '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
+  resultMessage.textContent = value ? message + ": " + value : message;
+  resultBox.style.display = "block";
+}
+
+function testLevel12Redirect(value) {
   const encoded = encodeURIComponent(value);
   const url =
-    "/VulnerableApp/Http3xxStatusCodeBasedInjection/LEVEL_11?returnTo=" +
+    "/VulnerableApp/Http3xxStatusCodeBasedInjection/LEVEL_12?returnTo=" +
     encoded;
 
   fetch(url, {
@@ -21,26 +28,18 @@ function testLevel11Redirect(value) {
         return;
       }
 
-      if (response.status === 403) {
-        return response.text().then(function (message) {
-          resultTitle.innerHTML =
-            '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
-          resultMessage.textContent = message + ": " + value;
-          resultBox.style.display = "block";
-        });
-      }
+      return response.text().then(function (message) {
+        showBlocked(message || "Redirect blocked", value);
+      });
     })
     .catch(function () {
-      resultTitle.innerHTML =
-        '<span class="resultIcon">!</span><span>Redirect Blocked</span>';
-      resultMessage.textContent = "Unable to test redirect right now.";
-      resultBox.style.display = "block";
+      showBlocked("Unable to test redirect right now.", "");
     });
 }
 
 if (button && input) {
   button.addEventListener("click", function () {
-    testLevel11Redirect(input.value);
+    testLevel12Redirect(input.value);
   });
 }
 

--- a/src/test/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjectionTest.java
+++ b/src/test/java/org/sasanlabs/service/vulnerability/openRedirect/Http3xxStatusCodeBasedInjectionTest.java
@@ -654,4 +654,62 @@ class Http3xxStatusCodeBasedInjectionTest {
         assertThat(responseEntity.getBody())
                 .contains("Redirect blocked: untrusted redirect target");
     }
+
+    @Test
+    @DisplayName("Level 12- a known destination name redirects to the mapped destination")
+    void test_That_IndirectReference_RedirectsKnownName_Level12() {
+        ResponseEntity<String> responseEntity =
+                http3xxStatusCodeBasedInjection.getVulnerablePayloadLevel12("home");
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(responseEntity.getHeaders().getFirst(LOCATION_HEADER_KEY))
+                .isEqualTo("/VulnerableApp/");
+    }
+
+    @Test
+    @DisplayName("Level 12- an unknown destination name is rejected without a Location header")
+    void test_That_IndirectReference_RejectsUnknownName_Level12() {
+        ResponseEntity<String> responseEntity =
+                http3xxStatusCodeBasedInjection.getVulnerablePayloadLevel12("nosuchname");
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(responseEntity.getHeaders().get(LOCATION_HEADER_KEY)).isNull();
+        assertThat(responseEntity.getBody()).contains("Redirect blocked: unknown destination");
+    }
+
+    @Test
+    @DisplayName(
+            "Level 12- no redirect payload reaches the Location header, since the value is only ever a lookup key")
+    void test_That_IndirectReference_NeverEmitsCallerSuppliedTarget_Level12() {
+        String[] payloads = {
+            "https://www.malicious.com",
+            "http://www.malicious.com",
+            "//www.malicious.com",
+            "///www.malicious.com",
+            "\\\\www.malicious.com",
+            "/\\www.malicious.com",
+            "www.malicious.com",
+            "javascript:alert(1)",
+            "https://www.malicious.com@localhost/",
+            "%2f%2fwww.malicious.com",
+            "HOME",
+            " home",
+            "home ",
+            "home/../..",
+            "/VulnerableApp/",
+            "/"
+        };
+
+        for (String payload : payloads) {
+            ResponseEntity<String> responseEntity =
+                    http3xxStatusCodeBasedInjection.getVulnerablePayloadLevel12(payload);
+
+            assertThat(responseEntity.getStatusCode())
+                    .as("payload should be rejected: %s", payload)
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(responseEntity.getHeaders().get(LOCATION_HEADER_KEY))
+                    .as("no Location header should be emitted for: %s", payload)
+                    .isNull();
+        }
+    }
 }


### PR DESCRIPTION
Towards #403.

That issue asks for two or three more secure implementations in the open redirect package. One of them has effectively landed already: #619 added `LEVEL_11`, which is secure. This adds another, and deliberately not a third variant of what is already there.

**Why not another allowlist.** `LEVEL_8` and `LEVEL_11` are both marked secure, but they run the same check, `WHITELISTED_URLS.contains(urlToRedirect)`. They differ only in what happens on failure, a quiet 200 against a 403. So the class demonstrates one secure technique twice. Since the issue exists to give scanners false positive material, a second technique seemed more useful than a third variant of the first.

**What LEVEL_12 does.** The `returnTo` parameter carries a short destination name rather than a URL, and the application maps that name to a destination it already holds. Nothing the caller sends ever reaches the `Location` header, so there is no value to smuggle past a filter. That makes it secure by construction rather than by a check that has to be argued about, which is the property that makes it useful as a false positive: the usual redirect payloads have nothing to act on.

Unknown names are answered with 400 and no `Location` header.

**Verified against a running instance, with a control.** A test that everything rejects proves nothing, so the same harness was pointed at `LEVEL_1`, which is fully open, and it did redirect to an external host. `LEVEL_12` was then given nineteen inputs: the scheme forms, protocol relative, backslash and mixed slash forms, `javascript:`, userinfo before the host, single and double encoded forms, a CRLF attempt, a null byte, case variants, leading and trailing whitespace, a duplicated query parameter, and the two URLs the existing allowlist does accept.

Every `Location` header it emitted was one of its own two mapped destinations. No input produced an attacker chosen target.

One result is worth stating rather than hiding. Sending the name `home`, a null byte, and then a URL answers 302 to `/VulnerableApp/`, because the null byte truncates the parameter and what remains matches a known name. That is not a bypass, since the destination still comes from the map rather than from the request, and it is a fair illustration of the point: even when input handling does something surprising, the worst case here is that a valid name matched.

`./gradlew spotlessCheck build` passes with 474 tests, 0 failures, 2 skipped.

**On scope.** I asked four questions on #403 in August about how far this should go and did not want to sit on the issue indefinitely, so I have taken the narrowest reading. If you would rather it looked different, this is cheap to redirect.

I also considered a host based check that parses the value and compares the host against an allowed set. It is a real pattern and would be good material, but a level marked secure that a scanner is right to flag is worse for your ground truth than no level at all, so I would rather do that one separately and with proper adversarial testing than bundle it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a secure redirect demonstration using approved destination names instead of arbitrary URLs.
  - Added an interactive test page with examples of allowed destination names and blocked URL inputs.
  - Added guidance explaining the secure redirect policy.
  - Approved destinations redirect successfully, while unknown names and direct URL payloads are rejected with a bad-request response and no redirect.
  - Added validation covering malicious URL formats, path traversal, and other unsafe inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->