### PR TITLE
Fix typo in SSRF error message (occured -> occurred)

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/ssrf/SSRFVulnerability.java
@@ -49,7 +49,7 @@ public class SSRFVulnerability {
             obj.toURI();
             return true;
         } catch (MalformedURLException | URISyntaxException e) {
-            LOGGER.error("Provided URL: {} is not valid and following exception occured", url, e);
+            LOGGER.error("Provided URL: {} is not valid and following exception occurred", url, e);
             return false;
         }
     }


### PR DESCRIPTION
`SSRFVulnerability` logs an error containing the misspelling **occured**. This fixes it to **occurred**.

No behaviour change - log text only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a spelling error in the URL validation error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->