### PR TITLE
docs: name the ground-truth endpoints and sync translation GIFs (#727)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ report. Both DAST and SAST scanners are supported via the same endpoint:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` is optional and defaults to `DAST`; `type`/`cwe`/`wascId` are individually optional — any one axis matching is enough)
   - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - Response body and `benchmarks/<tool>-results.json` on disk: coverage report
+- Ground truth: `GET http://<baseurl>/VulnerableApp/scanner/dast` for DAST and `GET http://<baseurl>/VulnerableApp/scanner/sast` for SAST. The bare `/scanner` path is deprecated and stays until 30 Sep 2027.
 
 Running the scanner itself is out of scope — you supply the JSON. See
 [`benchmarks/README.md`](benchmarks/README.md) for the full input/output

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -43,7 +43,13 @@ OWASP VulnerableApp एक मॉड्यूलर, जानबूझकर �
 स्वचालन, पुनरुत्पादन क्षमता और विकास के लिए
 
 ### उपयोगकर्ता इंटरफ़ेस ###
-![VulnerableApp-facade UI](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## प्रोजेक्ट चलाना
 प्रोजेक्ट चलाने के 2 तरीके हैं:
@@ -136,13 +142,15 @@ Password: hacker
 
 VulnerableApp एक comparator के साथ आता है जो स्कैनर के निष्कर्षों का प्रोजेक्ट के अंतर्निहित ग्राउंड ट्रुथ के विरुद्ध मूल्यांकन करता है और coverage / missed / unmatched रिपोर्ट तैयार करता है। DAST और SAST दोनों स्कैनर एक ही एंडपॉइंट के माध्यम से समर्थित हैं:
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - एंडपॉइंट: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - अनुरोध बॉडी — अपने स्कैनर के अनुसार उपयुक्त संरचना चुनें:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` वैकल्पिक है और डिफ़ॉल्ट रूप से `DAST` होता है; `type`/`cwe`/`wascId` अलग-अलग वैकल्पिक हैं — किसी एक अक्ष पर मेल पर्याप्त है)
   - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - प्रतिक्रिया बॉडी और डिस्क पर `benchmarks/<tool>-results.json`: कवरेज रिपोर्ट
 
-स्कैनर को स्वयं चलाना इस दायरे से बाहर है — आपको JSON प्रदान करना होगा। पूर्ण इनपुट/आउटपुट स्कीमा, मिलान नियम, मानक भेद्यता-प्रकार शब्दावली और `curl` उदाहरणों के लिए [`benchmarks/README.md`](../../../benchmarks/README.md) देखें।
+स्कैनर को स्वयं चलाना इस दायरे से बाहर है — आपको JSON प्रदान करना होगा। पूर्ण इनपुट/आउटपुट स्कीमा, मिलान नियम, मानक भेद्यता-प्रकार शब्दावली और `curl` उदाहरणों के लिए [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) देखें।
 
 ## संपर्क
 यदि आप किसी चरण में अटक जाते हैं या प्रोजेक्ट तथा उसके उद्देश्यों से संबंधित कुछ समझना चाहते हैं, तो karan.sasan@owasp.org पर ईमेल भेजें या [issue](https://github.com/SasanLabs/VulnerableApp/issues) दर्ज करें। हम आपकी सहायता करने का पूरा प्रयास करेंगे।

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -44,7 +44,13 @@ OWASP VulnerableApp은 재현 가능한 테스트 시나리오를 통해 보안 
 자동화, 재현성, 그리고 진화
 
 ### 사용자 인터페이스 ###
-![VulnerableApp-facade UI](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## 프로젝트 실행하기
 
@@ -142,13 +148,15 @@ Password: hacker
 
 VulnerableApp은 스캐너가 찾아낸 결과를 프로젝트에 내장된 정답(ground truth)과 비교해서 채점하고, 커버리지/누락/불일치 리포트를 만들어주는 비교기(comparator)를 제공합니다. DAST와 SAST 스캐너 모두 동일한 엔드포인트로 지원됩니다:
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - 엔드포인트: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - 요청 본문 — 사용하는 스캐너에 맞는 형태를 선택하세요:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType`은 선택 항목이며 기본값은 `DAST`입니다. `type`/`cwe`/`wascId`도 각각 선택 항목이며, 이 중 하나만 일치해도 충분합니다)
   - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - 응답 본문과 디스크에 저장되는 `benchmarks/<tool>-results.json`: 커버리지 리포트
 
-스캐너 자체를 실행하는 것은 이 기능의 범위 밖이며, 사용자가 JSON을 직접 제공해야 합니다. 전체 입출력 스키마, 매칭 규칙, 표준 취약점 유형 용어집, `curl` 예제는 [`benchmarks/README.md`](../../../benchmarks/README.md)를 참고하세요.
+스캐너 자체를 실행하는 것은 이 기능의 범위 밖이며, 사용자가 JSON을 직접 제공해야 합니다. 전체 입출력 스키마, 매칭 규칙, 표준 취약점 유형 용어집, `curl` 예제는 [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md)를 참고하세요.
 
 ## 문의
 

--- a/docs/i18n/pa/README.md
+++ b/docs/i18n/pa/README.md
@@ -43,7 +43,13 @@ OWASP VulnerableApp ਇੱਕ ਮੋਡੀਊਲਰ, ਜਾਣ-ਬੁੱਝ ਕ�
 ਆਟੋਮੇਸ਼ਨ, ਦੁਹਰਾਏ ਜਾ ਸਕਣ ਦੀ ਸਮਰੱਥਾ ਅਤੇ ਵਿਕਾਸ
 
 ### ਯੂਜ਼ਰ ਇੰਟਰਫੇਸ ###
-![VulnerableApp-facade UI](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## ਪ੍ਰੋਜੈਕਟ ਚਲਾਉਣਾ
 ਪ੍ਰੋਜੈਕਟ ਚਲਾਉਣ ਦੇ 2 ਤਰੀਕੇ ਹਨ:
@@ -137,13 +143,15 @@ Password: hacker
 
 VulnerableApp ਵਿੱਚ ਇੱਕ comparator ਸ਼ਾਮਲ ਹੈ ਜੋ ਸਕੈਨਰ ਦੇ ਨਤੀਜਿਆਂ ਨੂੰ ਪ੍ਰੋਜੈਕਟ ਦੀ ਅੰਦਰੂਨੀ ground truth ਨਾਲ ਤੁਲਨਾ ਕਰਦਾ ਹੈ ਅਤੇ coverage / missed / unmatched ਰਿਪੋਰਟ ਤਿਆਰ ਕਰਦਾ ਹੈ। DAST ਅਤੇ SAST ਦੋਵੇਂ ਸਕੈਨਰ ਇੱਕੋ endpoint ਰਾਹੀਂ ਸਮਰਥਿਤ ਹਨ:
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - Request body — ਆਪਣੇ ਸਕੈਨਰ ਦੇ ਅਨੁਸਾਰ ਫਾਰਮੈਟ ਚੁਣੋ:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` ਵਿਕਲਪਿਕ ਹੈ ਅਤੇ ਡਿਫਾਲਟ `DAST` ਹੈ; `type`/`cwe`/`wascId` ਵੱਖ-ਵੱਖ ਵਿਕਲਪਿਕ ਹਨ — ਕਿਸੇ ਇੱਕ ਧੁਰੇ 'ਤੇ ਮੇਲ ਕਾਫ਼ੀ ਹੈ)
   - SAST: `{ tool, scanType: "SAST", findings: [ { filePath, line, cwe, type } ] }`
 - Response body ਅਤੇ ਡਿਸਕ 'ਤੇ `benchmarks/<tool>-results.json`: coverage ਰਿਪੋਰਟ
 
-ਸਕੈਨਰ ਖੁਦ ਚਲਾਉਣਾ ਇਸਦੀ ਸੀਮਾ ਤੋਂ ਬਾਹਰ ਹੈ — ਤੁਸੀਂ JSON ਪ੍ਰਦਾਨ ਕਰਦੇ ਹੋ। ਪੂਰੀ input/output ਸਕੀਮਾ, matching rules, canonical vulnerability-type vocabulary ਅਤੇ `curl` ਉਦਾਹਰਣਾਂ ਲਈ [`benchmarks/README.md`](../../../benchmarks/README.md) ਵੇਖੋ।
+ਸਕੈਨਰ ਖੁਦ ਚਲਾਉਣਾ ਇਸਦੀ ਸੀਮਾ ਤੋਂ ਬਾਹਰ ਹੈ — ਤੁਸੀਂ JSON ਪ੍ਰਦਾਨ ਕਰਦੇ ਹੋ। ਪੂਰੀ input/output ਸਕੀਮਾ, matching rules, canonical vulnerability-type vocabulary ਅਤੇ `curl` ਉਦਾਹਰਣਾਂ ਲਈ [`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) ਵੇਖੋ।
 
 ## ਸੰਪਰਕ
 ਜੇ ਤੁਸੀਂ ਕਿਸੇ ਵੀ ਕਦਮ ਵਿੱਚ ਫਸ ਜਾਓ ਜਾਂ ਪ੍ਰੋਜੈਕਟ ਅਤੇ ਇਸਦੇ ਉਦੇਸ਼ਾਂ ਨਾਲ ਸੰਬੰਧਿਤ ਕੁਝ ਸਮਝਣਾ ਚਾਹੁੰਦੇ ਹੋ, ਤਾਂ karan.sasan@owasp.org 'ਤੇ ਈਮੇਲ ਭੇਜੋ ਜਾਂ ਇੱਕ [issue](https://github.com/SasanLabs/VulnerableApp/issues) ਬਣਾਓ ਅਤੇ ਅਸੀਂ ਤੁਹਾਡੀ ਮਦਦ ਕਰਨ ਦੀ ਪੂਰੀ ਕੋਸ਼ਿਸ਼ ਕਰਾਂਗੇ।

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -44,7 +44,13 @@ A maioria das aplicações vulneráveis é:
 automação, reprodutibilidade e evolução
 
 ### Interface do usuário ###
-![VulnerableApp-facade UI](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## Executando o projeto
 Há 2 formas de executar o projeto:
@@ -140,6 +146,8 @@ O VulnerableApp inclui um comparador que nota os achados de um scanner contra a
 verdade de referência do projeto e grava um relatório de cobertura / missed / unmatched.
 Scanners DAST e SAST usam o mesmo endpoint:
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - Endpoint: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - Corpo da requisição — use o formato do seu scanner:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` é opcional e o padrão é `DAST`; `type`/`cwe`/`wascId` são opcionais individualmente — basta um eixo bater)
@@ -147,7 +155,7 @@ Scanners DAST e SAST usam o mesmo endpoint:
 - Corpo da resposta e `benchmarks/<tool>-results.json` em disco: relatório de cobertura
 
 Rodar o scanner em si fica fora do escopo — você envia o JSON. Veja
-[`benchmarks/README.md`](../../../benchmarks/README.md) para os schemas de
+[`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) para os schemas de
 entrada/saída, regras de matching, vocabulário canônico de tipos de
 vulnerabilidade e exemplos de `curl`.
 

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -44,7 +44,13 @@ OWASP VulnerableApp — это модульное намеренно уязви�
 автоматизации, воспроизводимости и развития
 
 ### Пользовательский интерфейс ###
-![Интерфейс VulnerableApp-facade](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## Запуск проекта
 Существует 2 способа запуска проекта:
@@ -137,6 +143,8 @@ Password: hacker
 
 VulnerableApp включает компаратор, который оценивает результаты работы сканера относительно встроенной «эталонной» базы проекта и создаёт отчёт о покрытии, пропущенных и лишних находках. Один и тот же конечный пункт поддерживает как DAST-, так и SAST-сканеры:
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - Конечная точка: `POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - Тело запроса — выберите формат, соответствующий вашему сканеру:
   - DAST: `{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }` (`scanType` необязателен и по умолчанию равен `DAST`; поля `type`/`cwe`/`wascId` по отдельности необязательны — достаточно совпадения по любому одному критерию)
@@ -144,7 +152,7 @@ VulnerableApp включает компаратор, который оценив
 - Тело ответа и файл `benchmarks/<tool>-results.json` на диске: отчёт о покрытии
 
 Запуск самого сканера не входит в область ответственности проекта — вы самостоятельно предоставляете JSON. См.
-[`benchmarks/README.md`](../../../benchmarks/README.md) для получения полной информации о схемах входных и выходных данных, правилах сопоставления, каноническом словаре типов уязвимостей и примерах `curl`.
+[`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md) для получения полной информации о схемах входных и выходных данных, правилах сопоставления, каноническом словаре типов уязвимостей и примерах `curl`.
 
 ## Контакты
 Если вы столкнулись с трудностями при выполнении какого-либо из шагов или хотите лучше понять проект и его цели, напишите на адрес karan.sasan@owasp.org или создайте [issue](https://github.com/SasanLabs/VulnerableApp/issues), и мы постараемся помочь.

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -43,7 +43,13 @@ OWASP VulnerableApp 是一个模块化的、刻意包含漏洞的应用程序，
 自动化、可复现性和持续演进
 
 ### 用户界面 ###
-![VulnerableApp-facade UI](https://raw.githubusercontent.com/SasanLabs/VulnerableApp-facade/main/docs/images/gif/VulnerableApp-Facade.gif)
+![Challenge Mode](../../gifs/challenge-mode.gif)
+
+![Switching Modes](../../gifs/scanner-mode.gif)
+
+![Scanner Mode](../../gifs/scanner-mode1.gif)
+
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
 
 ## 运行项目
 有两种方式可以运行该项目：
@@ -141,6 +147,8 @@ Password: hacker
 
 VulnerableApp 内置了一个比较器，可将扫描器发现的问题与项目内置的真实漏洞基准进行对比，并生成覆盖率 / 漏检 / 未匹配报告。DAST 和 SAST 扫描器均支持通过同一个接口进行测试：
 
+![Scanner Benchmark](../../gifs/scanner-benchmark.gif)
+
 - 接口：`POST http://<baseurl>/VulnerableApp/scanner/benchmark`
 - 请求体 —— 根据你的扫描器选择相应格式：
   - DAST：`{ tool, scanType: "DAST", findings: [ { url, type, cwe, wascId } ] }`（`scanType` 可选，默认值为 `DAST`；`type`、`cwe`、`wascId` 均为可选字段——任意一个维度匹配即可）
@@ -148,7 +156,7 @@ VulnerableApp 内置了一个比较器，可将扫描器发现的问题与项目
 - 响应体以及磁盘上的 `benchmarks/<tool>-results.json`：覆盖率报告
 
 扫描器本身的运行不在本项目范围内——你只需提供 JSON。完整的输入/输出 Schema、匹配规则、规范化漏洞类型词汇表以及 `curl` 示例，请参阅：
-[`benchmarks/README.md`](../../../benchmarks/README.md)
+[`benchmarks/README.md`](https://github.com/SasanLabs/VulnerableApp/blob/master/benchmarks/README.md)
 
 ## 联系方式
 如果你在任何步骤中遇到困难，或者对项目及其目标有任何疑问，欢迎发送邮件至 karan.sasan@owasp.org，或者提交一个 [issue](https://github.com/SasanLabs/VulnerableApp/issues)，我们将尽力提供帮助。


### PR DESCRIPTION
Closes #727.

- `README.md`: one bullet in the benchmarking section names `GET /scanner/dast` and `GET /scanner/sast`. It also notes that bare `/scanner` is deprecated and stays until 30 Sep 2027.
- Six translations under `docs/i18n/`: the GIFs from #786 replace the old facade GIF. The benchmarking section gets the benchmark GIF, as in the root README. The `benchmarks/README.md` link is now absolute.

This PR adds and changes no translated text. The new images use the same English alt text as #786, so `ru` loses its Russian alt text on the old image.

<details><summary>How I checked it</summary>

- In each translation: 0 facade GIFs, 5 GIF references, all 5 resolving on disk, 0 relative `../../../` links.
- The Pages site serves all four GIFs under /VulnerableApp/gifs/, which is where ../../gifs/ resolves from each translation page. The old relative benchmarks link returned 404 there in all six. The absolute URL returns 200.
- The `Sunset` date and the `GET` method come from `VulnerableAppRestController`. `VulnerableAppRestControllerTest` asserts the date and a 200 response to `GET` on both endpoints, and passes 10 of 10.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the scanner benchmark endpoints and the planned availability period for the legacy `/scanner` path.
  - Updated translated README pages with clearer local animations covering challenges, mode switching, scanner usage, and benchmarking.
  - Added scanner benchmarking visuals and corrected links to the benchmark documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->